### PR TITLE
operator: Add no hugepages test

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 ## Test cases summary
 
-### Total test cases: 112
+### Total test cases: 113
 
 ### Total suites: 10
 
@@ -19,7 +19,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |manageability|2|
 |networking|11|
 |observability|5|
-|operator|7|
+|operator|8|
 |performance|6|
 |platform-alteration|13|
 |preflight|17|
@@ -36,11 +36,11 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |---|---|
 |7|1|
 
-### Non-Telco specific tests only: 65
+### Non-Telco specific tests only: 66
 
 |Mandatory|Optional|
 |---|---|
-|42|23|
+|42|24|
 
 ### Telco specific tests only: 27
 
@@ -1249,6 +1249,22 @@ Tags|common,operator
 |Far-Edge|Mandatory|
 |Non-Telco|Mandatory|
 |Telco|Mandatory|
+
+#### operator-pods-no-hugepages
+
+Property|Description
+---|---
+Unique ID|operator-pods-no-hugepages
+Description|Tests that check that the pods do not have hugepages enabled.
+Suggested Remediation|Ensure that the pods are not using hugepages
+Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements
+Exception Process|No exceptions
+Tags|common,operator
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Optional|
+|Far-Edge|Optional|
+|Non-Telco|Optional|
+|Telco|Optional|
 
 #### operator-semantic-versioning
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1255,7 +1255,7 @@ Tags|common,operator
 Property|Description
 ---|---
 Unique ID|operator-pods-no-hugepages
-Description|Tests that check that the pods do not have hugepages enabled.
+Description|Tests that the pods do not have hugepages enabled.
 Suggested Remediation|Ensure that the pods are not using hugepages
 Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements
 Exception Process|No exceptions

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -57,6 +57,7 @@ testCases:
     - operator-install-status-succeeded
     - operator-semantic-versioning
     - operator-single-crd-owner
+    - operator-pods-no-hugepages
     - performance-exclusive-cpu-pool
     - performance-max-resources-exec-probes
     - performance-shared-cpu-pool-non-rt-scheduling-policy       # hazelcast pod meets requirements

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -647,6 +647,16 @@ func GetNoOperatorsSkipFn(env *provider.TestEnvironment) func() (bool, string) {
 	}
 }
 
+func GetNoOperatorPodsSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.CSVToPodListMap) == 0 {
+			return true, "no operator pods found"
+		}
+
+		return false, ""
+	}
+}
+
 func GetNoOperatorCrdsSkipFn(env *provider.TestEnvironment) func() (bool, string) {
 	return func() (bool, string) {
 		if len(env.Crds) == 0 {

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -114,6 +114,7 @@ const (
 	TestOperatorRunAsNonRootDocLink                     = DocOperatorRequirement
 	TestOperatorAutomountTokensDocLink                  = DocOperatorRequirement
 	TestOperatorReadOnlyFilesystemDocLink               = DocOperatorRequirement
+	TestOperatorPodsNoHugepagesDocLink                  = DocOperatorRequirement
 
 	// Observability Test Suite
 	TestLoggingIdentifierDocLink                            = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-logging"

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -130,6 +130,7 @@ var (
 	TestOperatorCrdVersioningIdentifier               claim.Identifier
 	TestOperatorCrdSchemaIdentifier                   claim.Identifier
 	TestOperatorSingleCrdOwnerIdentifier              claim.Identifier
+	TestOperatorPodsNoHugepages                       claim.Identifier
 	TestPodNodeSelectorAndAffinityBestPractices       claim.Identifier
 	TestPodHighAvailabilityBestPractices              claim.Identifier
 	TestPodClusterRoleBindingsBestPracticesIdentifier claim.Identifier
@@ -1013,6 +1014,22 @@ that Node's kernel may not have the same hacks.'`,
 			Telco:    Mandatory,
 			NonTelco: Mandatory,
 			Extended: Mandatory,
+		},
+		TagCommon)
+
+	TestOperatorPodsNoHugepages = AddCatalogEntry(
+		"pods-no-hugepages",
+		common.OperatorTestKey,
+		`Tests that check that the pods do not have hugepages enabled.`,
+		OperatorPodsNoHugepagesRemediation,
+		NoExceptions,
+		TestOperatorPodsNoHugepagesDocLink,
+		false,
+		map[string]string{
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
+			Extended: Optional,
 		},
 		TagCommon)
 

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -1020,7 +1020,7 @@ that Node's kernel may not have the same hacks.'`,
 	TestOperatorPodsNoHugepages = AddCatalogEntry(
 		"pods-no-hugepages",
 		common.OperatorTestKey,
-		`Tests that check that the pods do not have hugepages enabled.`,
+		`Tests that the pods do not have hugepages enabled.`,
 		OperatorPodsNoHugepagesRemediation,
 		NoExceptions,
 		TestOperatorPodsNoHugepagesDocLink,

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -97,6 +97,8 @@ const (
 
 	OperatorSingleCrdOwnerRemediation = `Ensure that a CRD is owned by only one Operator`
 
+	OperatorPodsNoHugepagesRemediation = `Ensure that the pods are not using hugepages`
+
 	PodNodeSelectorAndAffinityBestPracticesRemediation = `In most cases, Pod's should not specify their host Nodes through nodeSelector or nodeAffinity. However, there are cases in which workloads require specialized hardware specific to a particular class of Node.`
 
 	PodHighAvailabilityBestPracticesRemediation = `In high availability cases, Pod podAntiAffinity rule should be specified for pod scheduling and pod replica value is set to more than 1 .`

--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -95,7 +95,7 @@ func LoadChecks() {
 		}))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestOperatorPodsNoHugepages)).
-		WithSkipCheckFn(testhelper.GetNoOperatorsSkipFn(&env)).
+		WithSkipCheckFn(testhelper.GetNoOperatorsSkipFn(&env), testhelper.GetNoOperatorPodsSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testOperatorPodsNoHugepages(c, &env)
 			return nil


### PR DESCRIPTION
Adds an `operator` suite test for making sure they are not using hugepages in their pods that utilizes the existing `pod.HasHugepages()` function.

Note, I have left the test case as fully `Optional` for now until we discuss Mandatory or Optional as a group.

