### PR TITLE
Address some unused vars; update golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,6 +121,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.51.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.52.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ COMMON_GO_ARGS=-race
 GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
-GOLANGCI_VERSION=v1.51.1
+GOLANGCI_VERSION=v1.52.1
 LINKER_TNF_RELEASE_FLAGS=-X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitCommit=${GIT_COMMIT}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitRelease=${GIT_RELEASE}
 LINKER_TNF_RELEASE_FLAGS+= -X github.com/test-network-function/cnf-certification-test/cnf-certification-test.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/cmd/tnf/addclaim/addclaim.go
+++ b/cmd/tnf/addclaim/addclaim.go
@@ -41,7 +41,7 @@ const (
 )
 
 //nolint:funlen
-func claimUpdate(cmd *cobra.Command, args []string) error {
+func claimUpdate(_ *cobra.Command, _ []string) error {
 	claimFileTextPtr := &Claim
 	reportFilesTextPtr := &Reportdir
 	fileUpdated := false

--- a/cmd/tnf/addclaim/compareclaim.go
+++ b/cmd/tnf/addclaim/compareclaim.go
@@ -33,7 +33,7 @@ type Cni struct {
 	Plugins []interface{} "json:\"plugins\""
 }
 
-func claimCompare(cmd *cobra.Command, args []string) error {
+func claimCompare(_ *cobra.Command, _ []string) error {
 	claimFileTextPtr := Claim1
 	claimFileTextPtr2 := Claim2
 	err := claimCompareFilesfunc(claimFileTextPtr, claimFileTextPtr2)

--- a/cnf-certification-test/platform/cnffsdiff/fsdiff_test.go
+++ b/cnf-certification-test/platform/cnffsdiff/fsdiff_test.go
@@ -32,7 +32,7 @@ type ClientHoldersMock struct {
 	err    error
 }
 
-func (o ClientHoldersMock) ExecCommandContainer(ctx clientsholder.Context, command string) (stdout, stderr string, err error) {
+func (o ClientHoldersMock) ExecCommandContainer(_ clientsholder.Context, _ string) (stdout, stderr string, err error) {
 	stdout, stderr, err = o.stdout, o.stderr, o.err
 	return stdout, stderr, err
 }

--- a/cnf-certification-test/platform/hugepages/hugepages_test.go
+++ b/cnf-certification-test/platform/hugepages/hugepages_test.go
@@ -143,7 +143,7 @@ type fakeK8sClient struct {
 	execCommandFunctionMocker func() (stdout string, stderr string, err error)
 }
 
-func (client *fakeK8sClient) ExecCommandContainer(context clientsholder.Context, cmd string) (stdout, stderr string, err error) {
+func (client *fakeK8sClient) ExecCommandContainer(_ clientsholder.Context, _ string) (stdout, stderr string, err error) {
 	return client.execCommandFunctionMocker()
 }
 

--- a/cnf-certification-test/preflight/suite_test.go
+++ b/cnf-certification-test/preflight/suite_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/test-network-function/cnf-certification-test/cnf-certification-test/identifiers"
 )
 
-func TestGetUniqueTestEntriesFromContainerResults(t *testing.T) {
+func TestGetUniqueTestEntriesFromContainerResults(_ *testing.T) {
 	// Note: preflight lib does not expose their underlying plibRuntime.Result struct vars so I can not write unit tests for this
 }
 
-func TestGetUniqueTestEntriesFromOperatorResults(t *testing.T) {
+func TestGetUniqueTestEntriesFromOperatorResults(_ *testing.T) {
 	// Note: preflight lib does not expose their underlying plibRuntime.Result struct vars so I can not write unit tests for this
 }
 

--- a/docs/test-standalone.md
+++ b/docs/test-standalone.md
@@ -27,7 +27,7 @@ make install-tools
 Dependency|Minimum Version
 ---|---
 [GoLang](https://golang.org/dl/)|1.20
-[golangci-lint](https://golangci-lint.run/usage/install/)|1.51.1
+[golangci-lint](https://golangci-lint.run/usage/install/)|1.52.1
 [jq](https://stedolan.github.io/jq/)|1.6
 [OpenShift Client](https://mirror.openshift.com/pub/openshift-v4/clients/ocp/)|4.11
 

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -78,7 +78,7 @@ func SetupFakeOlmClient(olmMockObjects []runtime.Object) {
 // runtime mocking objects loading, use the proper clientset mocking function.
 //
 //nolint:funlen,gocyclo
-func GetTestClientsHolder(k8sMockObjects []runtime.Object, filenames ...string) *ClientsHolder {
+func GetTestClientsHolder(k8sMockObjects []runtime.Object) *ClientsHolder {
 	// Build slices of different objects depending on what client
 	// is supposed to expect them.
 	var k8sClientObjects []runtime.Object

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -340,9 +340,8 @@ func getPodContainers(aPod *corev1.Pod, useIgnoreList bool) (containerList []*Co
 		// Build slices of containers based on whether or not we are "ignoring" them or not.
 		if useIgnoreList && container.HasIgnoredContainerName() {
 			continue
-		} else {
-			containerList = append(containerList, &container)
 		}
+		containerList = append(containerList, &container)
 	}
 	return containerList
 }


### PR DESCRIPTION
The new golangci-lint release [v1.52.1](https://github.com/golangci/golangci-lint/releases/tag/v1.52.1) is flagging some new things as linter errors.