### PR TITLE
Add some more context to errors in OCP node test

### DIFF
--- a/cnf-certification-test/platform/suite.go
+++ b/cnf-certification-test/platform/suite.go
@@ -513,7 +513,7 @@ func testNodeOperatingSystemStatus(env *provider.TestEnvironment) {
 				// Get the short version from the node
 				shortVersion, err := node.GetRHCOSVersion()
 				if err != nil {
-					tnf.ClaimFilePrintf("Node %s failed to gather RHEL version", node.Data.Name)
+					tnf.ClaimFilePrintf("Node %s failed to gather RHCOS version. Error: %s", node.Data.Name, err.Error())
 					failedWorkerNodes = append(failedWorkerNodes, node.Data.Name)
 					continue
 				}
@@ -528,7 +528,7 @@ func testNodeOperatingSystemStatus(env *provider.TestEnvironment) {
 				// Get the short version from the node
 				shortVersion, err := node.GetRHELVersion()
 				if err != nil {
-					tnf.ClaimFilePrintf("Node %s failed to gather RHEL version", node.Data.Name)
+					tnf.ClaimFilePrintf("Node %s failed to gather RHEL version. Error: %s", node.Data.Name, err.Error())
 					failedWorkerNodes = append(failedWorkerNodes, node.Data.Name)
 					continue
 				}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -198,7 +198,7 @@ func (node *Node) IsRHEL() bool {
 func (node *Node) GetRHCOSVersion() (string, error) {
 	// Check if the node is running CoreOS or not
 	if !node.IsRHCOS() {
-		return "", errors.New("invalid OS type")
+		return "", fmt.Errorf("invalid OS type: %s", node.Data.Status.NodeInfo.OSImage)
 	}
 
 	// Red Hat Enterprise Linux CoreOS 410.84.202205031645-0 (Ootpa) --> 410.84.202205031645-0
@@ -217,7 +217,7 @@ func (node *Node) GetRHCOSVersion() (string, error) {
 func (node *Node) GetRHELVersion() (string, error) {
 	// Check if the node is running RHEL or not
 	if !node.IsRHEL() {
-		return "", errors.New("invalid OS type")
+		return "", fmt.Errorf("invalid OS type: %s", node.Data.Status.NodeInfo.OSImage)
 	}
 
 	// Red Hat Enterprise Linux 8.5 (Ootpa) --> 8.5


### PR DESCRIPTION
The latest QE tests failed with errors:

```
[2022-07-06T22:51:48.358Z] [1mSTEP:[0m Testing the control-plane and workers in the cluster for Operating System compatibility [38;5;243m07/06/22 22:51:48.171[0m
[2022-07-06T22:51:48.358Z] Node ocp471752071-worker-2 failed to gather RHEL version
[2022-07-06T22:51:48.358Z] Node ocp471752071-worker-0 failed to gather RHEL version
[2022-07-06T22:51:48.358Z] Node ocp471752071-worker-1 failed to gather RHEL version
[2022-07-06T22:51:48.358Z] Number of worker nodes running non-RHCOS or non-RHEL based operating systems: 3
[2022-07-06T22:51:48.358Z] [38;5;243m------------------------------[0m
[2022-07-06T22:51:48.358Z] [38;5;9m• [FAILED] [0.001 seconds][0m
```

And I'm not exactly sure what the error is because we don't print that out.  I added the error strings in the message and fixed a logging string.