### PR TITLE
Update probe image to v0.0.8

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -19,7 +19,7 @@ env:
   OCT_IMAGE_NAME: redhat-best-practices-for-k8s/oct
   OCT_IMAGE_TAG: latest
   PROBE_IMAGE_NAME: redhat-best-practices-for-k8s/certsuite-probe
-  PROBE_IMAGE_TAG: v0.0.7
+  PROBE_IMAGE_TAG: v0.0.8
   CERTSUITE_CONFIG_DIR: /tmp/certsuite/config
   CERTSUITE_OUTPUT_DIR: /tmp/certsuite/output
   SMOKE_TESTS_LOG_LEVEL: debug

--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -39,7 +39,7 @@ func NewCommand() *cobra.Command {
 	runCmd.PersistentFlags().Bool("include-web-files", false, "Save web files in the configured output folder")
 	runCmd.PersistentFlags().Bool("enable-data-collection", false, "Allow sending test results to an external data collector")
 	runCmd.PersistentFlags().Bool("create-xml-junit-file", false, "Create a JUnit file with the test results")
-	runCmd.PersistentFlags().String("certsuite-probe-image", "quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.7", "Certsuite probe image")
+	runCmd.PersistentFlags().String("certsuite-probe-image", "quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.8", "Certsuite probe image")
 	runCmd.PersistentFlags().String("daemonset-cpu-req", "100m", "CPU request for the probe daemonset container")
 	runCmd.PersistentFlags().String("daemonset-cpu-lim", "100m", "CPU limit for the probe daemonset container")
 	runCmd.PersistentFlags().String("daemonset-mem-req", "100M", "Memory request for the probe daemonset container")

--- a/docs/runtime-env.md
+++ b/docs/runtime-env.md
@@ -63,4 +63,4 @@ See more about this variable [here](https://github.com/redhat-openshift-ecosyste
 against a private container registry that has self-signed certificates.
 
 Note that you can also specify the probe pod image to use with `SUPPORT_IMAGE`
-environment variable, default to `certsuite-probe:v0.0.7`.
+environment variable, default to `certsuite-probe:v0.0.8`.

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "debugTag": "v0.0.7",
+  "debugTag": "v0.0.8",
   "claimFormat": "v0.5.0",
   "parserTag": "v0.5.0"
 }


### PR DESCRIPTION
https://github.com/redhat-best-practices-for-k8s/certsuite-probe/releases/tag/v0.0.8