### PR TITLE
Remove bad ref to QE repo in ARM runs

### DIFF
--- a/.github/workflows/qe-ocp-arm-416.yaml
+++ b/.github/workflows/qe-ocp-arm-416.yaml
@@ -91,7 +91,7 @@ jobs:
         with:
           repository: ${{ env.QE_REPO }}
           path: certsuite-qe
-          ref: limit_procs
+          ref: main
 
       - name: Preemptively potential QE namespaces
         run: ./scripts/delete-namespaces.sh


### PR DESCRIPTION
This job should be checking out `main` instead of `limit_procs`.