### PR TITLE
operator: Multiple same operators installed test

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 ## Test cases summary
 
-### Total test cases: 114
+### Total test cases: 116
 
 ### Total suites: 10
 
@@ -19,7 +19,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |manageability|2|
 |networking|12|
 |observability|5|
-|operator|9|
+|operator|10|
 |performance|6|
 |platform-alteration|13|
 |preflight|17|
@@ -36,11 +36,11 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |---|---|
 |8|1|
 
-### Non-Telco specific tests only: 67
+### Non-Telco specific tests only: 68
 
 |Mandatory|Optional|
 |---|---|
-|42|25|
+|43|25|
 
 ### Telco specific tests only: 27
 
@@ -1266,15 +1266,31 @@ Tags|common,operator
 |Non-Telco|Mandatory|
 |Telco|Mandatory|
 
+#### operator-multiple-same-operators
+
+Property|Description
+---|---
+Unique ID|operator-multiple-same-operators
+Description|Tests whether multiple instances of the same Operator CSV are installed.
+Suggested Remediation|Ensure that only one Operator of the same type is installed in the cluster.
+Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements
+Exception Process|No exceptions
+Tags|common,operator
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Mandatory|
+|Far-Edge|Mandatory|
+|Non-Telco|Mandatory|
+|Telco|Mandatory|
+
 #### operator-olm-skip-range
 
 Property|Description
 ---|---
 Unique ID|operator-olm-skip-range
 Description|Test that checks the operator has a valid olm skip range.
-Suggested Remediation|Ensure that the Operator has a valid OLM skip range.
+Suggested Remediation|Ensure that the Operator has a valid OLM skip range. If the operator does not have another version to "skip", then ignore the result of this test.
 Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements
-Exception Process|No exceptions
+Exception Process|If there is not a version of the operator that needs to be skipped, then an exception will be granted.
 Tags|common,operator
 |**Scenario**|**Optional/Mandatory**|
 |Extended|Optional|

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -58,6 +58,7 @@ testCases:
     - operator-semantic-versioning
     - operator-single-crd-owner
     - operator-pods-no-hugepages
+    - operator-multiple-same-operators
     - performance-exclusive-cpu-pool
     - performance-max-resources-exec-probes
     - performance-shared-cpu-pool-non-rt-scheduling-policy       # hazelcast pod meets requirements

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -240,7 +240,7 @@ func buildTestEnvironment() { //nolint:funlen
 	}
 	env.AllSubscriptions = data.AllSubscriptions
 	env.AllCatalogSources = data.AllCatalogSources
-	env.AllOperators = createOperators(data.AllCsvs, data.AllSubscriptions, data.AllInstallPlans, data.AllCatalogSources, false, false)
+	env.AllOperators = createOperators(data.AllCsvs, data.AllSubscriptions, data.AllInstallPlans, data.AllCatalogSources, false, true)
 	env.AllOperatorsSummary = getSummaryAllOperators(env.AllOperators)
 	env.AllCrds = data.AllCrds
 	env.Namespaces = data.Namespaces

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -117,6 +117,7 @@ const (
 	TestOperatorReadOnlyFilesystemDocLink               = DocOperatorRequirement
 	TestOperatorPodsNoHugepagesDocLink                  = DocOperatorRequirement
 	TestOperatorOlmSkipRangeDocLink                     = DocOperatorRequirement
+	TestMultipleSameOperatorsIdentifierDocLink          = DocOperatorRequirement
 
 	// Observability Test Suite
 	TestLoggingIdentifierDocLink                            = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-logging"

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -133,6 +133,7 @@ var (
 	TestOperatorCrdSchemaIdentifier                   claim.Identifier
 	TestOperatorSingleCrdOwnerIdentifier              claim.Identifier
 	TestOperatorPodsNoHugepages                       claim.Identifier
+	TestMultipleSameOperatorsIdentifier               claim.Identifier
 	TestPodNodeSelectorAndAffinityBestPractices       claim.Identifier
 	TestPodHighAvailabilityBestPractices              claim.Identifier
 	TestPodClusterRoleBindingsBestPracticesIdentifier claim.Identifier
@@ -1064,6 +1065,22 @@ that Node's kernel may not have the same hacks.'`,
 			Telco:    Optional,
 			NonTelco: Optional,
 			Extended: Optional,
+		},
+		TagCommon)
+
+	TestMultipleSameOperatorsIdentifier = AddCatalogEntry(
+		"multiple-same-operators",
+		common.OperatorTestKey,
+		`Tests whether multiple instances of the same Operator CSV are installed.`,
+		MultipleSameOperatorsRemediation,
+		NoExceptions,
+		TestMultipleSameOperatorsIdentifierDocLink,
+		false,
+		map[string]string{
+			FarEdge:  Mandatory,
+			Telco:    Mandatory,
+			NonTelco: Mandatory,
+			Extended: Mandatory,
 		},
 		TagCommon)
 

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -101,6 +101,8 @@ const (
 
 	OperatorPodsNoHugepagesRemediation = `Ensure that the pods are not using hugepages`
 
+	MultipleSameOperatorsRemediation = `Ensure that only one Operator of the same type is installed in the cluster.`
+
 	PodNodeSelectorAndAffinityBestPracticesRemediation = `In most cases, Pod's should not specify their host Nodes through nodeSelector or nodeAffinity. However, there are cases in which workloads require specialized hardware specific to a particular class of Node.`
 
 	PodHighAvailabilityBestPracticesRemediation = `In high availability cases, Pod podAntiAffinity rule should be specified for pod scheduling and pod replica value is set to more than 1 .`


### PR DESCRIPTION
Adds a new mandatory test in the `operator` suite that checks to ensure the same CSV is not installed more than once.  CSVs installed by OLM are uniquely named `operator.version` format.  However it is possible to have the CSV exist in more than one namespace.  The best practices document forbids that from being the case.

If you try to install an operator more than once in the same cluster using the UI, it prevents it with the following message:

![image](https://github.com/user-attachments/assets/43d152af-c62a-4206-a855-68c7555efe6d)

So the only way you could get around this would be to manually apply YAMLs I would assume.  I was able to do that in my own cluster.
