### PR TITLE
Temporarily disable litmus

### DIFF
--- a/run-cnf-suites.sh
+++ b/run-cnf-suites.sh
@@ -103,8 +103,8 @@ fi
 if [[ ! -z "${TNF_PARTNER_SRC_DIR}" ]]; then
 	echo "attempting to install partner pods"
 	make -C $TNF_PARTNER_SRC_DIR install-partner-pods
-	echo "attempting to install litmus"
-	make -C $TNF_PARTNER_SRC_DIR install-litmus
+	#echo "attempting to install litmus"
+	#make -C $TNF_PARTNER_SRC_DIR install-litmus
 fi
 
 echo "Running with focus '$FOCUS'"
@@ -128,7 +128,7 @@ fi
 
 cd ./cnf-certification-test && ./cnf-certification-test.test $FOCUS_STRING $SKIP_STRING $LABEL_STRING ${GINKGO_ARGS}
 
-if [[ ! -z "${TNF_PARTNER_SRC_DIR}" ]]; then
-	echo "attempting to delete litmus"
-	make -C $TNF_PARTNER_SRC_DIR delete-litmus
-fi
+# if [[ ! -z "${TNF_PARTNER_SRC_DIR}" ]]; then
+# 	echo "attempting to delete litmus"
+# 	make -C $TNF_PARTNER_SRC_DIR delete-litmus
+# fi


### PR DESCRIPTION
#272 enabled the installation and tear down of the litmus operator and we have a hunch that it might be breaking QE.  Disabling the installation of the operator until we can track it down.