### PR TITLE
Upgrade golangci-lint to v1.46.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,6 +122,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.45.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.46.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
-GOLANGCI_VERSION=v1.45.2
+GOLANGCI_VERSION=v1.46.2
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ At a minimum, the following dependencies must be installed *prior* to running `m
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.18
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.45.2
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.46.2
 [jq](https://stedolan.github.io/jq/)|1.6
 [OpenShift Client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)|4.7
 

--- a/cnf-certification-test/accesscontrol/suite.go
+++ b/cnf-certification-test/accesscontrol/suite.go
@@ -294,7 +294,7 @@ func TestNamespace(env *provider.TestEnvironment) {
 	}
 
 	invalidCrsNum, claimsLog := namespace.GetInvalidCRsNum(invalidCrs)
-	if invalidCrsNum > 0 {
+	if invalidCrsNum > 0 && len(claimsLog.GetLogLines()) > 0 {
 		ginkgo.Fail(fmt.Sprintf("Found %d CRs belonging to invalid namespaces.", invalidCrsNum))
 		tnf.ClaimFilePrintf("%s", claimsLog.GetLogLines())
 	}

--- a/cnf-certification-test/lifecycle/scaling/deployment_scaling_test.go
+++ b/cnf-certification-test/lifecycle/scaling/deployment_scaling_test.go
@@ -68,8 +68,7 @@ func TestScaleDeploymentFunc(t *testing.T) {
 
 	for _, tc := range testCases {
 		var runtimeObjects []runtime.Object
-		var intVar *int32
-		intVar = new(int32)
+		intVar := new(int32)
 		*intVar = int32(tc.replicaCount)
 		tempDP := generateDeployment(tc.deploymentName, intVar)
 		runtimeObjects = append(runtimeObjects, tempDP)


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.46.2

One of the things this version started flagging was that `claimsLog` wasn't being used when it's clearly used in the conditional block below its declaration.  I'm not sure if it is a false positive or not.  Maybe future versions will fix this.