### PR TITLE
Fix for fatal error in diagnostics

### DIFF
--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -86,13 +86,15 @@ func GetHwInfoAllNodes() (out map[string]NodeHwInfo) {
 		lscpu, err := getHWJsonOutput(debugPod, o, lscpuCommand)
 		if err != nil {
 			log.Error("problem getting lscpu for node %s", debugPod.Spec.NodeName)
+		} else {
+			var ok bool
+			temp, ok := lscpu.(map[string]interface{})
+			if !ok {
+				log.Error("problem casting lscpu field for node %s, lscpu=%v", debugPod.Spec.NodeName, lscpu)
+			} else {
+				hw.Lscpu = temp["lscpu"]
+			}
 		}
-		var ok bool
-		hw.Lscpu, ok = lscpu.(map[string]interface{})["lscpu"]
-		if !ok {
-			log.Error("problem casting lscpu field for node %s, lscpu=%v", debugPod.Spec.NodeName, lscpu)
-		}
-
 		hw.IPconfig, err = getHWJsonOutput(debugPod, o, ipCommand)
 		if err != nil {
 			log.Error("problem getting ip config for node %s", debugPod.Spec.NodeName)

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -26,7 +26,7 @@ const (
 	defaultClaimPath       = "."
 	NoLabelsExpr           = "none"
 	labelsFlagName         = "label-filter"
-	labelsFlagDefaultValue = "common"
+	labelsFlagDefaultValue = "none"
 
 	labelsFlagUsage = "--label-filter <expression>  e.g. --label-filter 'access-control && !access-control-sys-admin-capability'"
 


### PR DESCRIPTION
Split casting of interface from reading content of the map, in case the cast failed
Change the default label to none to allow diagnostics only mode