### PR TITLE
networking: Add MTU value test for SRIOV NAD's

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -17,7 +17,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |affiliated-certification|4|
 |lifecycle|18|
 |manageability|2|
-|networking|11|
+|networking|12|
 |observability|5|
 |operator|8|
 |performance|6|
@@ -30,11 +30,11 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |---|---|
 |9|3|
 
-### Far-Edge specific tests only: 8
+### Far-Edge specific tests only: 9
 
 |Mandatory|Optional|
 |---|---|
-|7|1|
+|8|1|
 
 ### Non-Telco specific tests only: 66
 
@@ -1004,6 +1004,22 @@ Tags|telco,networking
 |Extended|Mandatory|
 |Far-Edge|Mandatory|
 |Non-Telco|Optional|
+|Telco|Mandatory|
+
+#### networking-network-attachment-definition-sriov-mtu
+
+Property|Description
+---|---
+Unique ID|networking-network-attachment-definition-sriov-mtu
+Description|Ensures that MTU values are set correctly in NetworkAttachmentDefinitions for SRIOV network interfaces.
+Suggested Remediation|Ensure that the MTU of the SR-IOV network attachment definition is set explicitly.
+Best Practice Reference|No Doc Link - Far Edge
+Exception Process|There is no documented exception process for this.
+Tags|faredge,networking
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Mandatory|
+|Far-Edge|Mandatory|
+|Non-Telco|Mandatory|
 |Telco|Mandatory|
 
 #### networking-network-policy-deny-all

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -88,6 +88,7 @@ testCases:
     - networking-dpdk-cpu-pinning-exec-probe
     - networking-icmpv6-connectivity
     - networking-restart-on-reboot-sriov-pod
+    - networking-network-attachment-definition-sriov-mtu
     - performance-exclusive-cpu-pool-rt-scheduling-policy
     - performance-isolated-cpu-pool-rt-scheduling-policy
     - performance-rt-apps-no-exec-probes

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -8,18 +8,19 @@ const (
 	NoDocLink         = "No Doc Link"
 
 	// Networking Suite
-	TestICMPv4ConnectivityIdentifierDocLink         = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-ipv4-&-ipv6"
-	TestNetworkPolicyDenyAllIdentifierDocLink       = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-vrfs-aka-routing-instances"
-	TestReservedExtendedPartnerPortsDocLink         = NoDocLinkExtended
-	TestDpdkCPUPinningExecProbeDocLink              = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cpu-manager-pinning"
-	TestRestartOnRebootLabelOnPodsUsingSRIOVDocLink = NoDocLinkFarEdge
-	TestLimitedUseOfExecProbesIdentifierDocLink     = NoDocLinkFarEdge
-	TestICMPv6ConnectivityIdentifierDocLink         = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-ipv4-&-ipv6"
-	TestICMPv4ConnectivityMultusIdentifierDocLink   = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-high-level-cnf-expectations"
-	TestICMPv6ConnectivityMultusIdentifierDocLink   = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-high-level-cnf-expectations"
-	TestServiceDualStackIdentifierDocLink           = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-ipv4-&-ipv6"
-	TestUndeclaredContainerPortsUsageDocLink        = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-requirements-cnf-reqs"
-	TestOCPReservedPortsUsageDocLink                = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-ports-reserved-by-openshift"
+	TestICMPv4ConnectivityIdentifierDocLink             = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-ipv4-&-ipv6"
+	TestNetworkPolicyDenyAllIdentifierDocLink           = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-vrfs-aka-routing-instances"
+	TestReservedExtendedPartnerPortsDocLink             = NoDocLinkExtended
+	TestDpdkCPUPinningExecProbeDocLink                  = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cpu-manager-pinning"
+	TestRestartOnRebootLabelOnPodsUsingSRIOVDocLink     = NoDocLinkFarEdge
+	TestNetworkAttachmentDefinitionSRIOVUsingMTUDocLink = NoDocLinkFarEdge
+	TestLimitedUseOfExecProbesIdentifierDocLink         = NoDocLinkFarEdge
+	TestICMPv6ConnectivityIdentifierDocLink             = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-ipv4-&-ipv6"
+	TestICMPv4ConnectivityMultusIdentifierDocLink       = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-high-level-cnf-expectations"
+	TestICMPv6ConnectivityMultusIdentifierDocLink       = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-high-level-cnf-expectations"
+	TestServiceDualStackIdentifierDocLink               = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-ipv4-&-ipv6"
+	TestUndeclaredContainerPortsUsageDocLink            = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-requirements-cnf-reqs"
+	TestOCPReservedPortsUsageDocLink                    = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-ports-reserved-by-openshift"
 
 	// Access Control Suite
 	Test1337UIDIdentifierDocLink                             = NoDocLinkExtended

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -103,6 +103,7 @@ var (
 	TestRestartOnRebootLabelOnPodsUsingSRIOV          claim.Identifier
 	TestSecConNonRootUserIDIdentifier                 claim.Identifier
 	TestSecConRunAsNonRootIdentifier                  claim.Identifier
+	TestNetworkAttachmentDefinitionSRIOVUsingMTU      claim.Identifier
 	TestSecContextIdentifier                          claim.Identifier
 	TestSecConPrivilegeEscalation                     claim.Identifier
 	TestContainerHostPort                             claim.Identifier
@@ -577,6 +578,22 @@ func InitCatalog() map[claim.Identifier]claim.TestCaseDescription {
 			FarEdge:  Mandatory,
 			Telco:    Optional,
 			NonTelco: Optional,
+			Extended: Mandatory,
+		},
+		TagFarEdge)
+
+	TestNetworkAttachmentDefinitionSRIOVUsingMTU = AddCatalogEntry(
+		"network-attachment-definition-sriov-mtu",
+		common.NetworkingTestKey,
+		`Ensures that MTU values are set correctly in NetworkAttachmentDefinitions for SRIOV network interfaces.`,
+		SRIOVNetworkAttachmentDefinitionMTURemediation,
+		NoDocumentedProcess,
+		TestNetworkAttachmentDefinitionSRIOVUsingMTUDocLink,
+		false,
+		map[string]string{
+			FarEdge:  Mandatory,
+			Telco:    Mandatory,
+			NonTelco: Mandatory,
 			Extended: Mandatory,
 		},
 		TagFarEdge)

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -196,6 +196,8 @@ const (
 
 	SRIOVPodsRestartOnRebootLabelRemediation = `Ensure that the label restart-on-reboot exists on pods that use SRIOV network interfaces.`
 
+	SRIOVNetworkAttachmentDefinitionMTURemediation = `Ensure that the MTU of the SR-IOV network attachment definition is set explicitly.`
+
 	HelmVersionV3Remediation = `Check Helm Chart is v3 and not v2 which is not supported due to security risks associated with Tiller.`
 
 	ContainerIsCertifiedDigestRemediation = "Ensure that your container has passed the Red Hat Container Certification Program (CCP)."


### PR DESCRIPTION
Adds a test that checks that Network Attachment Definitions are specifying their MTU values explicitly.

EDIT: I was trying to follow the quick start guide [here](https://github.com/openshift/sriov-network-operator/blob/master/doc/quickstart.md) for the SRIOV network operator but I don't have access to the necessary [hardware](https://github.com/k8snetworkplumbingwg/sriov-network-operator/blob/master/doc/supported-hardware.md).

We'll have to maybe figure out how to test this via QE on supported hardware in the future.