### PR TITLE
Update golangci settings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,13 +24,11 @@ linters-settings:
         # do not include the "operation" and "assign"
         checks: argument,case,condition,return
   govet:
-    settings:
-      printf:
-        funcs:
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Infof
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Warnf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Errorf
-          - (github.com/golangci/golangci-lint/pkg/logutils.Log).Fatalf
+    disable:
+      - printf
+  gosec:
+    excludes: 
+      - G115
   lll:
     line-length: 250
   maligned:
@@ -92,7 +90,6 @@ linters:
   # - prealloc
   # - revive
   # - copyloopvar
-  # - structcheck
   # - testpackage
   # - wsl
 issues:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -63,7 +63,6 @@ func PrintBanner() {
 type cliCheckLogSniffer struct{}
 
 func isTTY() bool {
-	//nolint:gosec
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
@@ -95,7 +94,6 @@ func updateRunningCheckLine(checkName string, stopChan <-chan bool) {
 }
 
 func getTerminalWidth() int {
-	//nolint:gosec
 	width, _, _ := term.GetSize(int(os.Stdin.Fd()))
 	return width
 }

--- a/internal/clientsholder/command.go
+++ b/internal/clientsholder/command.go
@@ -39,7 +39,7 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 	commandStr := []string{"sh", "-c", command}
 	var buffOut bytes.Buffer
 	var buffErr bytes.Buffer
-	//nolint:govet
+
 	log.Debug(fmt.Sprintf("execute command on ns=%s, pod=%s container=%s, cmd: %s", ctx.GetNamespace(), ctx.GetPodName(), ctx.GetContainerName(), strings.Join(commandStr, " ")))
 	req := clientsholder.K8sClient.CoreV1().RESTClient().
 		Post().

--- a/internal/results/archiver.go
+++ b/internal/results/archiver.go
@@ -19,7 +19,6 @@ const (
 )
 
 func generateZipFileName() string {
-	//nolint:govet
 	return fmt.Sprintf(time.Now().Format(tarGzFileNamePrefixLayout) + "-" + tarGzFileNameSuffix)
 }
 

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -80,11 +80,9 @@ func (c *Container) GetUID() (string, error) {
 		uid = split[len(split)-1]
 	}
 	if uid == "" {
-		//nolint:govet
 		log.Debug(fmt.Sprintf("could not find uid of %s/%s/%s\n", c.Namespace, c.Podname, c.Name))
 		return "", errors.New("cannot determine container UID")
 	}
-	//nolint:govet
 	log.Debug(fmt.Sprintf("uid of %s/%s/%s=%s\n", c.Namespace, c.Podname, c.Name, uid))
 	return uid, nil
 }
@@ -138,7 +136,6 @@ func (c *Container) SetPreflightResults(preflightImageCache map[string]Preflight
 	}
 
 	// Take all of the Preflight logs and stick them into our log.
-	//nolint:govet
 	log.Info(logbytes.String())
 
 	// Store the Preflight test results into the container's PreflightResults var and into the cache.

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -114,7 +114,6 @@ func (op *Operator) SetPreflightResults(env *TestEnvironment) error {
 	}
 
 	// Take all of the preflight logs and stick them into our log.
-	//nolint:govet
 	log.Info(logbytes.String())
 
 	e := os.RemoveAll("artifacts/")

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -732,7 +732,6 @@ func testAutomountServiceToken(check *checksdb.Check, env *provider.TestEnvironm
 		client := clientsholder.GetClientsHolder()
 		podPassed, newMsg := rbac.EvaluateAutomountTokens(client.K8sClient.CoreV1(), put)
 		if !podPassed {
-			//nolint:govet
 			check.LogError(newMsg)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, newMsg, false))
 		} else {
@@ -916,7 +915,6 @@ func testNoSSHDaemonsAllowed(check *checksdb.Check, env *provider.TestEnvironmen
 		}
 
 		// 2. Check if SSH port is listening
-		//nolint:gosec
 		sshPortInfo := netutil.PortInfo{PortNumber: int32(sshServicePortNumber), Protocol: sshServicePortProtocol}
 		listeningPorts, err := netutil.GetListeningPorts(cut)
 		if err != nil {

--- a/tests/lifecycle/scaling/deployment_scaling_test.go
+++ b/tests/lifecycle/scaling/deployment_scaling_test.go
@@ -75,7 +75,6 @@ func TestScaleDeploymentFunc(t *testing.T) {
 	for _, tc := range testCases {
 		var runtimeObjects []runtime.Object
 		intVar := new(int32)
-		//nolint:gosec
 		*intVar = int32(tc.replicaCount)
 		tempDP := generateDeployment(tc.deploymentName, intVar)
 		runtimeObjects = append(runtimeObjects, tempDP)
@@ -89,7 +88,6 @@ func TestScaleDeploymentFunc(t *testing.T) {
 		// Get the deployment from the fake API
 		dp, err := c.K8sClient.AppsV1().Deployments("namespace1").Get(context.TODO(), tc.deploymentName, metav1.GetOptions{})
 		assert.Nil(t, err)
-		//nolint:gosec
 		assert.Equal(t, int32(tc.replicaCount), *dp.Spec.Replicas)
 	}
 }
@@ -144,7 +142,6 @@ func TestScaleHpaDeploymentFunc(t *testing.T) {
 
 	for _, tc := range testCases {
 		intVar := new(int32)
-		//nolint:gosec
 		*intVar = int32(tc.replicaCount)
 		tempDP := generateDeployment(tc.deploymentName, intVar)
 
@@ -187,7 +184,6 @@ func TestScaleHpaDeploymentFunc(t *testing.T) {
 		// Get the deployment from the fake API
 		hpa, err := c.AutoscalingV1().HorizontalPodAutoscalers("namespace1").Get(context.TODO(), "hpaName", metav1.GetOptions{})
 		assert.Nil(t, err)
-		//nolint:gosec
 		assert.Equal(t, int32(tc.expectedReplicaCount), hpa.Spec.MaxReplicas)
 	}
 }

--- a/tests/lifecycle/suite.go
+++ b/tests/lifecycle/suite.go
@@ -582,7 +582,6 @@ func testPodsRecreation(check *checksdb.Check, env *provider.TestEnvironment) { 
 	needsPostMortemInfo := true
 	defer func() {
 		if needsPostMortemInfo {
-			//nolint:govet
 			check.LogDebug(postmortem.Log())
 		}
 		// Since we are possible exiting early, we need to make sure we set the result at the end of the function.

--- a/tests/networking/netutil/netutil.go
+++ b/tests/networking/netutil/netutil.go
@@ -61,7 +61,6 @@ func parseListeningPorts(cmdOut string) (map[PortInfo]bool, error) {
 			return nil, fmt.Errorf("string to int conversion error, err: %v", err)
 		}
 		protocol := strings.ToUpper(fields[indexProtocol])
-		//nolint:gosec
 		portInfo := PortInfo{int32(port), protocol}
 
 		portSet[portInfo] = true

--- a/tests/platform/hugepages/hugepages.go
+++ b/tests/platform/hugepages/hugepages.go
@@ -290,7 +290,6 @@ func logMcKernelArgumentsHugepages(hugepagesPerSize map[int]int, defhugepagesz i
 	for size, count := range hugepagesPerSize {
 		sb.WriteString(fmt.Sprintf(", size=%dkB - count=%d", size, count))
 	}
-	//nolint:govet
 	log.Info(sb.String())
 }
 

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -224,7 +224,6 @@ func runHandler(w http.ResponseWriter, r *http.Request) {
 	log.SetLogger(log.GetMultiLogger(buf))
 
 	jsonData := r.FormValue("jsonData") // "jsonData" is the name of the JSON input field
-	//nolint:govet
 	log.Info(jsonData)
 	var data RequestedData
 	if err := json.Unmarshal([]byte(jsonData), &data); err != nil {


### PR DESCRIPTION
- Excludes `G115` from the `gosec` linter.
- Disables `printf` linting under `govet`.