### PR TITLE
Assert equal vs Assert true for comparisons

### DIFF
--- a/cmd/certsuite/claim/compare/testcases/testcases_test.go
+++ b/cmd/certsuite/claim/compare/testcases/testcases_test.go
@@ -1,9 +1,6 @@
 package testcases
 
 import (
-	"maps"
-	"reflect"
-	"slices"
 	"testing"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/cmd/certsuite/pkg/claim"
@@ -80,7 +77,7 @@ func TestGetTestCasesResultsMap(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			resultsMap := getTestCasesResultsMap(tc.results)
-			assert.True(t, maps.Equal(tc.expectedTestCasesResultsMap, resultsMap))
+			assert.Equal(t, tc.expectedTestCasesResultsMap, resultsMap)
 		})
 	}
 }
@@ -139,7 +136,7 @@ func TestGetMergedTestCasesNames(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.description, func(t *testing.T) {
 			tcMergedNamesList := getMergedTestCasesNames(tc.claim1Results, tc.claim2Results)
-			assert.True(t, slices.Equal(tc.expectedMergedTcNames, tcMergedNamesList))
+			assert.Equal(t, tc.expectedMergedTcNames, tcMergedNamesList)
 		})
 	}
 }
@@ -304,7 +301,7 @@ func TestGetDiffReport(t *testing.T) {
 
 			// Check test case results differences
 			t.Logf("diffs: %+v", diffReport.TestCases)
-			assert.True(t, reflect.DeepEqual(tc.expectedDiffReport.TestCases, diffReport.TestCases))
+			assert.Equal(t, tc.expectedDiffReport.TestCases, diffReport.TestCases)
 
 			// Check count
 			assert.Equal(t, tc.expectedDiffReport.DifferentTestCasesResults, diffReport.DifferentTestCasesResults)

--- a/cmd/certsuite/generate/catalog/catalog_test.go
+++ b/cmd/certsuite/generate/catalog/catalog_test.go
@@ -18,7 +18,6 @@ package catalog
 
 import (
 	"errors"
-	"slices"
 	"sort"
 	"testing"
 
@@ -82,6 +81,6 @@ func TestGetSuitesFromIdentifiers(t *testing.T) {
 		sort.Strings(tc.expectedSuites)
 		results := GetSuitesFromIdentifiers(tc.testKeys)
 		sort.Strings(results)
-		assert.True(t, slices.Equal(tc.expectedSuites, results))
+		assert.Equal(t, tc.expectedSuites, results)
 	}
 }

--- a/pkg/arrayhelper/arrayhelper_test.go
+++ b/pkg/arrayhelper/arrayhelper_test.go
@@ -17,8 +17,6 @@
 package arrayhelper
 
 import (
-	"maps"
-	"slices"
 	"sort"
 	"strings"
 	"testing"
@@ -84,7 +82,7 @@ func TestArgListToMap(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		assert.True(t, maps.Equal(tc.expectedMap, ArgListToMap(tc.argList)))
+		assert.Equal(t, tc.expectedMap, ArgListToMap(tc.argList))
 	}
 }
 
@@ -111,6 +109,6 @@ func TestUnique(t *testing.T) {
 		sort.Strings(tc.expectedSlice)
 		results := Unique(tc.testSlice)
 		sort.Strings(results)
-		assert.True(t, slices.Equal(tc.expectedSlice, results))
+		assert.Equal(t, tc.expectedSlice, results)
 	}
 }

--- a/pkg/autodiscover/autodiscover_operators_test.go
+++ b/pkg/autodiscover/autodiscover_operators_test.go
@@ -3,7 +3,6 @@
 package autodiscover
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,6 +50,6 @@ func TestGetAllNamespaces(t *testing.T) {
 		clientSet := fake.NewSimpleClientset(testRuntimeObjects...)
 		namespaces, err := getAllNamespaces(clientSet.CoreV1())
 		assert.Nil(t, err)
-		assert.True(t, slices.Equal(tc.expectedNamespaces, namespaces))
+		assert.Equal(t, tc.expectedNamespaces, namespaces)
 	}
 }

--- a/tests/platform/operatingsystem/operatingsystem_test.go
+++ b/tests/platform/operatingsystem/operatingsystem_test.go
@@ -18,7 +18,6 @@ package operatingsystem
 
 import (
 	"errors"
-	"maps"
 	"os"
 	"testing"
 
@@ -62,7 +61,7 @@ func TestGetRHCOSMappedVersionsFromFile(t *testing.T) {
 		} else {
 			result, err := GetRHCOSMappedVersions(string(file))
 			assert.Nil(t, err)
-			assert.True(t, maps.Equal(tc.expectedOutput, result))
+			assert.Equal(t, tc.expectedOutput, result)
 		}
 	}
 }

--- a/tests/platform/sysctlconfig/sysctlconfig_test.go
+++ b/tests/platform/sysctlconfig/sysctlconfig_test.go
@@ -17,7 +17,6 @@
 package sysctlconfig
 
 import (
-	"maps"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -59,6 +58,6 @@ func TestParseSysctlSystemOutput(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		assert.True(t, maps.Equal(parseSysctlSystemOutput(tc.sysctlOutput), tc.expectedResult))
+		assert.Equal(t, parseSysctlSystemOutput(tc.sysctlOutput), tc.expectedResult)
 	}
 }


### PR DESCRIPTION
@greyerof pointed out that under the Assert.Equal function call, its doing the comparison using reflect.DeepEqual anyways.

Follow up to #2484 to just completely remove the comparison if we're using assert equal anyways.