### PR TITLE
Add Setter and Getter functions to results spreadsheet google creds

### DIFF
--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -58,6 +58,14 @@ func NewCommand() *cobra.Command {
 	return uploadResultSpreadSheetCmd
 }
 
+func SetCredentials(credenitalsPath string) {
+	credentials = credenitalsPath
+}
+
+func GetCredentials() string {
+	return credentials
+}
+
 func readCSV(fp string) ([][]string, error) {
 	file, err := os.Open(fp)
 	if err != nil {

--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -58,14 +58,6 @@ func NewCommand() *cobra.Command {
 	return uploadResultSpreadSheetCmd
 }
 
-func SetCredentials(credentialsPath string) {
-	credentials = credentialsPath
-}
-
-func GetCredentials() string {
-	return credentials
-}
-
 func readCSV(fp string) ([][]string, error) {
 	file, err := os.Open(fp)
 	if err != nil {
@@ -81,7 +73,7 @@ func readCSV(fp string) ([][]string, error) {
 	return records, nil
 }
 
-func CreateSheetsAndDriveServices() (sheetService *sheets.Service, driveService *drive.Service, err error) {
+func CreateSheetsAndDriveServices(credentials string) (sheetService *sheets.Service, driveService *drive.Service, err error) {
 	ctx := context.Background()
 	b, err := os.ReadFile(credentials)
 	if err != nil {
@@ -329,7 +321,7 @@ func createRawResultsSheet(fp string) (*sheets.Sheet, error) {
 }
 
 func generateResultsSpreadSheet() {
-	sheetService, driveService, err := CreateSheetsAndDriveServices()
+	sheetService, driveService, err := CreateSheetsAndDriveServices(credentials)
 	if err != nil {
 		log.Fatalf("Unable to create services: %v", err)
 	}

--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -58,8 +58,8 @@ func NewCommand() *cobra.Command {
 	return uploadResultSpreadSheetCmd
 }
 
-func SetCredentials(credenitalsPath string) {
-	credentials = credenitalsPath
+func SetCredentials(credentialsPath string) {
+	credentials = credentialsPath
 }
 
 func GetCredentials() string {


### PR DESCRIPTION
This PR adds `credentials` as an argument of  `CreateSheetsAndDriveServices` func  in order to allow the use of it independently from using `upload results-spreadsheet` sub-command.
In current state, the credentials are sent using a flag to the mentioned sub command, which limits functions using this variable to run using the sub-command only.
In the `operator-results-spreadsheet` repo, we would like to allow the use of `CreateSheetsAndDriveServices` func (which uses the `credentials` variable) in order to add more columns to an existing sheet, and for that we need the credentials to be set manually.