### PR TITLE
Remove logrus as direct dependency

### DIFF
--- a/cmd/certsuite/generate/catalog/catalog.go
+++ b/cmd/certsuite/generate/catalog/catalog.go
@@ -27,7 +27,6 @@ import (
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
 	plibContainer "github.com/redhat-openshift-ecosystem/openshift-preflight/container"
 	plibOperator "github.com/redhat-openshift-ecosystem/openshift-preflight/operator"
-	"github.com/sirupsen/logrus"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite-claim/pkg/claim"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
@@ -138,7 +137,7 @@ func addPreflightTestsToCatalog() {
 	// Create artifacts handler
 	artifactsWriter, err := artifacts.NewMapWriter()
 	if err != nil {
-		logrus.Errorf("error creating artifact, failed to add preflight tests to catalog")
+		log.Error("error creating artifact, failed to add preflight tests to catalog")
 		return
 	}
 	ctx := artifacts.ContextWithWriter(context.TODO(), artifactsWriter)
@@ -148,11 +147,11 @@ func addPreflightTestsToCatalog() {
 	checkContainer := plibContainer.NewCheck(dummy, optsContainer...)
 	_, checksOperator, err := checkOperator.List(ctx)
 	if err != nil {
-		logrus.Errorf("error getting preflight operator tests.")
+		log.Error("error getting preflight operator tests.")
 	}
 	_, checksContainer, err := checkContainer.List(ctx)
 	if err != nil {
-		logrus.Errorf("error getting preflight container tests.")
+		log.Error("error getting preflight container tests.")
 	}
 
 	allChecks := checksOperator

--- a/cmd/certsuite/generate/catalog/catalog.go
+++ b/cmd/certsuite/generate/catalog/catalog.go
@@ -137,7 +137,7 @@ func addPreflightTestsToCatalog() {
 	// Create artifacts handler
 	artifactsWriter, err := artifacts.NewMapWriter()
 	if err != nil {
-		log.Error("error creating artifact, failed to add preflight tests to catalog")
+		log.Error("Error creating artifact, failed to add preflight tests to catalog: %v", err)
 		return
 	}
 	ctx := artifacts.ContextWithWriter(context.TODO(), artifactsWriter)
@@ -147,11 +147,11 @@ func addPreflightTestsToCatalog() {
 	checkContainer := plibContainer.NewCheck(dummy, optsContainer...)
 	_, checksOperator, err := checkOperator.List(ctx)
 	if err != nil {
-		log.Error("error getting preflight operator tests.")
+		log.Error("Error getting preflight operator tests: %v", err)
 	}
 	_, checksContainer, err := checkContainer.List(ctx)
 	if err != nil {
-		log.Error("error getting preflight container tests.")
+		log.Error("Error getting preflight container tests: %v", err)
 	}
 
 	allChecks := checksOperator

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.1
 require (
 	github.com/Masterminds/semver/v3 v3.3.0
 	github.com/redhat-best-practices-for-k8s/certsuite-claim v1.0.48
-	github.com/sirupsen/logrus v1.9.3
+	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/pkg/claimhelper/claimhelper.go
+++ b/pkg/claimhelper/claimhelper.go
@@ -281,7 +281,7 @@ func MarshalConfigurations() (configurations []byte, err error) {
 	config := provider.GetTestEnvironment()
 	configurations, err = j.Marshal(config)
 	if err != nil {
-		log.Error("error converting configurations to JSON: %v", err)
+		log.Error("Error converting configurations to JSON: %v", err)
 		return configurations, err
 	}
 	return configurations, nil

--- a/tests/accesscontrol/namespace/namespace.go
+++ b/tests/accesscontrol/namespace/namespace.go
@@ -70,7 +70,7 @@ func getCrsPerNamespaces(aCrd *apiextv1.CustomResourceDefinition) (crdNamespaces
 		log.Debug("Looking for CRs from CRD: %s api version:%s group:%s plural:%s", aCrd.Name, version.Name, aCrd.Spec.Group, aCrd.Spec.Names.Plural)
 		crs, err := oc.DynamicClient.Resource(gvr).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			log.Error("error getting %s: %v\n", aCrd.Name, err)
+			log.Error("Error getting %s: %v\n", aCrd.Name, err)
 			return crdNamespaces, err
 		}
 		crdNamespaces = make(map[string][]string)

--- a/tests/lifecycle/podrecreation/podrecreation.go
+++ b/tests/lifecycle/podrecreation/podrecreation.go
@@ -90,7 +90,7 @@ func CountPodsWithDelete(pods []*provider.Pod, nodeName, mode string) (count int
 			}
 			err := deletePod(put.Pod, mode, &wg)
 			if err != nil {
-				log.Error("error deleting %s", put)
+				log.Error("Error deleting %s", put)
 			}
 		}
 	}
@@ -124,7 +124,7 @@ func deletePod(pod *corev1.Pod, mode string, wg *sync.WaitGroup) error {
 		GracePeriodSeconds: &gracePeriodSeconds,
 	})
 	if err != nil {
-		log.Error("error deleting %s err: %v", pod.String(), err)
+		log.Error("Error deleting %s err: %v", pod.String(), err)
 		return err
 	}
 	if mode == DeleteBackground {

--- a/tests/platform/isredhat/isredhat.go
+++ b/tests/platform/isredhat/isredhat.go
@@ -74,7 +74,7 @@ func (b *BaseImageInfo) runCommand(cmd string) (string, error) {
 		return "", err
 	}
 	if outerr != "" {
-		log.Error("error when running baseimage command, err: %v", outerr)
+		log.Error("Error when running baseimage command, err: %v", outerr)
 		return "", errors.New(outerr)
 	}
 	return output, nil

--- a/tests/platform/nodetainted/nodetainted.go
+++ b/tests/platform/nodetainted/nodetainted.go
@@ -41,7 +41,7 @@ var runCommand = func(ctx *clientsholder.Context, cmd string) (string, error) {
 		return "", err
 	}
 	if outerr != "" {
-		log.Error("error when running nodetainted command err=%v", outerr)
+		log.Error("Error when running nodetainted command err=%v", outerr)
 		return "", errors.New(outerr)
 	}
 	return output, nil


### PR DESCRIPTION
I noticed that we were only using `logrus` as a direct dependency in 3 lines.  By switching these lines over to the `log` package we can remove logrus as a direct dependency.