### PR TITLE
Switch comparisons from reflect.DeepEqual to slices/maps libs

### DIFF
--- a/cmd/certsuite/claim/compare/testcases/testcases_test.go
+++ b/cmd/certsuite/claim/compare/testcases/testcases_test.go
@@ -1,7 +1,9 @@
 package testcases
 
 import (
+	"maps"
 	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/cmd/certsuite/pkg/claim"
@@ -78,7 +80,7 @@ func TestGetTestCasesResultsMap(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			resultsMap := getTestCasesResultsMap(tc.results)
-			assert.True(t, reflect.DeepEqual(tc.expectedTestCasesResultsMap, resultsMap))
+			assert.True(t, maps.Equal(tc.expectedTestCasesResultsMap, resultsMap))
 		})
 	}
 }
@@ -137,7 +139,7 @@ func TestGetMergedTestCasesNames(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			tcMergedNamesList := getMergedTestCasesNames(tc.claim1Results, tc.claim2Results)
-			assert.True(t, reflect.DeepEqual(tc.expectedMergedTcNames, tcMergedNamesList))
+			assert.True(t, slices.Equal(tc.expectedMergedTcNames, tcMergedNamesList))
 		})
 	}
 }

--- a/cmd/certsuite/generate/catalog/catalog_test.go
+++ b/cmd/certsuite/generate/catalog/catalog_test.go
@@ -18,7 +18,7 @@ package catalog
 
 import (
 	"errors"
-	"reflect"
+	"slices"
 	"sort"
 	"testing"
 
@@ -82,6 +82,6 @@ func TestGetSuitesFromIdentifiers(t *testing.T) {
 		sort.Strings(tc.expectedSuites)
 		results := GetSuitesFromIdentifiers(tc.testKeys)
 		sort.Strings(results)
-		assert.True(t, reflect.DeepEqual(tc.expectedSuites, results))
+		assert.True(t, slices.Equal(tc.expectedSuites, results))
 	}
 }

--- a/pkg/arrayhelper/arrayhelper_test.go
+++ b/pkg/arrayhelper/arrayhelper_test.go
@@ -17,7 +17,8 @@
 package arrayhelper
 
 import (
-	"reflect"
+	"maps"
+	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -83,7 +84,7 @@ func TestArgListToMap(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		assert.True(t, reflect.DeepEqual(tc.expectedMap, ArgListToMap(tc.argList)))
+		assert.True(t, maps.Equal(tc.expectedMap, ArgListToMap(tc.argList)))
 	}
 }
 
@@ -110,6 +111,6 @@ func TestUnique(t *testing.T) {
 		sort.Strings(tc.expectedSlice)
 		results := Unique(tc.testSlice)
 		sort.Strings(results)
-		assert.True(t, reflect.DeepEqual(tc.expectedSlice, results))
+		assert.True(t, slices.Equal(tc.expectedSlice, results))
 	}
 }

--- a/pkg/autodiscover/autodiscover_operators_test.go
+++ b/pkg/autodiscover/autodiscover_operators_test.go
@@ -3,7 +3,7 @@
 package autodiscover
 
 import (
-	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,6 +51,6 @@ func TestGetAllNamespaces(t *testing.T) {
 		clientSet := fake.NewSimpleClientset(testRuntimeObjects...)
 		namespaces, err := getAllNamespaces(clientSet.CoreV1())
 		assert.Nil(t, err)
-		assert.True(t, reflect.DeepEqual(tc.expectedNamespaces, namespaces))
+		assert.True(t, slices.Equal(tc.expectedNamespaces, namespaces))
 	}
 }

--- a/pkg/podhelper/podhelper_test.go
+++ b/pkg/podhelper/podhelper_test.go
@@ -1,7 +1,7 @@
 package podhelper
 
 import (
-	"reflect"
+	"maps"
 	"testing"
 
 	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -84,7 +84,7 @@ func Test_followOwnerReferences(t *testing.T) {
 			if err := followOwnerReferences(resourceList, client, gotResults, tt.args.namespace, tt.args.ownerRefs); (err != nil) != tt.wantErr {
 				t.Errorf("followOwnerReferences() error = %v, wantErr %v", err, tt.wantErr)
 			}
-			if !reflect.DeepEqual(gotResults, tt.args.topOwners) {
+			if !maps.Equal(gotResults, tt.args.topOwners) {
 				t.Errorf("followOwnerReferences() = %v, want %v", gotResults, tt.args.topOwners)
 			}
 		})

--- a/pkg/provider/operators_test.go
+++ b/pkg/provider/operators_test.go
@@ -17,7 +17,7 @@
 package provider
 
 import (
-	"reflect"
+	"slices"
 	"testing"
 
 	"github.com/operator-framework/api/pkg/lib/version"
@@ -399,7 +399,7 @@ func Test_getSummaryAllOperators(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotSummary := getSummaryAllOperators(tt.args.operators); !reflect.DeepEqual(gotSummary, tt.wantSummary) {
+			if gotSummary := getSummaryAllOperators(tt.args.operators); !slices.Equal(gotSummary, tt.wantSummary) {
 				t.Errorf("getSummaryAllOperators() = %v, want %v", gotSummary, tt.wantSummary)
 			}
 		})

--- a/tests/accesscontrol/securitycontextcontainer/securitycontextcontainer.go
+++ b/tests/accesscontrol/securitycontextcontainer/securitycontextcontainer.go
@@ -5,7 +5,7 @@ package securitycontextcontainer
 
 import (
 	"fmt"
-	"reflect"
+	"slices"
 	"sort"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
@@ -236,7 +236,7 @@ func updateCapabilitiesFromContainer(cut *provider.Container, containerSCC *Cont
 		sort.Strings(sliceDropCapabilities)
 		sort.Strings(requiredDropCapabilities)
 
-		if stringhelper.SubSlice(sliceDropCapabilities, requiredDropCapabilities) || reflect.DeepEqual(sliceDropCapabilities, dropAll) {
+		if stringhelper.SubSlice(sliceDropCapabilities, requiredDropCapabilities) || slices.Equal(sliceDropCapabilities, dropAll) {
 			containerSCC.RequiredDropCapabilitiesPresent = OK
 		}
 		//nolint:gocritic

--- a/tests/lifecycle/podsets/podsets_test.go
+++ b/tests/lifecycle/podsets/podsets_test.go
@@ -18,7 +18,7 @@ package podsets
 
 import (
 	"fmt"
-	"reflect"
+	"maps"
 	"testing"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
@@ -178,7 +178,7 @@ func TestGetPodSetNodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetAllNodesForAllPodSets(provider.ConvertArrayPods(tt.args.pods)); !reflect.DeepEqual(got, tt.want) {
+			if got := GetAllNodesForAllPodSets(provider.ConvertArrayPods(tt.args.pods)); !maps.Equal(got, tt.want) {
 				t.Errorf("GetAllNodesForAllPodSets() = %v, want %v", got, tt.want)
 			}
 		})

--- a/tests/networking/netcommons/netcommons_test.go
+++ b/tests/networking/netcommons/netcommons_test.go
@@ -17,7 +17,7 @@
 package netcommons
 
 import (
-	"reflect"
+	"slices"
 	"sort"
 	"testing"
 
@@ -101,7 +101,7 @@ func TestFilterIPListByIPVersion(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := FilterIPListByIPVersion(tt.args.ipList, tt.args.aIPVersion); !reflect.DeepEqual(got, tt.want) {
+			if got := FilterIPListByIPVersion(tt.args.ipList, tt.args.aIPVersion); !slices.Equal(got, tt.want) {
 				t.Errorf("FilterIPListByIPVersion() = %v, want %v", got, tt.want)
 			}
 		})

--- a/tests/platform/operatingsystem/operatingsystem_test.go
+++ b/tests/platform/operatingsystem/operatingsystem_test.go
@@ -18,8 +18,8 @@ package operatingsystem
 
 import (
 	"errors"
+	"maps"
 	"os"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -62,7 +62,7 @@ func TestGetRHCOSMappedVersionsFromFile(t *testing.T) {
 		} else {
 			result, err := GetRHCOSMappedVersions(string(file))
 			assert.Nil(t, err)
-			assert.True(t, reflect.DeepEqual(tc.expectedOutput, result))
+			assert.True(t, maps.Equal(tc.expectedOutput, result))
 		}
 	}
 }

--- a/tests/platform/sysctlconfig/sysctlconfig_test.go
+++ b/tests/platform/sysctlconfig/sysctlconfig_test.go
@@ -17,7 +17,7 @@
 package sysctlconfig
 
 import (
-	"reflect"
+	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,6 +59,6 @@ func TestParseSysctlSystemOutput(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		assert.True(t, reflect.DeepEqual(parseSysctlSystemOutput(tc.sysctlOutput), tc.expectedResult))
+		assert.True(t, maps.Equal(parseSysctlSystemOutput(tc.sysctlOutput), tc.expectedResult))
 	}
 }


### PR DESCRIPTION
Take advantage of `slices` and `maps` built in packages when comparing maps and string slices.

The `maps` and `slices` packages were added in Go 1.21: https://tip.golang.org/doc/go1.21#library