### PR TITLE
Restrict OCP self-hosted PR runners

### DIFF
--- a/.github/workflows/qe-ocp-arm-416.yaml
+++ b/.github/workflows/qe-ocp-arm-416.yaml
@@ -23,6 +23,7 @@ env:
 
 jobs:
   build-arm-image-for-qe:
+    if: github.event.pull_request.user.login!='dependabot[bot]'
     runs-on: qe-ocp-arm1
     steps:
       - name: Check out code
@@ -52,7 +53,7 @@ jobs:
   qe-ocp-arm-testing:
     runs-on: qe-ocp-arm1
     needs: build-arm-image-for-qe
-    if: needs.build-arm-image-for-qe.result == 'success'
+    if: needs.build-arm-image-for-qe.result == 'success' && github.event.pull_request.user.login!='dependabot[bot]'
     strategy:
       fail-fast: false
       matrix: 

--- a/.github/workflows/qe-ocp-pre-main.yaml
+++ b/.github/workflows/qe-ocp-pre-main.yaml
@@ -21,6 +21,7 @@ jobs:
   # Build the image used for testing first, then pass the reference to the QE tests.
   # This saves time and resources by not building the image in each QE suite.
   build-image-for-qe:
+    if: github.event.pull_request.user.login!='dependabot[bot]'
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
@@ -49,7 +50,7 @@ jobs:
   qe-ocp-testing:
     runs-on: qe-ocp-416
     needs: build-image-for-qe
-    if: needs.build-image-for-qe.result == 'success'
+    if: needs.build-image-for-qe.result == 'success' && github.event.pull_request.user.login!='dependabot[bot]'
     strategy:
       fail-fast: false
       matrix: 


### PR DESCRIPTION
No need to run these jobs on the OCP self-hosted runners if the author is dependabot.