### PR TITLE
Gather service accounts in claim file

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -244,9 +244,6 @@ jobs:
           path: |
             certsuite-out/*.tar.gz
 
-      - name: Remove tarball(s) to save disk space.
-        run: rm -f certsuite-out/*.tar.gz
-
       - name: Check the smoke test results against the expected results template
         run: ./certsuite check results --log-file="certsuite-out/certsuite.log"
 

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -80,6 +80,8 @@ type DiscoveredTestData struct {
 	RoleBindings           []rbacv1.RoleBinding // Contains all rolebindings from all namespaces
 	Roles                  []rbacv1.Role        // Contains all roles from all namespaces
 	Services               []*corev1.Service
+	ServiceAccounts        []*corev1.ServiceAccount
+	AllServiceAccounts     []*corev1.ServiceAccount
 	Hpas                   []*scalingv1.HorizontalPodAutoscaler
 	Subscriptions          []olmv1Alpha.Subscription
 	AllSubscriptions       []olmv1Alpha.Subscription
@@ -250,7 +252,14 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	if err != nil {
 		log.Fatal("Cannot get list of services, err: %v", err)
 	}
-
+	data.ServiceAccounts, err = getServiceAccounts(oc.K8sClient.CoreV1(), data.Namespaces)
+	if err != nil {
+		log.Fatal("Cannot get list of service accounts under test, err: %v", err)
+	}
+	data.AllServiceAccounts, err = getServiceAccounts(oc.K8sClient.CoreV1(), []string{metav1.NamespaceAll})
+	if err != nil {
+		log.Fatal("Cannot get list of all service accounts, err: %v", err)
+	}
 	data.ExecutedBy = config.ExecutedBy
 	data.PartnerName = config.PartnerName
 	data.CollectorAppPassword = config.CollectorAppPassword

--- a/pkg/autodiscover/autodiscover_service_accounts.go
+++ b/pkg/autodiscover/autodiscover_service_accounts.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2022-2023 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+package autodiscover
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+func getServiceAccounts(oc corev1client.CoreV1Interface, namespaces []string) (servicesAccounts []*corev1.ServiceAccount, err error) {
+	for _, ns := range namespaces {
+		s, err := oc.ServiceAccounts(ns).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return servicesAccounts, err
+		}
+		for i := range s.Items {
+			servicesAccounts = append(servicesAccounts, &s.Items[i])
+		}
+	}
+	return servicesAccounts, nil
+}

--- a/pkg/autodiscover/autodiscover_service_accounts.go
+++ b/pkg/autodiscover/autodiscover_service_accounts.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 Red Hat, Inc.
+// Copyright (C) 2022-2024 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_services_accounts_test.go
+++ b/pkg/autodiscover/autodiscover_services_accounts_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2023 Red Hat, Inc.
+// Copyright (C) 2020-2024 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_services_accounts_test.go
+++ b/pkg/autodiscover/autodiscover_services_accounts_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2020-2023 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+package autodiscover
+
+import (
+	"testing"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestGetServiceAccounts(t *testing.T) {
+	generateServiceAccount := func(name, namespace string) *corev1.ServiceAccount {
+		return &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	}
+
+	testCases := []struct {
+		serviceAccountName      string
+		serviceAccountNamespace string
+		expectedServiceAccounts []*corev1.ServiceAccount
+	}{
+		{
+			serviceAccountName:      "testServiceAccount",
+			serviceAccountNamespace: "tnf",
+			expectedServiceAccounts: []*corev1.ServiceAccount{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testServiceAccount",
+						Namespace: "tnf",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		var testRuntimeObjects []runtime.Object
+		testRuntimeObjects = append(testRuntimeObjects, generateServiceAccount(tc.serviceAccountName, tc.serviceAccountNamespace))
+		oc := clientsholder.GetTestClientsHolder(testRuntimeObjects)
+		services, err := getServiceAccounts(oc.K8sClient.CoreV1(), []string{tc.serviceAccountNamespace})
+		assert.Nil(t, err)
+		assert.Equal(t, tc.expectedServiceAccounts, services)
+	}
+}

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -730,7 +730,7 @@ func testAutomountServiceToken(check *checksdb.Check, env *provider.TestEnvironm
 
 		// Evaluate the pod's automount service tokens and any attached service accounts
 		client := clientsholder.GetClientsHolder()
-		podPassed, newMsg := rbac.EvaluateAutomountTokens(client.K8sClient.CoreV1(), put.Pod)
+		podPassed, newMsg := rbac.EvaluateAutomountTokens(client.K8sClient.CoreV1(), put)
 		if !podPassed {
 			//nolint:govet
 			check.LogError(newMsg)

--- a/tests/common/rbac/automount.go
+++ b/tests/common/rbac/automount.go
@@ -45,7 +45,7 @@ func EvaluateAutomountTokens(client corev1typed.CoreV1Interface, put *provider.P
 	// Collect information about the service account attached to the pod.
 	saAutomountServiceAccountToken, err := put.IsAutomountServiceAccountSetOnSA()
 	if err != nil {
-		return false, ""
+		return false, err.Error()
 	}
 
 	// The pod token is false means the pod is configured properly

--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -428,7 +428,7 @@ func testOperatorPodsAutomountTokens(check *checksdb.Check, env *provider.TestEn
 			check.LogInfo("Testing Pod %q in namespace %q", pod.Name, pod.Namespace)
 			// Evaluate the pod's automount service tokens and any attached service accounts
 			client := clientsholder.GetClientsHolder()
-			podPassed, newMsg := rbac.EvaluateAutomountTokens(client.K8sClient.CoreV1(), pod.Pod)
+			podPassed, newMsg := rbac.EvaluateAutomountTokens(client.K8sClient.CoreV1(), pod)
 			if !podPassed {
 				check.LogInfo("Pod %q in namespace %q has automount service account token set to false", pod.Name, pod.Namespace)
 				compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(pod.Namespace, pod.Name, "Pod has automount service account token set to false", true))


### PR DESCRIPTION
Refactoring to collect service accounts in autodiscover package and save them to claim file
- All service accounts are collected during discovery in AllServiceAccounts slice
- The AllServiceAccountsMap is mapping service account namespace + service account name to the service account objects for conveniently searching service accounts
- The AllServiceAccountsMap is part of the provide.Pod object. This allows for unit testing and easy access of the service account information in IsAutomountServiceAccountSetOnSA
- IsAutomountServiceAccountSetOnSA queries the Automount service account token from the pod object
- AllServiceAccounts and testServiceAccount are saved in the claim file

TODO:  
- ~system tests~
- doc