### PR TITLE
Revert "Remove references to oc client"

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -9,6 +9,7 @@ on:
 env:
   REGISTRY: quay.io
   REGISTRY_LOCAL: localhost
+  RELEASE_LEVEL: '4.10'
   IMAGE_NAME: testnetworkfunction/cnf-certification-test
   IMAGE_TAG: unstable
   TNF_CONTAINER_CLIENT: docker
@@ -189,11 +190,14 @@ jobs:
 
       - name: Build the `cnf-certification-test` image
         run: |
+          VERSIONS=($(sudo curl -sH 'Accept: application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-${RELEASE_LEVEL}&arch=amd64" | jq -r '.nodes[].version' | sort -t "." -k1,1n -k2,2n -k3,3n))
+          OPENSHIFT_VERSION=${VERSIONS[${#VERSIONS[@]} - 1]}
           docker build --no-cache \
             -t ${REGISTRY_LOCAL}/${IMAGE_NAME}:${IMAGE_TAG} \
             -t ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} \
             --build-arg TNF_VERSION=${COMMIT_SHA} \
-            --build-arg TNF_SRC_URL=${TNF_SRC_URL} .
+            --build-arg TNF_SRC_URL=${TNF_SRC_URL} \
+            --build-arg OPENSHIFT_VERSION=${OPENSHIFT_VERSION} .
         env:
           COMMIT_SHA: ${{ github.sha }}
 

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -18,6 +18,7 @@ defaults:
 env:
   REGISTRY: quay.io
   REGISTRY_LOCAL: localhost
+  RELEASE_LEVEL: '4.10'
   IMAGE_NAME: testnetworkfunction/cnf-certification-test
   IMAGE_TAG: latest
   TNF_CONTAINER_CLIENT: docker
@@ -111,12 +112,15 @@ jobs:
 
       - name: Build the `cnf-certification-test` image
         run: |
+          VERSIONS=($(sudo curl -sH 'Accept: application/json' "https://api.openshift.com/api/upgrades_info/v1/graph?channel=stable-${RELEASE_LEVEL}&arch=amd64" | jq -r '.nodes[].version' | sort -t "." -k1,1n -k2,2n -k3,3n))
+          OPENSHIFT_VERSION=${VERSIONS[${#VERSIONS[@]} - 1]}
           docker build --no-cache \
             -t ${REGISTRY_LOCAL}/${IMAGE_NAME}:${IMAGE_TAG} \
             -t ${REGISTRY}/${IMAGE_NAME}:${IMAGE_TAG} \
             -t ${REGISTRY}/${IMAGE_NAME}:${TNF_VERSION} \
             --build-arg TNF_VERSION=${TNF_VERSION} \
-            --build-arg TNF_SRC_URL=${TNF_SRC_URL} .
+            --build-arg TNF_SRC_URL=${TNF_SRC_URL} \
+            --build-arg OPENSHIFT_VERSION=${OPENSHIFT_VERSION} .
 
       # Create a minikube cluster for testing.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ ARG TNF_PARTNER_DIR=/usr/tnf-partner
 
 ENV TNF_PARTNER_SRC_DIR=$TNF_PARTNER_DIR/src
 
+ARG OPENSHIFT_VERSION
+ENV OPENSHIFT_VERSION=${OPENSHIFT_VERSION}
+
 ENV TNF_DIR=/usr/tnf
 ENV TNF_SRC_DIR=${TNF_DIR}/tnf-src
 ENV TNF_BIN_DIR=${TNF_DIR}/cnf-certification-test
@@ -10,7 +13,7 @@ ENV TNF_BIN_DIR=${TNF_DIR}/cnf-certification-test
 ENV TEMP_DIR=/tmp
 
 # Install dependencies
-RUN dnf update; dnf install -y gcc git jq make wget
+RUN yum install -y gcc git jq make wget
 
 # Install Go binary
 ENV GO_DL_URL="https://golang.org/dl"
@@ -25,7 +28,16 @@ RUN if [[ "$(uname -m)" -eq "x86_64" ]] ; then \
          echo "CPU architecture not supported" && exit 1; \
      fi
 
-# Add go directory to $PATH
+# Install oc binary
+ENV OC_BIN_TAR="openshift-client-linux.tar.gz"
+ENV OC_DL_URL="https://mirror.openshift.com/pub/openshift-v4/clients/ocp"/${OPENSHIFT_VERSION}/${OC_BIN_TAR}
+ENV OC_BIN="/usr/local/oc/bin"
+RUN wget --directory-prefix=${TEMP_DIR} ${OC_DL_URL} && \
+    mkdir -p ${OC_BIN} && \
+    tar -C ${OC_BIN} -xzf ${TEMP_DIR}/${OC_BIN_TAR} && \
+    chmod a+x ${OC_BIN}/oc
+
+# Add go and oc binary directory to $PATH
 ENV PATH=${PATH}:"/usr/local/go/bin":${GOPATH}/"bin"
 
 # Git identifier to checkout
@@ -75,8 +87,8 @@ WORKDIR ${TNF_DIR}
 RUN ln -s ${TNF_DIR}/config/testconfigure.yml ${TNF_DIR}/cnf-certification-test/testconfigure.yml
 
 # Remove most of the build artefacts
-RUN dnf remove -y gcc git wget && \
-	dnf clean all && \
+RUN yum remove -y gcc git wget && \
+	yum clean all && \
 	rm -rf ${TNF_SRC_DIR} && \
 	rm -rf ${TEMP_DIR} && \
 	rm -rf /root/.cache && \
@@ -93,6 +105,7 @@ COPY --from=build / /
 ENV TNF_CONFIGURATION_PATH=/usr/tnf/config/tnf_config.yml
 ENV KUBECONFIG=/usr/tnf/kubeconfig/config
 ENV TNF_PARTNER_SRC_DIR=$TNF_PARTNER_DIR/src
+ENV PATH="/usr/local/oc/bin:${PATH}"
 WORKDIR /usr/tnf
 ENV SHELL=/bin/bash
 CMD ["./run-cnf-suites.sh", "-o", "claim", "-f", "diagnostic"]


### PR DESCRIPTION
Reverts test-network-function/cnf-certification-test#220

Removing this was causing QE failures because it requires the oc client to figure out if this is an OCP cluster or not.