### PR TITLE
Avoid failing workflow when collectors sanity check fails

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -399,8 +399,8 @@ jobs:
         if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
         uses: ./.github/actions/slack-webhook-sender
         with:
-          message: 'Collector sanity check has failed'
           slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
+          message: 'Collector sanity check has failed'
 
       - name: Upload container test results as an artifact
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -399,8 +399,8 @@ jobs:
         if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
         uses: ./.github/actions/slack-webhook-sender
         with:
-          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
           message: 'Collector sanity check has failed'
+          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
 
       - name: Upload container test results as an artifact
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -387,6 +387,7 @@ jobs:
             --label-filter="${SMOKE_TESTS_LABELS_FILTER}"
 
       - name: Run sanity check on collector
+        id: collector_sanity_check
         uses: ./collector/.github/actions/run-sanity-check
         with:
           working_directory: collector
@@ -395,7 +396,7 @@ jobs:
         continue-on-error: true
 
       - name: Send chat msg to dev team if collector's sanity check failed.
-        if: ${{ failure() }}
+        if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
         uses: ./.github/actions/slack-webhook-sender
         with:
           message: "Collector's sanity check has failed"

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -392,6 +392,14 @@ jobs:
           working_directory: collector
           collector_username: ${COLLECTOR_CIUSER}
           collector_password: ${COLLECTOR_CIPASSWORD}
+        continue-on-error: true
+
+      - name: Send chat msg to dev team if collector's sanity check failed.
+        if: ${{ failure() }}
+        uses: ./.github/actions/slack-webhook-sender
+        with:
+          message: "Collector's sanity check has failed"
+          slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
 
       - name: Upload container test results as an artifact
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -399,7 +399,7 @@ jobs:
         if: ${{ steps.collector_sanity_check.outcome == 'failure' }}
         uses: ./.github/actions/slack-webhook-sender
         with:
-          message: "Collector's sanity check has failed"
+          message: 'Collector sanity check has failed'
           slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
 
       - name: Upload container test results as an artifact


### PR DESCRIPTION
This PR avoids failing `pre-main` workflow when collector's sanity check fails - instead it will only send a warning message to the our slack channel.