### PR TITLE
operator: add olm.skipRange annotation test

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 ## Test cases summary
 
-### Total test cases: 113
+### Total test cases: 114
 
 ### Total suites: 10
 
@@ -19,7 +19,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |manageability|2|
 |networking|11|
 |observability|5|
-|operator|8|
+|operator|9|
 |performance|6|
 |platform-alteration|13|
 |preflight|17|
@@ -36,11 +36,11 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |---|---|
 |7|1|
 
-### Non-Telco specific tests only: 66
+### Non-Telco specific tests only: 67
 
 |Mandatory|Optional|
 |---|---|
-|42|24|
+|42|25|
 
 ### Telco specific tests only: 27
 
@@ -1249,6 +1249,22 @@ Tags|common,operator
 |Far-Edge|Mandatory|
 |Non-Telco|Mandatory|
 |Telco|Mandatory|
+
+#### operator-olm-skip-range
+
+Property|Description
+---|---
+Unique ID|operator-olm-skip-range
+Description|Test that checks the operator has a valid olm skip range.
+Suggested Remediation|Ensure that the Operator has a valid OLM skip range.
+Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements
+Exception Process|No exceptions
+Tags|common,operator
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Optional|
+|Far-Edge|Optional|
+|Non-Telco|Optional|
+|Telco|Optional|
 
 #### operator-pods-no-hugepages
 

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -78,6 +78,7 @@ testCases:
     - lifecycle-startup-probe                                    # hazelcast pod doesn't define this probe
     - manageability-container-port-name-format                   # hazelcast declares not allowed port name "webhook-server".
     - manageability-containers-image-tag                         # hazelcast container not using image tag.
+    - operator-olm-skip-range                                    # hazelcast operator does not have a skip range
   skip:
     - access-control-sys-ptrace-capability
     - affiliated-certification-helm-version

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -115,6 +115,7 @@ const (
 	TestOperatorAutomountTokensDocLink                  = DocOperatorRequirement
 	TestOperatorReadOnlyFilesystemDocLink               = DocOperatorRequirement
 	TestOperatorPodsNoHugepagesDocLink                  = DocOperatorRequirement
+	TestOperatorOlmSkipRangeDocLink                     = DocOperatorRequirement
 
 	// Observability Test Suite
 	TestLoggingIdentifierDocLink                            = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-logging"

--- a/tests/identifiers/exceptions.go
+++ b/tests/identifiers/exceptions.go
@@ -49,4 +49,6 @@ const (
 
 	// affiliated certification exception process
 	AffiliatedCert = NoDocumentedProcess + " " + `A partner can run the Red Hat Best Practices Test Suite before passing other certifications (Container/Operator/HelmChart) but the affiliated certification test cases in the Red Hat Best Practices Test Suite must be re-run once the other certifications have been granted.` //nolint:lll
+
+	OperatorSkipRangeExceptionProcess = `If there is not a version of the operator that needs to be skipped, then an exception will be granted.`
 )

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -124,6 +124,7 @@ var (
 	TestOperatorIsInstalledViaOLMIdentifier           claim.Identifier
 	TestOperatorHasSemanticVersioningIdentifier       claim.Identifier
 	TestSecConReadOnlyFilesystem                      claim.Identifier
+	TestOperatorOlmSkipRange                          claim.Identifier
 	TestOperatorAutomountTokens                       claim.Identifier
 	TestOperatorRunAsNonRoot                          claim.Identifier
 	TestOperatorRunAsUserID                           claim.Identifier
@@ -966,6 +967,22 @@ that Node's kernel may not have the same hacks.'`,
 			Telco:    Mandatory,
 			NonTelco: Mandatory,
 			Extended: Mandatory,
+		},
+		TagCommon)
+
+	TestOperatorOlmSkipRange = AddCatalogEntry(
+		"olm-skip-range",
+		common.OperatorTestKey,
+		`Test that checks the operator has a valid olm skip range.`,
+		OperatorOlmSkipRangeRemediation,
+		NoExceptions,
+		TestOperatorOlmSkipRangeDocLink,
+		false,
+		map[string]string{
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
+			Extended: Optional,
 		},
 		TagCommon)
 

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -975,7 +975,7 @@ that Node's kernel may not have the same hacks.'`,
 		common.OperatorTestKey,
 		`Test that checks the operator has a valid olm skip range.`,
 		OperatorOlmSkipRangeRemediation,
-		NoExceptions,
+		OperatorSkipRangeExceptionProcess,
 		TestOperatorOlmSkipRangeDocLink,
 		false,
 		map[string]string{

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -95,6 +95,8 @@ const (
 
 	OperatorCrdVersioningRemediation = `Ensure that the Operator CRD has a valid version.`
 
+	OperatorOlmSkipRangeRemediation = `Ensure that the Operator has a valid OLM skip range.`
+
 	OperatorSingleCrdOwnerRemediation = `Ensure that a CRD is owned by only one Operator`
 
 	OperatorPodsNoHugepagesRemediation = `Ensure that the pods are not using hugepages`

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -95,7 +95,7 @@ const (
 
 	OperatorCrdVersioningRemediation = `Ensure that the Operator CRD has a valid version.`
 
-	OperatorOlmSkipRangeRemediation = `Ensure that the Operator has a valid OLM skip range.`
+	OperatorOlmSkipRangeRemediation = `Ensure that the Operator has a valid OLM skip range. If the operator does not have another version to "skip", then ignore the result of this test.`
 
 	OperatorSingleCrdOwnerRemediation = `Ensure that a CRD is owned by only one Operator`
 

--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -39,6 +39,7 @@ var (
 	}
 )
 
+//nolint:funlen
 func LoadChecks() {
 	log.Debug("Loading %s suite checks", common.OperatorTestKey)
 


### PR DESCRIPTION
Adds a test looking for the existence of the olm.skipRange annotation on the CSV.

Note: We will have to switch the expected result of this test to `skipped` when Hazelcast operator is removed.

build-depends: https://github.com/dci-labs/dallas-pipelines/pull/1245