### PR TITLE
Automate results spreadsheet authentication

### DIFF
--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -85,6 +85,8 @@ func CreateSheetsAndDriveServices(credentials string) (sheetService *sheets.Serv
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to parse client secret file to config: %v", err)
 	}
+	config.RedirectURL = "http://localhost:8085"
+
 	client, err := getClient(config)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to get client: %v", err)
@@ -321,10 +323,12 @@ func createRawResultsSheet(fp string) (*sheets.Sheet, error) {
 }
 
 func generateResultsSpreadSheet() {
+	log.Print("Starting authentication process.")
 	sheetService, driveService, err := CreateSheetsAndDriveServices(credentials)
 	if err != nil {
 		log.Fatalf("Unable to create services: %v", err)
 	}
+	log.Println("Authentication has succeeded, generating results spreadsheet...")
 
 	rootFolderID, err := extractFolderIDFromURL(rootFolderURL)
 	if err != nil {
@@ -370,5 +374,5 @@ func generateResultsSpreadSheet() {
 		log.Fatalf("Unable to apply filter to the spread sheet: %v", err)
 	}
 
-	fmt.Printf("Results spreadsheet was created successfully: %s\n", spreadsheet.SpreadsheetUrl)
+	log.Printf("Results spreadsheet was created successfully: %s\n", spreadsheet.SpreadsheetUrl)
 }


### PR DESCRIPTION
This PR adds an automation for authenticating the creation of a results spreadsheet (created using certsuite's `upload results-spreadsheet` sub-command).

An Oauth 2.0 authorization protocol is required for running the spreadsheet app.
If the required token is already present when running the app, the authorization will be completed successfully. 
otherwise, a local server will be created. The server will wait (inside a separate go routine) to receive an auth code, that will later on be exchanged with a token that will approve the authentication of the user running the app.

While the server is waiting for the token, a web browser will be opened (based on the os the app is running on), there the user will be asked to allow the app to access their google account. 
Once the user allow the access, a request will be sent to the server.
The server will handle the request by extracting the auth code from the request. 
Than, the server will be shutdown gracefully, and the auth code will be exchanged with a token as mentioned above, allowing the app continue running.