### PR TITLE
Update GolangCI-lint to v1.60.2; various fixes

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -73,7 +73,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86 # v6.1.0
         with:
-          version: v1.59
+          version: v1.60
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,7 +51,7 @@ linters:
     - dogsled
     - errcheck
     - exhaustive
-    - exportloopref
+    - copyloopvar
     - funlen
     - goconst
     - gocritic
@@ -91,7 +91,7 @@ linters:
   # - noctx
   # - prealloc
   # - revive
-  # - exportloopref
+  # - copyloopvar
   # - structcheck
   # - testpackage
   # - wsl

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
 CLAIM_FORMAT_VERSION=$(shell script/get-claim-version.sh)
-GOLANGCI_VERSION=v1.60.1
+GOLANGCI_VERSION=v1.60.2
 LINKER_CERTSUITE_RELEASE_FLAGS=-X github.com/redhat-best-practices-for-k8s/certsuite/pkg/versions.GitCommit=${GIT_COMMIT}
 LINKER_CERTSUITE_RELEASE_FLAGS+= -X github.com/redhat-best-practices-for-k8s/certsuite/pkg/versions.GitRelease=${GIT_RELEASE}
 LINKER_CERTSUITE_RELEASE_FLAGS+= -X github.com/redhat-best-practices-for-k8s/certsuite/pkg/versions.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -63,6 +63,7 @@ func PrintBanner() {
 type cliCheckLogSniffer struct{}
 
 func isTTY() bool {
+	//nolint:gosec
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
@@ -94,6 +95,7 @@ func updateRunningCheckLine(checkName string, stopChan <-chan bool) {
 }
 
 func getTerminalWidth() int {
+	//nolint:gosec
 	width, _, _ := term.GetSize(int(os.Stdin.Fd()))
 	return width
 }

--- a/internal/clientsholder/command.go
+++ b/internal/clientsholder/command.go
@@ -39,6 +39,7 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 	commandStr := []string{"sh", "-c", command}
 	var buffOut bytes.Buffer
 	var buffErr bytes.Buffer
+	//nolint:govet
 	log.Debug(fmt.Sprintf("execute command on ns=%s, pod=%s container=%s, cmd: %s", ctx.GetNamespace(), ctx.GetPodName(), ctx.GetContainerName(), strings.Join(commandStr, " ")))
 	req := clientsholder.K8sClient.CoreV1().RESTClient().
 		Post().

--- a/internal/results/archiver.go
+++ b/internal/results/archiver.go
@@ -19,6 +19,7 @@ const (
 )
 
 func generateZipFileName() string {
+	//nolint:govet
 	return fmt.Sprintf(time.Now().Format(tarGzFileNamePrefixLayout) + "-" + tarGzFileNameSuffix)
 }
 

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -80,9 +80,11 @@ func (c *Container) GetUID() (string, error) {
 		uid = split[len(split)-1]
 	}
 	if uid == "" {
+		//nolint:govet
 		log.Debug(fmt.Sprintf("could not find uid of %s/%s/%s\n", c.Namespace, c.Podname, c.Name))
 		return "", errors.New("cannot determine container UID")
 	}
+	//nolint:govet
 	log.Debug(fmt.Sprintf("uid of %s/%s/%s=%s\n", c.Namespace, c.Podname, c.Name, uid))
 	return uid, nil
 }
@@ -136,6 +138,7 @@ func (c *Container) SetPreflightResults(preflightImageCache map[string]Preflight
 	}
 
 	// Take all of the Preflight logs and stick them into our log.
+	//nolint:govet
 	log.Info(logbytes.String())
 
 	// Store the Preflight test results into the container's PreflightResults var and into the cache.

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -114,6 +114,7 @@ func (op *Operator) SetPreflightResults(env *TestEnvironment) error {
 	}
 
 	// Take all of the preflight logs and stick them into our log.
+	//nolint:govet
 	log.Info(logbytes.String())
 
 	e := os.RemoveAll("artifacts/")

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -207,10 +207,7 @@ func (p *Pod) CreatedByDeploymentConfig() (bool, error) {
 
 func (p *Pod) HasNodeSelector() bool {
 	// Checks whether or not the pod has a nodeSelector or a NodeName supplied
-	if p.Spec.NodeSelector == nil || len(p.Spec.NodeSelector) == 0 {
-		return false
-	}
-	return true
+	return len(p.Spec.NodeSelector) != 0
 }
 
 func (p *Pod) IsRuntimeClassNameSpecified() bool {

--- a/script/run-basic-batch-operators-test.sh
+++ b/script/run-basic-batch-operators-test.sh
@@ -244,7 +244,7 @@ wait_all_packages_ok() {
 		elapsed_time \
 		timeout_seconds=600
 
-	prev_count="$(get_packeges)"
+	prev_count="$(get_packages)"
 	start_time="$(date +%s 2>&1)" || {
 		echo "date failed with error $?: $start_time" >>"$LOG_FILE_PATH"
 		return 0
@@ -252,7 +252,7 @@ wait_all_packages_ok() {
 
 	# wait until package number is stable
 	while true; do
-		curr_count=$(get_packeges)
+		curr_count=$(get_packages)
 		if [ "${curr_count}" -ne "${prev_count}" ] || [ "${curr_count}" -eq 0 ]; then
 			prev_count="${curr_count}"
 		else
@@ -273,7 +273,7 @@ wait_all_packages_ok() {
 	done
 }
 
-get_packeges() {
+get_packages() {
 	oc get packagemanifest \
 		-n ${OPERATOR_CATALOG_NAMESPACE} -o json |
 		jq -r '.items[] | select(.status.catalogSource == "'${OPERATOR_CATALOG_NAME}'") | .metadata.name' |

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -732,6 +732,7 @@ func testAutomountServiceToken(check *checksdb.Check, env *provider.TestEnvironm
 		client := clientsholder.GetClientsHolder()
 		podPassed, newMsg := rbac.EvaluateAutomountTokens(client.K8sClient.CoreV1(), put.Pod)
 		if !podPassed {
+			//nolint:govet
 			check.LogError(newMsg)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, newMsg, false))
 		} else {
@@ -915,6 +916,7 @@ func testNoSSHDaemonsAllowed(check *checksdb.Check, env *provider.TestEnvironmen
 		}
 
 		// 2. Check if SSH port is listening
+		//nolint:gosec
 		sshPortInfo := netutil.PortInfo{PortNumber: int32(sshServicePortNumber), Protocol: sshServicePortProtocol}
 		listeningPorts, err := netutil.GetListeningPorts(cut)
 		if err != nil {

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -81,7 +81,7 @@ const (
 	TestPodHighAvailabilityBestPracticesDocLink        = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-high-level-cnf-expectations"
 	TestPodDeploymentBestPracticesIdentifierDocLink    = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-no-naked-pods"
 	TestDeploymentScalingIdentifierDocLink             = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-high-level-cnf-expectations"
-	TestStateFulSetScalingIdentifierDocLink            = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-high-level-cnf-expectations"
+	TestStatefulSetScalingIdentifierDocLink            = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-high-level-cnf-expectations"
 	TestImagePullPolicyIdentifierDocLink               = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-use-imagepullpolicy-if-not-present"
 	TestPodRecreationIdentifierDocLink                 = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-upgrade-expectations"
 	TestLivenessProbeIdentifierDocLink                 = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-high-level-cnf-expectations"

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -134,7 +134,7 @@ var (
 	TestPodClusterRoleBindingsBestPracticesIdentifier claim.Identifier
 	TestPodDeploymentBestPracticesIdentifier          claim.Identifier
 	TestDeploymentScalingIdentifier                   claim.Identifier
-	TestStateFulSetScalingIdentifier                  claim.Identifier
+	TestStatefulSetScalingIdentifier                  claim.Identifier
 	TestImagePullPolicyIdentifier                     claim.Identifier
 	TestPodRecreationIdentifier                       claim.Identifier
 	TestPodRoleBindingsBestPracticesIdentifier        claim.Identifier
@@ -1126,13 +1126,13 @@ that Node's kernel may not have the same hacks.'`,
 		},
 		TagCommon)
 
-	TestStateFulSetScalingIdentifier = AddCatalogEntry(
+	TestStatefulSetScalingIdentifier = AddCatalogEntry(
 		"statefulset-scaling",
 		common.LifecycleTestKey,
 		`Tests that workload statefulsets support scale in/out operations. First, the test starts getting the current replicaCount (N) of the statefulset/s with the Pod Under Test. Then, it executes the scale-in oc command for (N-1) replicas. Lastly, it executes the scale-out oc command, restoring the original replicaCount of the statefulset/s. In case of statefulsets that are managed by HPA the test is changing the min and max value to statefulset Replica - 1 during scale-in and the original replicaCount again for both min/max during the scale-out stage. Lastly its restoring the original min/max replica of the statefulset/s`, //nolint:lll
 		StatefulSetScalingRemediation,
 		NoDocumentedProcess+NotApplicableSNO,
-		TestStateFulSetScalingIdentifierDocLink,
+		TestStatefulSetScalingIdentifierDocLink,
 		true,
 		map[string]string{
 			FarEdge:  Optional,

--- a/tests/lifecycle/scaling/deployment_scaling_test.go
+++ b/tests/lifecycle/scaling/deployment_scaling_test.go
@@ -75,6 +75,7 @@ func TestScaleDeploymentFunc(t *testing.T) {
 	for _, tc := range testCases {
 		var runtimeObjects []runtime.Object
 		intVar := new(int32)
+		//nolint:gosec
 		*intVar = int32(tc.replicaCount)
 		tempDP := generateDeployment(tc.deploymentName, intVar)
 		runtimeObjects = append(runtimeObjects, tempDP)
@@ -88,6 +89,7 @@ func TestScaleDeploymentFunc(t *testing.T) {
 		// Get the deployment from the fake API
 		dp, err := c.K8sClient.AppsV1().Deployments("namespace1").Get(context.TODO(), tc.deploymentName, metav1.GetOptions{})
 		assert.Nil(t, err)
+		//nolint:gosec
 		assert.Equal(t, int32(tc.replicaCount), *dp.Spec.Replicas)
 	}
 }
@@ -142,6 +144,7 @@ func TestScaleHpaDeploymentFunc(t *testing.T) {
 
 	for _, tc := range testCases {
 		intVar := new(int32)
+		//nolint:gosec
 		*intVar = int32(tc.replicaCount)
 		tempDP := generateDeployment(tc.deploymentName, intVar)
 
@@ -184,6 +187,7 @@ func TestScaleHpaDeploymentFunc(t *testing.T) {
 		// Get the deployment from the fake API
 		hpa, err := c.AutoscalingV1().HorizontalPodAutoscalers("namespace1").Get(context.TODO(), "hpaName", metav1.GetOptions{})
 		assert.Nil(t, err)
+		//nolint:gosec
 		assert.Equal(t, int32(tc.expectedReplicaCount), hpa.Spec.MaxReplicas)
 	}
 }

--- a/tests/lifecycle/scaling/statefulset_scaling.go
+++ b/tests/lifecycle/scaling/statefulset_scaling.go
@@ -50,14 +50,14 @@ func TestScaleStatefulSet(statefulset *appsv1.StatefulSet, timeout time.Duration
 		// scale up
 		replicas++
 		logger.Debug("Scale UP statefulset to %d replicas", replicas)
-		if !scaleStateFulsetHelper(clients, ssClients, statefulset, replicas, timeout, logger) {
+		if !scaleStatefulsetHelper(clients, ssClients, statefulset, replicas, timeout, logger) {
 			logger.Error("Cannot scale statefulset = %s:%s", namespace, name)
 			return false
 		}
 		// scale down
 		replicas--
 		logger.Debug("Scale DOWN statefulset to %d replicas", replicas)
-		if !scaleStateFulsetHelper(clients, ssClients, statefulset, replicas, timeout, logger) {
+		if !scaleStatefulsetHelper(clients, ssClients, statefulset, replicas, timeout, logger) {
 			logger.Error("Cannot scale statefulset = %s:%s", namespace, name)
 			return false
 		}
@@ -65,13 +65,13 @@ func TestScaleStatefulSet(statefulset *appsv1.StatefulSet, timeout time.Duration
 		// scale down
 		replicas--
 		logger.Debug("Scale DOWN statefulset to %d replicas", replicas)
-		if !scaleStateFulsetHelper(clients, ssClients, statefulset, replicas, timeout, logger) {
+		if !scaleStatefulsetHelper(clients, ssClients, statefulset, replicas, timeout, logger) {
 			logger.Error("Cannot scale statefulset = %s:%s", namespace, name)
 			return false
 		} // scale up
 		replicas++
 		logger.Debug("Scale UP statefulset to %d replicas", replicas)
-		if !scaleStateFulsetHelper(clients, ssClients, statefulset, replicas, timeout, logger) {
+		if !scaleStatefulsetHelper(clients, ssClients, statefulset, replicas, timeout, logger) {
 			logger.Error("Cannot scale statefulset = %s:%s", namespace, name)
 			return false
 		}
@@ -79,7 +79,7 @@ func TestScaleStatefulSet(statefulset *appsv1.StatefulSet, timeout time.Duration
 	return true
 }
 
-func scaleStateFulsetHelper(clients *clientsholder.ClientsHolder, ssClient v1.StatefulSetInterface, statefulset *appsv1.StatefulSet, replicas int32, timeout time.Duration, logger *log.Logger) bool {
+func scaleStatefulsetHelper(clients *clientsholder.ClientsHolder, ssClient v1.StatefulSetInterface, statefulset *appsv1.StatefulSet, replicas int32, timeout time.Duration, logger *log.Logger) bool {
 	name := statefulset.Name
 	namespace := statefulset.Namespace
 

--- a/tests/lifecycle/suite.go
+++ b/tests/lifecycle/suite.go
@@ -582,6 +582,7 @@ func testPodsRecreation(check *checksdb.Check, env *provider.TestEnvironment) { 
 	needsPostMortemInfo := true
 	defer func() {
 		if needsPostMortemInfo {
+			//nolint:govet
 			check.LogDebug(postmortem.Log())
 		}
 		// Since we are possible exiting early, we need to make sure we set the result at the end of the function.

--- a/tests/lifecycle/suite.go
+++ b/tests/lifecycle/suite.go
@@ -180,7 +180,7 @@ func LoadChecks() {
 		}))
 
 	// Statefulset scaling test
-	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestStateFulSetScalingIdentifier)).
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestStatefulSetScalingIdentifier)).
 		WithSkipCheckFn(
 			testhelper.GetNotIntrusiveSkipFn(&env),
 			testhelper.GetNotEnoughWorkersSkipFn(&env, minWorkerNodesForLifecycle)).

--- a/tests/networking/netutil/netutil.go
+++ b/tests/networking/netutil/netutil.go
@@ -61,6 +61,7 @@ func parseListeningPorts(cmdOut string) (map[PortInfo]bool, error) {
 			return nil, fmt.Errorf("string to int conversion error, err: %v", err)
 		}
 		protocol := strings.ToUpper(fields[indexProtocol])
+		//nolint:gosec
 		portInfo := PortInfo{int32(port), protocol}
 
 		portSet[portInfo] = true

--- a/tests/platform/hugepages/hugepages.go
+++ b/tests/platform/hugepages/hugepages.go
@@ -290,6 +290,7 @@ func logMcKernelArgumentsHugepages(hugepagesPerSize map[int]int, defhugepagesz i
 	for size, count := range hugepagesPerSize {
 		sb.WriteString(fmt.Sprintf(", size=%dkB - count=%d", size, count))
 	}
+	//nolint:govet
 	log.Info(sb.String())
 }
 

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -224,6 +224,7 @@ func runHandler(w http.ResponseWriter, r *http.Request) {
 	log.SetLogger(log.GetMultiLogger(buf))
 
 	jsonData := r.FormValue("jsonData") // "jsonData" is the name of the JSON input field
+	//nolint:govet
 	log.Info(jsonData)
 	var data RequestedData
 	if err := json.Unmarshal([]byte(jsonData), &data); err != nil {


### PR DESCRIPTION
Looks like there was an update to the linter which is now flagging things previously unflagged.

This seems to mostly target integer conversions which have been unflagged in the past.