### PR TITLE
Updating the default list of telco operators

### DIFF
--- a/cmd/certsuite/claim/show/csv/cnf-type.json
+++ b/cmd/certsuite/claim/show/csv/cnf-type.json
@@ -46,5 +46,7 @@
   "servicemeshoperator": "Telco",
   "file-integrity-operator": "Telco",
   "kiali-ossm": "Telco",
-  "node-healthcheck-operator": "Telco"
+  "node-healthcheck-operator": "Telco",
+  "lvms-operator": "Telco",
+  "power-monitoring-operator": "Telco"
 }

--- a/cmd/certsuite/claim/show/csv/cnf-type.json
+++ b/cmd/certsuite/claim/show/csv/cnf-type.json
@@ -48,5 +48,7 @@
   "kiali-ossm": "Telco",
   "node-healthcheck-operator": "Telco",
   "lvms-operator": "Telco",
-  "power-monitoring-operator": "Telco"
+  "power-monitoring-operator": "Telco",
+  "tempo-operator": "Telco",
+  "loki-operator": "Telco"
 }


### PR DESCRIPTION
Adding the following operators to the default list of telco operators
lvms-operator
power-monitoring-operator
loki-operator
tempo-operator