### PR TITLE
Make necessary results spreadsheet functions public 

### DIFF
--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -148,7 +148,7 @@ func createSingleWorkloadRawResultsSheet(rawResultsSheet *sheets.Sheet, workload
 	filteredRows[0].Values = append(filteredRows[0].Values, rawResultsSheet.Data[0].RowData[0].Values...)
 
 	headers := getHeadersFromSheet(rawResultsSheet)
-	indices, err := getHeaderIndicesByColumnNames(headers, []string{"CNFName"})
+	indices, err := GetHeaderIndicesByColumnNames(headers, []string{"CNFName"})
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +222,7 @@ func createConclusionsSheet(sheetsService *sheets.Service, driveService *drive.S
 	}
 
 	rawSheetHeaders := getHeadersFromSheet(rawResultsSheet)
-	colsIndices, err := getHeaderIndicesByColumnNames(rawSheetHeaders, []string{workloadNameRawResultsCol, workloadTypeRawResultsCol, operatorVersionRawResultsCol})
+	colsIndices, err := GetHeaderIndicesByColumnNames(rawSheetHeaders, []string{workloadNameRawResultsCol, workloadTypeRawResultsCol, operatorVersionRawResultsCol})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -73,7 +73,7 @@ func readCSV(fp string) ([][]string, error) {
 	return records, nil
 }
 
-func createSheetsAndDriveServices() (sheetService *sheets.Service, driveService *drive.Service, err error) {
+func CreateSheetsAndDriveServices() (sheetService *sheets.Service, driveService *drive.Service, err error) {
 	ctx := context.Background()
 	b, err := os.ReadFile(credentials)
 	if err != nil {
@@ -321,7 +321,7 @@ func createRawResultsSheet(fp string) (*sheets.Sheet, error) {
 }
 
 func generateResultsSpreadSheet() {
-	sheetService, driveService, err := createSheetsAndDriveServices()
+	sheetService, driveService, err := CreateSheetsAndDriveServices()
 	if err != nil {
 		log.Fatalf("Unable to create services: %v", err)
 	}

--- a/cmd/certsuite/upload/results_spreadsheet/sheet_utils.go
+++ b/cmd/certsuite/upload/results_spreadsheet/sheet_utils.go
@@ -14,7 +14,7 @@ func getHeadersFromSheet(sheet *sheets.Sheet) []string {
 	return headers
 }
 
-func getHeadersFromValueRange(sheetsValues *sheets.ValueRange) []string {
+func GetHeadersFromValueRange(sheetsValues *sheets.ValueRange) []string {
 	headers := []string{}
 	for _, val := range sheetsValues.Values[0] {
 		headers = append(headers, fmt.Sprint(val))
@@ -22,7 +22,7 @@ func getHeadersFromValueRange(sheetsValues *sheets.ValueRange) []string {
 	return headers
 }
 
-func getHeaderIndicesByColumnNames(headers, names []string) ([]int, error) {
+func GetHeaderIndicesByColumnNames(headers, names []string) ([]int, error) {
 	indices := []int{}
 	for _, name := range names {
 		found := false
@@ -40,7 +40,7 @@ func getHeaderIndicesByColumnNames(headers, names []string) ([]int, error) {
 	return indices, nil
 }
 
-func getSheetIDByName(spreadsheet *sheets.Spreadsheet, name string) (int64, error) {
+func GetSheetIDByName(spreadsheet *sheets.Spreadsheet, name string) (int64, error) {
 	for _, sheet := range spreadsheet.Sheets {
 		if sheet.Properties.Title == name {
 			return sheet.Properties.SheetId, nil
@@ -75,13 +75,13 @@ func addDescendingSortFilterToSheet(srv *sheets.Service, spreadsheet *sheets.Spr
 	if err != nil {
 		return fmt.Errorf("unable to retrieve sheet %s values: %v", sheetName, err)
 	}
-	headers := getHeadersFromValueRange(sheetsValues)
-	indices, err := getHeaderIndicesByColumnNames(headers, []string{colName})
+	headers := GetHeadersFromValueRange(sheetsValues)
+	indices, err := GetHeaderIndicesByColumnNames(headers, []string{colName})
 	if err != nil {
 		return nil
 	}
 
-	sheetID, err := getSheetIDByName(spreadsheet, sheetName)
+	sheetID, err := GetSheetIDByName(spreadsheet, sheetName)
 	if err != nil {
 		return fmt.Errorf("unable to retrieve sheet %s id: %v", sheetName, err)
 	}
@@ -117,8 +117,8 @@ func addFilterByFailedAndMandatoryToSheet(srv *sheets.Service, spreadsheet *shee
 	if err != nil {
 		return fmt.Errorf("unable to retrieve sheet %s values: %v", sheetName, err)
 	}
-	headers := getHeadersFromValueRange(sheetsValues)
-	indices, err := getHeaderIndicesByColumnNames(headers, []string{"State", "Mandatory/Optional"})
+	headers := GetHeadersFromValueRange(sheetsValues)
+	indices, err := GetHeaderIndicesByColumnNames(headers, []string{"State", "Mandatory/Optional"})
 	if err != nil {
 		return nil
 	}
@@ -126,7 +126,7 @@ func addFilterByFailedAndMandatoryToSheet(srv *sheets.Service, spreadsheet *shee
 	stateColIndex := indices[0]
 	isMandatoryColIndex := indices[1]
 
-	sheetID, err := getSheetIDByName(spreadsheet, sheetName)
+	sheetID, err := GetSheetIDByName(spreadsheet, sheetName)
 	if err != nil {
 		return fmt.Errorf("unable to retrieve sheet %s id: %v", sheetName, err)
 	}


### PR DESCRIPTION
In order to allow the use of some functions that are used in certsuite sub command `upload results-spreadsheet` creation  in the "operator-results-spreadsheet" repo (that extends the use of the existing spreadsheet), this PR makes those functions public.