### PR TITLE
Add check to ensure workload compliance with the next k8s version

### DIFF
--- a/cmd/certsuite/main_test.go
+++ b/cmd/certsuite/main_test.go
@@ -66,6 +66,7 @@ func TestCertsuiteInfoCmd(t *testing.T) {
 | observability-crd-status                                 |
 | observability-termination-policy                         |
 | observability-pod-disruption-budget                      |
+| observability-compatibility-with-next-ocp-release        |
 ------------------------------------------------------------
 `
 	assert.Equal(t, expectedOutput, string(out))

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -55,6 +55,7 @@ testCases:
     - observability-crd-status
     - observability-pod-disruption-budget
     - observability-termination-policy
+    - observability-compatibility-with-next-ocp-release
     - operator-crd-openapi-schema
     - operator-crd-versioning
     - operator-install-source

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/scale"
 
 	cncfNetworkAttachmentv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/client/clientset/versioned/typed/k8s.cni.cncf.io/v1"
+	apiserverscheme "github.com/openshift/client-go/apiserver/clientset/versioned"
 	ocpMachine "github.com/openshift/client-go/machineconfiguration/clientset/versioned"
 	appsv1 "k8s.io/api/apps/v1"
 	scalingv1 "k8s.io/api/autoscaling/v1"
@@ -70,6 +71,7 @@ type ClientsHolder struct {
 	KubeConfig           []byte
 	ready                bool
 	GroupResources       []*metav1.APIResourceList
+	ApiserverClient      apiserverscheme.Interface
 }
 
 var clientsHolder = ClientsHolder{}
@@ -328,6 +330,11 @@ func newClientsHolder(filenames ...string) (*ClientsHolder, error) { //nolint:fu
 	clientsHolder.CNCFNetworkingClient, err = cncfNetworkAttachmentv1.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
 		return nil, fmt.Errorf("cannot instantiate CNCF networking client")
+	}
+
+	clientsHolder.ApiserverClient, err = apiserverscheme.NewForConfig(clientsHolder.RestConfig)
+	if err != nil {
+		return nil, fmt.Errorf("cannot instantiate apiserverscheme: %w", err)
 	}
 
 	clientsHolder.ready = true

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -116,10 +116,11 @@ const (
 	TestOperatorReadOnlyFilesystemDocLink               = DocOperatorRequirement
 
 	// Observability Test Suite
-	TestLoggingIdentifierDocLink                  = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-logging"
-	TestTerminationMessagePolicyIdentifierDocLink = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-pod-exit-status"
-	TestCrdsStatusSubresourceIdentifierDocLink    = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements"
-	TestPodDisruptionBudgetIdentifierDocLink      = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-upgrade-expectations"
+	TestLoggingIdentifierDocLink                            = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-logging"
+	TestTerminationMessagePolicyIdentifierDocLink           = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-pod-exit-status"
+	TestCrdsStatusSubresourceIdentifierDocLink              = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements"
+	TestPodDisruptionBudgetIdentifierDocLink                = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-upgrade-expectations"
+	TestAPICompatibilityWithNextOCPReleaseIdentifierDocLink = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-to-be-removed-apis"
 
 	// Manageability Test Suite
 	TestContainersImageTagDocLink      = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-image-tagging"

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -163,6 +163,7 @@ var (
 	TestPodRequestsAndLimitsIdentifier                claim.Identifier
 	TestNamespaceResourceQuotaIdentifier              claim.Identifier
 	TestPodDisruptionBudgetIdentifier                 claim.Identifier
+	TestAPICompatibilityWithNextOCPReleaseIdentifier  claim.Identifier
 	TestPodTolerationBypassIdentifier                 claim.Identifier
 	TestPersistentVolumeReclaimPolicyIdentifier       claim.Identifier
 	TestContainersImageTag                            claim.Identifier
@@ -1587,6 +1588,22 @@ that Node's kernel may not have the same hacks.'`,
 			Telco:    Mandatory,
 			NonTelco: Mandatory,
 			Extended: Mandatory,
+		},
+		TagCommon)
+
+	TestAPICompatibilityWithNextOCPReleaseIdentifier = AddCatalogEntry(
+		"compatibility-with-next-ocp-release",
+		common.ObservabilityTestKey,
+		`Checks to ensure if the APIs the workload uses are compatible with the next OCP version`,
+		APICompatibilityWithNextOCPReleaseRemediation,
+		NoExceptions,
+		TestAPICompatibilityWithNextOCPReleaseIdentifierDocLink,
+		true,
+		map[string]string{
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
+			Extended: Optional,
 		},
 		TagCommon)
 

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -151,6 +151,8 @@ const (
 
 	PodDisruptionBudgetRemediation = `Ensure minAvailable is not zero and maxUnavailable does not equal the number of pods in the replica`
 
+	APICompatibilityWithNextOCPReleaseRemediation = `Ensure the APIs the workload uses are compatible with the next OCP version`
+
 	//nolint:gosec
 	PodTolerationBypassRemediation = `Do not allow pods to bypass the NoExecute, PreferNoSchedule, or NoSchedule tolerations that are default applied by Kubernetes.`
 

--- a/tests/observability/suite.go
+++ b/tests/observability/suite.go
@@ -21,11 +21,14 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
+	"github.com/Masterminds/semver"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/common"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/identifiers"
 	pdbv1 "github.com/redhat-best-practices-for-k8s/certsuite/tests/observability/pdb"
 
+	apiserv1 "github.com/openshift/api/apiserver/v1"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
@@ -77,6 +80,12 @@ func LoadChecks() {
 		WithSkipModeAll().
 		WithCheckFn(func(c *checksdb.Check) error {
 			testPodDisruptionBudgets(c, &env)
+			return nil
+		}))
+
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestAPICompatibilityWithNextOCPReleaseIdentifier)).
+		WithCheckFn(func(c *checksdb.Check) error {
+			testAPICompatibilityWithNextOCPRelease(c, &env)
 			return nil
 		}))
 }
@@ -269,5 +278,148 @@ func testPodDisruptionBudgets(check *checksdb.Check, env *provider.TestEnvironme
 		}
 	}
 
+	check.SetResult(compliantObjects, nonCompliantObjects)
+}
+
+// Function to build a map from workload service accounts
+// to their associated to-be-deprecated APIs and the release version
+// Filters:
+// - status.removedInRelease is not empty
+// - Verifies if the service account is inside the workload SA list from env.ServiceAccounts
+func buildServiceAccountToDeprecatedAPIMap(apiRequestCounts []apiserv1.APIRequestCount, workloadServiceAccountNames map[string]struct{}) map[string]map[string]string {
+	// Define a map where the key is the service account name and the value is another map
+	// The inner map key is the API name and the value is the release version in which it will be removed
+	serviceAccountToDeprecatedAPIs := make(map[string]map[string]string)
+
+	for i := range apiRequestCounts {
+		obj := &apiRequestCounts[i]
+		// Filter by non-empty removedInRelease
+		if obj.Status.RemovedInRelease != "" {
+			// Iterate over the last 24h usage data
+			for _, last24h := range obj.Status.Last24h {
+				for _, byNode := range last24h.ByNode {
+					for _, byUser := range byNode.ByUser {
+						// Split the username by ":" and take the last chunk to extract ServiceAccount
+						// from composed structures like system:serviceaccount:default:eventtest-operator-service-account
+						serviceAccountParts := strings.Split(byUser.UserName, ":")
+						strippedServiceAccount := serviceAccountParts[len(serviceAccountParts)-1]
+
+						// Check if the service account is in the workload SA list
+						if _, exists := workloadServiceAccountNames[strippedServiceAccount]; exists {
+							// Initialize the inner map if it does not exist
+							if serviceAccountToDeprecatedAPIs[strippedServiceAccount] == nil {
+								serviceAccountToDeprecatedAPIs[strippedServiceAccount] = make(map[string]string)
+							}
+							// Add the API and its RemovedInRelease K8s version to the map
+							serviceAccountToDeprecatedAPIs[strippedServiceAccount][obj.Name] = obj.Status.RemovedInRelease
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return serviceAccountToDeprecatedAPIs
+}
+
+// Evaluate workload API compliance with the next Kubernetes version
+func evaluateAPICompliance(
+	serviceAccountToDeprecatedAPIs map[string]map[string]string,
+	kubernetesVersion string,
+	workloadServiceAccountNames map[string]struct{}) (compliantObjects, nonCompliantObjects []*testhelper.ReportObject) {
+	version, err := semver.NewVersion(kubernetesVersion)
+	if err != nil {
+		fmt.Printf("Failed to parse Kubernetes version %q: %v", kubernetesVersion, err)
+		return nil, nil
+	}
+
+	// Increment the version to represent the next release for comparison
+	nextK8sVersion := version.IncMinor()
+
+	// Iterate over each service account and its deprecated APIs
+	for saName, deprecatedAPIs := range serviceAccountToDeprecatedAPIs {
+		for apiName, removedInRelease := range deprecatedAPIs {
+			removedVersion, err := semver.NewVersion(removedInRelease)
+			if err != nil {
+				fmt.Printf("Failed to parse Kubernetes version from APIRequestCount.status.removedInRelease: %s\n", err)
+				// Skip this API if the version parsing fails
+				continue
+			}
+
+			isCompliantWithNextK8sVersion := removedVersion.Minor() > nextK8sVersion.Minor()
+
+			// Define reasons with version information
+			nonCompliantReason := fmt.Sprintf("API %s used by service account %s is NOT compliant with Kubernetes version %s, it will be removed in release %s", apiName, saName, nextK8sVersion.String(), removedInRelease)
+			compliantReason := fmt.Sprintf("API %s used by service account %s is compliant with Kubernetes version %s, it will be removed in release %s", apiName, saName, nextK8sVersion.String(), removedInRelease)
+
+			var reportObject *testhelper.ReportObject
+			if isCompliantWithNextK8sVersion {
+				reportObject = testhelper.NewReportObject(compliantReason, "API", true)
+				reportObject.AddField("ActiveInRelease", nextK8sVersion.String())
+				compliantObjects = append(compliantObjects, reportObject)
+			} else {
+				reportObject = testhelper.NewReportObject(nonCompliantReason, "API", false)
+				reportObject.AddField("RemovedInRelease", removedInRelease)
+				nonCompliantObjects = append(nonCompliantObjects, reportObject)
+			}
+
+			reportObject.AddField("APIName", apiName)
+			reportObject.AddField("ServiceAccount", saName)
+		}
+	}
+
+	// Force the test to pass if both lists are empty
+	if len(compliantObjects) == 0 && len(nonCompliantObjects) == 0 {
+		for saName := range workloadServiceAccountNames {
+			reportObject := testhelper.NewReportObject("SA does not use any removed API", "ServiceAccount", true).
+				AddField("Name", saName)
+			compliantObjects = append(compliantObjects, reportObject)
+		}
+	}
+
+	return compliantObjects, nonCompliantObjects
+}
+
+// Function to extract unique workload-related service account names from the environment
+func extractUniqueServiceAccountNames(env *provider.TestEnvironment) map[string]struct{} {
+	uniqueServiceAccountNames := make(map[string]struct{})
+
+	// Iterate over the service accounts to extract names
+	for _, sa := range env.ServiceAccounts {
+		uniqueServiceAccountNames[sa.ObjectMeta.Name] = struct{}{}
+	}
+
+	return uniqueServiceAccountNames
+}
+
+// Function to test API compatibility with the next OCP release
+func testAPICompatibilityWithNextOCPRelease(check *checksdb.Check, env *provider.TestEnvironment) {
+	isOCP := provider.IsOCPCluster()
+	check.LogInfo("Is OCP: %v", isOCP)
+
+	if !isOCP {
+		check.LogInfo("The Kubernetes distribution is not OpenShift. Skipping API compatibility test.")
+		return
+	}
+
+	// Retrieve APIRequestCount using clientsholder
+	oc := clientsholder.GetClientsHolder()
+	apiRequestCounts, err := oc.ApiserverClient.ApiserverV1().APIRequestCounts().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		check.LogError("Error retrieving APIRequestCount objects: %s", err)
+		return
+	}
+
+	// Extract unique service account names from env.ServiceAccounts
+	workloadServiceAccountNames := extractUniqueServiceAccountNames(env)
+	check.LogInfo("Detected %d unique service account names for the workload: %v", len(workloadServiceAccountNames), workloadServiceAccountNames)
+
+	// Build a map from service accounts to deprecated APIs
+	serviceAccountToDeprecatedAPIs := buildServiceAccountToDeprecatedAPIMap(apiRequestCounts.Items, workloadServiceAccountNames)
+
+	// Evaluate API compliance with the next Kubernetes version
+	compliantObjects, nonCompliantObjects := evaluateAPICompliance(serviceAccountToDeprecatedAPIs, env.K8sVersion, workloadServiceAccountNames)
+
+	// Add test results
 	check.SetResult(compliantObjects, nonCompliantObjects)
 }

--- a/tests/observability/suite_test.go
+++ b/tests/observability/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2022 Red Hat, Inc.
+// Copyright (C) 2020-2025 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,3 +15,219 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package observability
+
+import (
+	"testing"
+
+	apiserv1 "github.com/openshift/api/apiserver/v1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestBuildServiceAccountToDeprecatedAPIMap(t *testing.T) {
+	// Example map of unique service account names for the workload
+	workloadServiceAccountNames := map[string]struct{}{
+		"builder":                            {},
+		"default":                            {},
+		"deployer":                           {},
+		"eventtest-operator-service-account": {},
+	}
+
+	testCases := []struct {
+		name                        string
+		apiRequestCounts            []apiserv1.APIRequestCount
+		workloadServiceAccountNames map[string]struct{}
+		expected                    map[string]map[string]string
+	}{
+		{
+			name: "Test to ensure proper mapping of service accounts to deprecated APIs",
+			apiRequestCounts: []apiserv1.APIRequestCount{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "api1",
+					},
+					Status: apiserv1.APIRequestCountStatus{
+						RemovedInRelease: "v1.20",
+						Last24h: []apiserv1.PerResourceAPIRequestLog{
+							{
+								ByNode: []apiserv1.PerNodeAPIRequestLog{
+									{
+										ByUser: []apiserv1.PerUserAPIRequestCount{
+											{
+												UserName:  "eventtest-operator-service-account",
+												UserAgent: "agent1",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "api2",
+					},
+					Status: apiserv1.APIRequestCountStatus{
+						RemovedInRelease: "v1.21",
+						Last24h: []apiserv1.PerResourceAPIRequestLog{
+							{
+								ByNode: []apiserv1.PerNodeAPIRequestLog{
+									{
+										ByUser: []apiserv1.PerUserAPIRequestCount{
+											{
+												UserName:  "unknown-sa",
+												UserAgent: "agent2",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			workloadServiceAccountNames: workloadServiceAccountNames,
+			expected: map[string]map[string]string{
+				"eventtest-operator-service-account": {
+					"api1": "v1.20",
+				},
+			},
+		},
+		{
+			name: "Test where no matching service account names exist",
+			apiRequestCounts: []apiserv1.APIRequestCount{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "api3",
+					},
+					Status: apiserv1.APIRequestCountStatus{
+						RemovedInRelease: "v1.22",
+						Last24h: []apiserv1.PerResourceAPIRequestLog{
+							{
+								ByNode: []apiserv1.PerNodeAPIRequestLog{
+									{
+										ByUser: []apiserv1.PerUserAPIRequestCount{
+											{
+												UserName:  "non-existent-sa",
+												UserAgent: "agent3",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			workloadServiceAccountNames: workloadServiceAccountNames,
+			expected:                    map[string]map[string]string{}, // Expect no output since 'non-existent-sa' is not in the SA map
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := buildServiceAccountToDeprecatedAPIMap(tc.apiRequestCounts, tc.workloadServiceAccountNames)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestEvaluateAPICompliance(t *testing.T) {
+	// Mock service account to deprecated APIs map
+	serviceAccountToDeprecatedAPIs := map[string]map[string]string{
+		"service-account-1": {
+			"api1": "1.21",
+		},
+		"service-account-2": {
+			"api2": "1.20",
+		},
+	}
+
+	// Mock current Kubernetes version
+	kubernetesVersion := "1.19"
+
+	// Mock workload service account names
+	workloadServiceAccountNames := map[string]struct{}{
+		"service-account-1": {},
+		"service-account-2": {},
+	}
+
+	// Call the function
+	compliantObjects, nonCompliantObjects := evaluateAPICompliance(serviceAccountToDeprecatedAPIs, kubernetesVersion, workloadServiceAccountNames)
+
+	// Helper to create a ReportObject with fields
+	createReportObject := func(reason, objType, apiName, removedInRelease, version, serviceAccount string, isCompliant bool) *testhelper.ReportObject {
+		obj := testhelper.NewReportObject(reason, objType, isCompliant)
+		obj.AddField("APIName", apiName)
+		obj.AddField("ServiceAccount", serviceAccount)
+		if isCompliant {
+			obj.AddField("ActiveInRelease", version)
+		} else {
+			obj.AddField("RemovedInRelease", removedInRelease)
+		}
+		return obj
+	}
+
+	// Expected results
+	expectedCompliantObjects := []*testhelper.ReportObject{
+		// API removed in 1.21 is compliant with Kubernetes 1.20 = (current version 1.19 + 1)
+		createReportObject(
+			"API api1 used by service account service-account-1 is compliant with Kubernetes version 1.20.0, it will be removed in release 1.21",
+			"API", "api1", "1.21", "1.20.0", "service-account-1", true,
+		),
+	}
+
+	expectedNonCompliantObjects := []*testhelper.ReportObject{
+		// API removed in 1.20 is non-compliant with Kubernetes 1.20 = (current version 1.19 + 1)
+		createReportObject(
+			"API api2 used by service account service-account-2 is NOT compliant with Kubernetes version 1.20.0, it will be removed in release 1.20",
+			"API", "api2", "1.20", "", "service-account-2", false,
+		),
+	}
+
+	// Helper function to compare ReportObjects
+	compareReportObjects := func(expected, actual []*testhelper.ReportObject) {
+		assert.Len(t, actual, len(expected))
+		for i, obj := range actual {
+			assert.Equal(t, expected[i].ObjectType, obj.ObjectType)
+			assert.ElementsMatch(t, expected[i].ObjectFieldsKeys, obj.ObjectFieldsKeys)
+			assert.ElementsMatch(t, expected[i].ObjectFieldsValues, obj.ObjectFieldsValues)
+		}
+	}
+
+	// Verify the results
+	compareReportObjects(expectedCompliantObjects, compliantObjects)
+	compareReportObjects(expectedNonCompliantObjects, nonCompliantObjects)
+
+	// Test for the empty lists situation
+	// Call the function with an empty map
+	emptyMap := map[string]map[string]string{}
+	workloadServiceAccountNames = map[string]struct{}{
+		"service-account-1": {},
+		"service-account-2": {},
+	}
+	compliantObjects, nonCompliantObjects = evaluateAPICompliance(emptyMap, kubernetesVersion, workloadServiceAccountNames)
+
+	// Expected result for the empty case
+	expectedEmptyResult := []*testhelper.ReportObject{
+		testhelper.NewReportObject(
+			"SA does not use any removed API",
+			"ServiceAccount", true,
+		).AddField("Name", "service-account-1"),
+		testhelper.NewReportObject(
+			"SA does not use any removed API",
+			"ServiceAccount", true,
+		).AddField("Name", "service-account-2"),
+	}
+
+	// Verify the result for the empty map case
+	assert.Len(t, compliantObjects, len(expectedEmptyResult))
+	assert.Empty(t, nonCompliantObjects)
+	for i, obj := range expectedEmptyResult {
+		assert.Equal(t, obj.ObjectType, compliantObjects[i].ObjectType)
+		assert.ElementsMatch(t, obj.ObjectFieldsKeys, compliantObjects[i].ObjectFieldsKeys)
+		assert.ElementsMatch(t, obj.ObjectFieldsValues, compliantObjects[i].ObjectFieldsValues)
+	}
+}


### PR DESCRIPTION
build-depends: https://github.com/redhatci/ansible-collection-redhatci-ocp/pull/421

Test setup: 

OCP 4.11.18 running as a local CRC-2.12.
On the top, deploying [eventtest-operator](https://github.com/redhatci/eventtest-operator?tab=readme-ov-file#demo-2-on-crc-2120-41118) using API [events.k8s.io/v1beta1](https://github.com/redhatci/eventtest-operator/blob/main/scripts/send_events.py#L39-L40) deprecated in OCP-4.12 / k8s 1.25. This API is used dynamically, out of Python kubernetes package. 

```
$ oc version
Client Version: 4.11.18
Kustomize Version: v4.5.4
Server Version: 4.11.18
Kubernetes Version: v1.24.6+5658434

$ make show
kubectl get crds | grep event
eventtests.eventtest.com                                          2024-07-31T12:10:01Z
kubectl get eventtests -n default
NAME           AGE
my-eventtest   30s
kubectl get pods
NAME                                 READY   STATUS    RESTARTS   AGE
eventtest-operator-978d77ddb-hh5cg   1/1     Running   0          28s

# eventtest-operator is running and sending events
$ oc get events | grep soon
21s         Normal    BreakingNews                                 eventtest/my-eventtest                    Rumors report messages sent to null. More updates expected soon. Stay tuned!
2s          Normal    BreakingNews                                 eventtest/my-eventtest                    Rumors report messages sent to null. More updates expected soon. Stay tuned!
12s         Normal    BreakingNews                                 eventtest/my-eventtest                    Rumors report messages sent to null. More updates expected soon. Stay tuned!
```

CNF config and invocation:

```
$ cat $ cat krishtop_config/tnf_config.yml
---
targetNameSpaces:
  - name: default

podsUnderTestLabels:
  - "name: eventtest-operator"

operatorsUnderTestLabels:
  - "name: eventtest-operator"


$ ./certsuite run --label-filter 'observability' --config-file krishtop_config/tnf_config.yml --kubeconfig= ~/.kube/config --output-dir results

-----------------------------------------------------------
| LOG (observability-compatibility-with-next-ocp-release) |
-----------------------------------------------------------
[INFO] [Sep  5 01:46:06.989] [check.go: 270] [observability-compatibility-with-next-ocp-release] Running check (labels: [common observability-compatibility-with-next-ocp-release observability])
[INFO] [Sep  5 01:46:06.989] [suite.go: 397] [observability-compatibility-with-next-ocp-release] Is OCP: true
[INFO] [Sep  5 01:46:07.888] [suite.go: 414] [observability-compatibility-with-next-ocp-release] 
Detected 4 unique service account names for the workload: 
map[builder:{} default:{} deployer:{} eventtest-operator-service-account:{}]
[INFO] [Sep  5 01:46:07.888] [checksdb.go: 115] [observability-compatibility-with-next-ocp-release] 
Recording result "FAILED", 
claimID: {Id:observability-compatibility-with-next-ocp-release Suite:observability Tags:common}
```

claim.json

```
      "observability-compatibility-with-next-ocp-release": {
        "capturedTestOutput": "[INFO] [Sep  6 06:15:59.009] [check.go: 270] [observability-compatibility-with-next-ocp-release] Running check (labels: [common observability-compatibility-with-next-ocp-release observability])\n[INFO] [Sep  6 06:15:59.009] [suite.go: 398] [observability-compatibility-with-next-ocp-release] Is OCP: true\n[INFO] [Sep  6 06:15:59.658] [suite.go: 415] [observability-compatibility-with-next-ocp-release] Detected 4 unique service account names for the workload: map[builder:{} default:{} deployer:{} eventtest-operator-service-account:{}]\n[INFO] [Sep  6 06:15:59.659] [checksdb.go: 115] [observability-compatibility-with-next-ocp-release] Recording result \"FAILED\", claimID: {Id:observability-compatibility-with-next-ocp-release Suite:observability Tags:common}\n",
        "catalogInfo": {
          "bestPracticeReference": "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-to-be-removed-apis",
          "description": "Checks to ensure if the APIs the workload uses are compatible with the next OCP version",
          "exceptionProcess": "No exceptions",
          "remediation": "Ensure the APIs the workload uses are compatible with the next OCP version"
        },
        "categoryClassification": {
          "Extended": "Optional",
          "FarEdge": "Optional",
          "NonTelco": "Optional",
          "Telco": "Optional"
        },
        "checkDetails": "{\"CompliantObjectsOut\":[{\"ObjectType\":\"API\",\"ObjectFieldsKeys\":
[\"Reason For Compliance\",\"ActiveInRelease\",\"APIName\",
\"ServiceAccount\"],
\"ObjectFieldsValues\":[\"API flowschemas.v1beta1.flowcontrol.apiserver.k8s.io used 
by service account default is compliant with Kubernetes version 1.25.0, 
it will be removed in release 1.26\",\"1.25.0\",
\"flowschemas.v1beta1.flowcontrol.apiserver.k8s.io\",\"default\"]},
{\"ObjectType\":\"API\",\"ObjectFieldsKeys\":
[\"Reason For Compliance\",\"ActiveInRelease\",\"APIName\",
\"ServiceAccount\"],\"ObjectFieldsValues\":
[\"API prioritylevelconfigurations.v1beta1.flowcontrol.apiserver.k8s.io used by service account 
default is compliant with Kubernetes version 1.25.0,
 it will be removed in release 1.26\",\"1.25.0\",\"prioritylevelconfigurations.v1beta1.flowcontrol.apiserver.k8s.io\",
\"default\"]}],
\"NonCompliantObjectsOut\":
[{\"ObjectType\":\"API\",\"ObjectFieldsKeys\":
[\"Reason For Non Compliance\",\"RemovedInRelease\",\"APIName\",
\"ServiceAccount\"],\"ObjectFieldsValues\":
[\"API events.v1beta1.events.k8s.io used by service account eventtest-operator-service-account 
is NOT compliant with Kubernetes version 1.25.0, 
it will be removed in release 1.25\",\"1.25\",\"events.v1beta1.events.k8s.io\",
\"eventtest-operator-service-account\"]}]}",
        "duration": 0,
        "endTime": "2024-09-06 06:15:59.659116808 +0200 CEST m=+2.662560049",
        "failureLineContent": "",
        "failureLocation": "",
        "skipReason": "",
        "startTime": "2024-09-06 06:15:59.0095167 +0200 CEST m=+2.012959932",
        "state": "failed",
        "testID": {
          "id": "observability-compatibility-with-next-ocp-release",
          "suite": "observability",
          "tags": "common"
        }
      },
```