### PR TITLE
Fixes for certsuite claim compare UTs.

### DIFF
--- a/cmd/certsuite/claim/compare/compare_test.go
+++ b/cmd/certsuite/claim/compare/compare_test.go
@@ -1,6 +1,13 @@
 package compare
 
-/*
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
 func Test_claimCompareFilesfunc(t *testing.T) {
 	testCases := []struct {
 		name               string
@@ -93,4 +100,3 @@ func Test_claimCompareFilesfunc(t *testing.T) {
 		})
 	}
 }
-*/

--- a/cmd/certsuite/claim/compare/testdata/claim_access_control.json
+++ b/cmd/certsuite/claim/compare/testdata/claim_access_control.json
@@ -28,7 +28,7 @@
         "checkDiscoveredContainerCertificationStatus": false,
         "collectorAppEndPoint": "http://localhost:8080",
         "collectorAppPassword": "test-password",
-        "probeDaemonSetNamespace": "custom-probepods-ns",
+        "probeDaemonSetNamespace": "different-probepods-ns",
         "executedBy": "default-executed-by",
         "managedDeployments": [
           {

--- a/cmd/certsuite/claim/compare/testdata/diff1.txt
+++ b/cmd/certsuite/claim/compare/testdata/diff1.txt
@@ -1,8 +1,8 @@
 VERSIONS: Differences
-FIELD             CLAIM 1                                      CLAIM 2
-/k8s              v1.26.4+c343423                              v1.26.3+b404935
-/ocp              4.13.1                                       4.13.0
+FIELD                   CLAIM 1                                      CLAIM 2
 /certSuiteGitCommit     1b968e53b79fd8e81e48b761c3efd7a808d4567e     20641f745f65aaba24d9f5105f6dee531f67fc37
+/k8s                    v1.26.4+c343423                              v1.26.3+b404935
+/ocp                    4.13.1                                       4.13.0
 
 VERSIONS: Only in CLAIM 1
 <none>
@@ -56,7 +56,7 @@ CONFIGURATIONS
 
 Cert Suite Configuration: Differences
 FIELD                        CLAIM 1                 CLAIM 2
-/probeDaemonSetNamespace     custom-probepods-ns     cnf-suite
+/probeDaemonSetNamespace     custom-probepods-ns     different-probepods-ns
 
 Cert Suite Configuration: Only in CLAIM 1
 <none>

--- a/cmd/certsuite/claim/compare/testdata/diff1_reverse.txt
+++ b/cmd/certsuite/claim/compare/testdata/diff1_reverse.txt
@@ -1,8 +1,8 @@
 VERSIONS: Differences
-FIELD             CLAIM 1                                      CLAIM 2
-/k8s              v1.26.3+b404935                              v1.26.4+c343423
-/ocp              4.13.0                                       4.13.1
+FIELD                   CLAIM 1                                      CLAIM 2
 /certSuiteGitCommit     20641f745f65aaba24d9f5105f6dee531f67fc37     1b968e53b79fd8e81e48b761c3efd7a808d4567e
+/k8s                    v1.26.3+b404935                              v1.26.4+c343423
+/ocp                    4.13.0                                       4.13.1
 
 VERSIONS: Only in CLAIM 1
 <none>
@@ -54,14 +54,14 @@ observability-termination-policy                            skipped   failed
 CONFIGURATIONS
 --------------
 
-CNF Cert Suite Configuration: Differences
-FIELD                        CLAIM 1       CLAIM 2
-/probeDaemonSetNamespace     cnf-suite     custom-probepods-ns
+Cert Suite Configuration: Differences
+FIELD                        CLAIM 1                    CLAIM 2
+/probeDaemonSetNamespace     different-probepods-ns     custom-probepods-ns
 
-CNF Cert Suite Configuration: Only in CLAIM 1
+Cert Suite Configuration: Only in CLAIM 1
 /targetNameSpaces/1=test-ns
 
-CNF Cert Suite Configuration: Only in CLAIM 2
+Cert Suite Configuration: Only in CLAIM 2
 <none>
 
 Cluster abnormal events count

--- a/cmd/certsuite/claim/compare/versions/versions_test.go
+++ b/cmd/certsuite/claim/compare/versions/versions_test.go
@@ -78,43 +78,43 @@ func TestCompare(t *testing.T) {
 					},
 				},
 			}},
-		}, /*
-			{
-				name: "non matching versions 2",
-				args: args{
-					claim1Versions: &officialClaimScheme.Versions{
-						ClaimFormat:        "1",
-						K8s:                "22AAA",
-						OcClient:           "333",
-						Ocp:                "4444",
-						CertSuite:          "55555",
-						CertSuiteGitCommit: "666666",
+		},
+		{
+			name: "non matching versions 2",
+			args: args{
+				claim1Versions: &officialClaimScheme.Versions{
+					ClaimFormat:        "1",
+					K8s:                "22AAA",
+					OcClient:           "333",
+					Ocp:                "4444",
+					CertSuite:          "55555",
+					CertSuiteGitCommit: "666666",
+				},
+				claim2Versions: &officialClaimScheme.Versions{
+					ClaimFormat:        "1",
+					K8s:                "22",
+					OcClient:           "333",
+					Ocp:                "4444",
+					CertSuite:          "55555BBBB",
+					CertSuiteGitCommit: "666666",
+				},
+			},
+			want: &DiffReport{Diffs: &diff.Diffs{
+				Name: "VERSIONS",
+				Fields: []diff.FieldDiff{
+					{
+						FieldPath:   "/certSuite",
+						Claim1Value: "55555",
+						Claim2Value: "55555BBBB",
 					},
-					claim2Versions: &officialClaimScheme.Versions{
-						ClaimFormat:        "1",
-						K8s:                "22",
-						OcClient:           "333",
-						Ocp:                "4444",
-						CertSuite:          "55555BBBB",
-						CertSuiteGitCommit: "666666",
+					{
+						FieldPath:   "/k8s",
+						Claim1Value: "22AAA",
+						Claim2Value: "22",
 					},
 				},
-				want: &DiffReport{Diffs: &diff.Diffs{
-					Name: "VERSIONS",
-					Fields: []diff.FieldDiff{
-						{
-							FieldPath:   "/k8s",
-							Claim1Value: "22AAA",
-							Claim2Value: "22",
-						},
-						{
-							FieldPath:   "/certSuite",
-							Claim1Value: "55555",
-							Claim2Value: "55555BBBB",
-						},
-					},
-				}},
-			},*/
+			}},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/certsuite/pkg/claim/claim.go
+++ b/cmd/certsuite/pkg/claim/claim.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	supportedClaimFormatVersion = "v0.4.0"
+	supportedClaimFormatVersion = "v0.5.0"
 )
 
 const (

--- a/cmd/certsuite/pkg/claim/claim_test.go
+++ b/cmd/certsuite/pkg/claim/claim_test.go
@@ -22,14 +22,14 @@ func TestIsClaimFormatVersionSupported(t *testing.T) {
 		},
 		{
 			claimFormatVersion: "v0.0.0",
-			expectedError:      "claim format version v0.0.0 is not supported. Supported version is v0.4.0",
+			expectedError:      "claim format version v0.0.0 is not supported. Supported version is v0.5.0",
 		},
 		{
 			claimFormatVersion: "v0.0.1",
-			expectedError:      "claim format version v0.0.1 is not supported. Supported version is v0.4.0",
+			expectedError:      "claim format version v0.0.1 is not supported. Supported version is v0.5.0",
 		},
 		{
-			claimFormatVersion: "v0.4.0",
+			claimFormatVersion: "v0.5.0",
 			expectedError:      "",
 		},
 	}


### PR DESCRIPTION
Some UTs were commented on commit 62f679d, so this commit uncomment and fixes them.

Also, supported claim schema has been switched to v0.5.0