### PR TITLE
Add Results spreadsheet constants and public functions

### DIFF
--- a/cmd/certsuite/upload/results_spreadsheet/const.go
+++ b/cmd/certsuite/upload/results_spreadsheet/const.go
@@ -1,18 +1,22 @@
 package resultsspreadsheet
 
 const (
-	ConclusionSheetName = "conclusions"
-	RawResultsSheetName = "raw results"
+	ConclusionSheetName            = "conclusions"
+	RawResultsSheetName            = "raw results"
+	SingleWorkloadResultsSheetName = "results"
 
 	categoryConclusionsCol        = "Category"
 	workloadVersionConclusionsCol = "Workload Version"
 	ocpVersionConclusionsCol      = "OCP Version"
 	WorkloadNameConclusionsCol    = "Workload Name"
-	resultsConclusionsCol         = "Results"
+	ResultsConclusionsCol         = "Results"
 
 	workloadNameRawResultsCol    = "CNFName"
 	workloadTypeRawResultsCol    = "CNFType"
 	operatorVersionRawResultsCol = "OperatorVersion"
+
+	nextStepAIIfFailSingleWorkloadSheetCol     = "Next Step AI If Fail"
+	conclusionIndividualSingleWorkloadSheetCol = "Owner/TechLead Conclusion"
 
 	cellContentLimit = 50000
 )

--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -18,7 +18,7 @@ import (
 )
 
 var stringToPointer = func(s string) *string { return &s }
-var conclusionSheetHeaders = []string{categoryConclusionsCol, workloadVersionConclusionsCol, ocpVersionConclusionsCol, WorkloadNameConclusionsCol, resultsConclusionsCol}
+var conclusionSheetHeaders = []string{categoryConclusionsCol, workloadVersionConclusionsCol, ocpVersionConclusionsCol, WorkloadNameConclusionsCol, ResultsConclusionsCol}
 
 var (
 	resultsFilePath string
@@ -140,14 +140,14 @@ func prepareRecordsForSpreadSheet(records [][]string) []*sheets.RowData {
 func createSingleWorkloadRawResultsSheet(rawResultsSheet *sheets.Sheet, workloadName string) (*sheets.Sheet, error) {
 	// Initialize sheet with the two new column headers only.
 	filteredRows := []*sheets.RowData{{Values: []*sheets.CellData{
-		{UserEnteredValue: &sheets.ExtendedValue{StringValue: stringToPointer("Owner/TechLead Conclusion")}},
-		{UserEnteredValue: &sheets.ExtendedValue{StringValue: stringToPointer("Next Step Actions")}},
+		{UserEnteredValue: &sheets.ExtendedValue{StringValue: stringToPointer(conclusionIndividualSingleWorkloadSheetCol)}},
+		{UserEnteredValue: &sheets.ExtendedValue{StringValue: stringToPointer(nextStepAIIfFailSingleWorkloadSheetCol)}},
 	}}}
 
 	// Add existing column headers from the rawResultsSheet
 	filteredRows[0].Values = append(filteredRows[0].Values, rawResultsSheet.Data[0].RowData[0].Values...)
 
-	headers := getHeadersFromSheet(rawResultsSheet)
+	headers := GetHeadersFromSheet(rawResultsSheet)
 	indices, err := GetHeaderIndicesByColumnNames(headers, []string{"CNFName"})
 	if err != nil {
 		return nil, err
@@ -221,7 +221,7 @@ func createConclusionsSheet(sheetsService *sheets.Service, driveService *drive.S
 		return nil, fmt.Errorf("unable to create workloads results folder: %v", err)
 	}
 
-	rawSheetHeaders := getHeadersFromSheet(rawResultsSheet)
+	rawSheetHeaders := GetHeadersFromSheet(rawResultsSheet)
 	colsIndices, err := GetHeaderIndicesByColumnNames(rawSheetHeaders, []string{workloadNameRawResultsCol, workloadTypeRawResultsCol, operatorVersionRawResultsCol})
 	if err != nil {
 		return nil, err
@@ -271,7 +271,7 @@ func createConclusionsSheet(sheetsService *sheets.Service, driveService *drive.S
 			case WorkloadNameConclusionsCol:
 				curCellData.UserEnteredValue.StringValue = &workloadName
 
-			case resultsConclusionsCol:
+			case ResultsConclusionsCol:
 				workloadResultsSpreadsheet, err := createSingleWorkloadRawResultsSpreadSheet(sheetsService, driveService, workloadsResultsFolder, rawResultsSheet, workloadName)
 				if err != nil {
 					return nil, fmt.Errorf("error has occurred while creating %s results file: %v", workloadName, err)

--- a/cmd/certsuite/upload/results_spreadsheet/sheet_utils.go
+++ b/cmd/certsuite/upload/results_spreadsheet/sheet_utils.go
@@ -6,7 +6,7 @@ import (
 	"google.golang.org/api/sheets/v4"
 )
 
-func getHeadersFromSheet(sheet *sheets.Sheet) []string {
+func GetHeadersFromSheet(sheet *sheets.Sheet) []string {
 	headers := []string{}
 	for _, val := range sheet.Data[0].RowData[0].Values {
 		headers = append(headers, *val.UserEnteredValue.StringValue)


### PR DESCRIPTION
This PR adds some constants related to the results spreadsheet to allow consistency in the `operator-results-spreadsheet` repo.
Also,  `getHeadersFromSheet` function was converted to a public function to allow its us in that repo as well.