### PR TITLE
operator: image bundle < 1000 references test

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -19,7 +19,7 @@ env:
   OCT_IMAGE_NAME: redhat-best-practices-for-k8s/oct
   OCT_IMAGE_TAG: latest
   PROBE_IMAGE_NAME: redhat-best-practices-for-k8s/certsuite-probe
-  PROBE_IMAGE_TAG: v0.0.10
+  PROBE_IMAGE_TAG: v0.0.11
   CERTSUITE_CONFIG_DIR: /tmp/certsuite/config
   CERTSUITE_OUTPUT_DIR: /tmp/certsuite/output
   SMOKE_TESTS_LOG_LEVEL: debug

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 ## Test cases summary
 
-### Total test cases: 116
+### Total test cases: 117
 
 ### Total suites: 10
 
@@ -19,7 +19,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |manageability|2|
 |networking|12|
 |observability|5|
-|operator|10|
+|operator|11|
 |performance|6|
 |platform-alteration|13|
 |preflight|17|
@@ -36,11 +36,11 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |---|---|
 |8|1|
 
-### Non-Telco specific tests only: 68
+### Non-Telco specific tests only: 69
 
 |Mandatory|Optional|
 |---|---|
-|43|25|
+|44|25|
 
 ### Telco specific tests only: 27
 
@@ -1185,6 +1185,22 @@ Tags|telco,observability
 |Telco|Mandatory|
 
 ### operator
+
+#### operator-catalogsource-bundle-count
+
+Property|Description
+---|---
+Unique ID|operator-catalogsource-bundle-count
+Description|Tests operator catalog source bundle count is less than 1000
+Suggested Remediation|Ensure that the Operator's catalog source has a valid bundle count less than 1000.
+Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements
+Exception Process|No exceptions
+Tags|common,operator
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Mandatory|
+|Far-Edge|Mandatory|
+|Non-Telco|Mandatory|
+|Telco|Mandatory|
 
 #### operator-crd-openapi-schema
 

--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -39,7 +39,7 @@ func NewCommand() *cobra.Command {
 	runCmd.PersistentFlags().Bool("include-web-files", false, "Save web files in the configured output folder")
 	runCmd.PersistentFlags().Bool("enable-data-collection", false, "Allow sending test results to an external data collector")
 	runCmd.PersistentFlags().Bool("create-xml-junit-file", false, "Create a JUnit file with the test results")
-	runCmd.PersistentFlags().String("certsuite-probe-image", "quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.10", "Certsuite probe image")
+	runCmd.PersistentFlags().String("certsuite-probe-image", "quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.11", "Certsuite probe image")
 	runCmd.PersistentFlags().String("daemonset-cpu-req", "100m", "CPU request for the probe daemonset container")
 	runCmd.PersistentFlags().String("daemonset-cpu-lim", "100m", "CPU limit for the probe daemonset container")
 	runCmd.PersistentFlags().String("daemonset-mem-req", "100M", "Memory request for the probe daemonset container")

--- a/docs/runtime-env.md
+++ b/docs/runtime-env.md
@@ -63,4 +63,4 @@ See more about this variable [here](https://github.com/redhat-openshift-ecosyste
 against a private container registry that has self-signed certificates.
 
 Note that you can also specify the probe pod image to use with `SUPPORT_IMAGE`
-environment variable, default to `certsuite-probe:v0.0.10`.
+environment variable, default to `certsuite-probe:v0.0.11`.

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -66,7 +66,6 @@ testCases:
     - platform-alteration-tainted-node-kernel
   fail:
     - affiliated-certification-container-is-certified-digest     # test container image is not certified
-
   skip:
     - access-control-sys-ptrace-capability
     - affiliated-certification-helm-version
@@ -87,6 +86,7 @@ testCases:
     - operator-single-crd-owner
     - operator-pods-no-hugepages
     - operator-multiple-same-operators
+    - operator-catalogsource-bundle-count
     - performance-exclusive-cpu-pool-rt-scheduling-policy
     - performance-isolated-cpu-pool-rt-scheduling-policy
     - performance-shared-cpu-pool-non-rt-scheduling-policy

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -169,7 +169,10 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	}
 	data.AllInstallPlans = getAllInstallPlans(oc.OlmClient)
 	data.AllCatalogSources = getAllCatalogSources(oc.OlmClient)
+	log.Info("Collected %d catalog sources during autodiscovery", len(data.AllCatalogSources))
+
 	data.AllPackageManifests = getAllPackageManifests(oc.OlmPkgClient)
+
 	data.Namespaces = namespacesListToStringList(config.TargetNameSpaces)
 	data.Pods, data.AllPods = findPodsByLabels(oc.K8sClient.CoreV1(), podsUnderTestLabelsObjects, data.Namespaces)
 	data.AbnormalEvents = findAbnormalEvents(oc.K8sClient.CoreV1(), data.Namespaces)

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -92,6 +92,7 @@ type DiscoveredTestData struct {
 	RoleBindings                 []rbacv1.RoleBinding // Contains all rolebindings from all namespaces
 	Roles                        []rbacv1.Role        // Contains all roles from all namespaces
 	Services                     []*corev1.Service
+	AllServices                  []*corev1.Service
 	ServiceAccounts              []*corev1.ServiceAccount
 	AllServiceAccounts           []*corev1.ServiceAccount
 	Hpas                         []*scalingv1.HorizontalPodAutoscaler
@@ -278,6 +279,10 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	data.Services, err = getServices(oc.K8sClient.CoreV1(), data.Namespaces, data.ServicesIgnoreList)
 	if err != nil {
 		log.Fatal("Cannot get list of services, err: %v", err)
+	}
+	data.AllServices, err = getServices(oc.K8sClient.CoreV1(), data.AllNamespaces, data.ServicesIgnoreList)
+	if err != nil {
+		log.Fatal("Cannot get list of all services, err: %v", err)
 	}
 	data.ServiceAccounts, err = getServiceAccounts(oc.K8sClient.CoreV1(), data.Namespaces)
 	if err != nil {

--- a/pkg/provider/catalogsources.go
+++ b/pkg/provider/catalogsources.go
@@ -1,7 +1,12 @@
 package provider
 
 import (
+	"strconv"
+
+	"github.com/Masterminds/semver"
 	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 )
 
 func GetCatalogSourceBundleCount(env *TestEnvironment, cs *olmv1Alpha.CatalogSource) int {
@@ -9,6 +14,72 @@ func GetCatalogSourceBundleCount(env *TestEnvironment, cs *olmv1Alpha.CatalogSou
 	// that are associated with the catalog source. This will give us the number of bundles that
 	// are available in the catalog source.
 
+	// If the OCP version is <= 4.12, we need to use the probe container to get the bundle count
+	const (
+		ocpMajorVersion = 4
+		ocpMinorVersion = 12
+	)
+
+	// Check if the cluster is running an OCP version <= 4.12
+	if env.OpenshiftVersion != "" {
+		log.Info("Cluster is determined to be running Openshift version %q.", env.OpenshiftVersion)
+		version, err := semver.NewVersion(env.OpenshiftVersion)
+		if err != nil {
+			log.Error("Failed to parse Openshift version %q.", env.OpenshiftVersion)
+			return 0
+		}
+
+		if version.Major() < ocpMajorVersion || (version.Major() == ocpMajorVersion && version.Minor() <= ocpMinorVersion) {
+			return getCatalogSourceBundleCountFromProbeContainer(env, cs)
+		}
+
+		// If we didn't find the bundle count via the probe container, we can attempt to use the package manifests
+	}
+
+	// If we didn't find the bundle count via the probe container, we can use the package manifests
+	// to get the bundle count
+	return getCatalogSourceBundleCountFromPackageManifests(env, cs)
+}
+
+func getCatalogSourceBundleCountFromProbeContainer(env *TestEnvironment, cs *olmv1Alpha.CatalogSource) int {
+	// We need to use the probe container to get the bundle count
+	// This is because the package manifests are not available in the cluster
+	// for OCP versions <= 4.12
+	o := clientsholder.GetClientsHolder()
+
+	// Find the kubernetes service associated with the catalog source
+	for _, svc := range env.Services {
+		// Skip if the service is not associated with the catalog source
+		if svc.Spec.Selector["olm.catalogSource"] != cs.Name {
+			continue
+		}
+
+		// Use a probe pod to get the bundle count
+		for _, probePod := range env.ProbePods {
+			ctx := clientsholder.NewContext(probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name)
+			cmd := "grpcurl -plaintext " + svc.Spec.ClusterIP + ":50051 api.Registry.ListBundles | jq -s 'length'"
+			cmdValue, errStr, err := o.ExecCommandContainer(ctx, cmd)
+			if err != nil || errStr != "" {
+				log.Error("Failed to execute command %s in probe pod %s", cmd, probePod.String())
+				continue
+			}
+
+			// Parse the command output
+			bundleCount, err := strconv.Atoi(cmdValue)
+			if err != nil {
+				log.Error("Failed to convert bundle count to integer: %s", cmdValue)
+				continue
+			}
+
+			// Try each probe pod until we get a valid bundle count (which should only be 1 probe pod)
+			return bundleCount
+		}
+	}
+
+	return 0
+}
+
+func getCatalogSourceBundleCountFromPackageManifests(env *TestEnvironment, cs *olmv1Alpha.CatalogSource) int {
 	totalRelatedBundles := 0
 	for _, pm := range env.AllPackageManifests {
 		// Skip if the package manifest is not associated with the catalog source

--- a/pkg/provider/catalogsources.go
+++ b/pkg/provider/catalogsources.go
@@ -1,0 +1,26 @@
+package provider
+
+import (
+	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
+)
+
+func GetCatalogSourceBundleCount(env *TestEnvironment, cs *olmv1Alpha.CatalogSource) int {
+	// Now that we know the catalog source, we are going to count up all of the relatedImages
+	// that are associated with the catalog source. This will give us the number of bundles that
+	// are available in the catalog source.
+
+	totalRelatedBundles := 0
+	for _, pm := range env.AllPackageManifests {
+		// Skip if the package manifest is not associated with the catalog source
+		if pm.Status.CatalogSource != cs.Name || pm.Status.CatalogSourceNamespace != cs.Namespace {
+			continue
+		}
+
+		// Count up the number of related bundles
+		for c := range pm.Status.Channels {
+			totalRelatedBundles += len(pm.Status.Channels[c].Entries)
+		}
+	}
+
+	return totalRelatedBundles
+}

--- a/pkg/provider/catalogsources_test.go
+++ b/pkg/provider/catalogsources_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"testing"
+
+	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	olmpkgv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetCatalogSourceBundleCount(t *testing.T) {
+	generateEnv := func(channelEntries []olmpkgv1.ChannelEntry) *TestEnvironment {
+		return &TestEnvironment{
+			AllPackageManifests: []*olmpkgv1.PackageManifest{
+				{
+					Status: olmpkgv1.PackageManifestStatus{
+						CatalogSource:          "test-catalog-source",
+						CatalogSourceNamespace: "test-catalog-source-namespace",
+						Channels: []olmpkgv1.PackageChannel{
+							{
+								Entries: channelEntries,
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testEnv  *TestEnvironment
+		testCS   *olmv1Alpha.CatalogSource
+		expected int
+	}{
+		{ // Test case 1
+			testEnv: generateEnv([]olmpkgv1.ChannelEntry{
+				{
+					Name: "test-csv.v1.0.0",
+				},
+				{
+					Name: "test-csv.v1.0.1",
+				},
+			}),
+			testCS: &olmv1Alpha.CatalogSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-catalog-source",
+					Namespace: "test-catalog-source-namespace",
+				},
+			},
+			expected: 2,
+		},
+		{ // Test Case 2 - No matching catalog source found, expecting 0
+			testEnv: generateEnv([]olmpkgv1.ChannelEntry{
+				{
+					Name: "test-csv.v1.0.0",
+				},
+				{
+					Name: "test-csv.v1.0.1",
+				},
+			}),
+			testCS: &olmv1Alpha.CatalogSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-catalog-source2",
+					Namespace: "test-catalog-source-namespace",
+				},
+			},
+			expected: 0,
+		},
+		{ // Test Case 3 - No images in the catalog source, expecting 0
+			testEnv: generateEnv([]olmpkgv1.ChannelEntry{}),
+			testCS: &olmv1Alpha.CatalogSource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-catalog-source",
+					Namespace: "test-catalog-source-namespace",
+				},
+			},
+			expected: 0,
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.expected, GetCatalogSourceBundleCount(testCase.testEnv, testCase.testCS))
+	}
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -104,6 +104,7 @@ type TestEnvironment struct { // rename this with testTarget
 
 	HorizontalScaler             []*scalingv1.HorizontalPodAutoscaler `json:"testHorizontalScaler"`
 	Services                     []*corev1.Service                    `json:"testServices"`
+	AllServices                  []*corev1.Service                    `json:"testAllServices"`
 	ServiceAccounts              []*corev1.ServiceAccount             `json:"testServiceAccounts"`
 	AllServiceAccounts           []*corev1.ServiceAccount             `json:"AllServiceAccounts"`
 	AllServiceAccountsMap        map[string]*corev1.ServiceAccount
@@ -335,6 +336,7 @@ func buildTestEnvironment() { //nolint:funlen,gocyclo
 	env.RoleBindings = data.RoleBindings
 	env.Roles = data.Roles
 	env.Services = data.Services
+	env.AllServices = data.AllServices
 	env.NetworkPolicies = data.NetworkPolicies
 	for _, nsHelmChartReleases := range data.HelmChartReleases {
 		for _, helmChartRelease := range nsHelmChartReleases {

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -261,6 +261,7 @@ func buildTestEnvironment() { //nolint:funlen,gocyclo
 		aEvent := NewEvent(&data.AbnormalEvents[i])
 		env.AbnormalEvents = append(env.AbnormalEvents, &aEvent)
 	}
+
 	// Service accounts
 	env.ServiceAccounts = data.ServiceAccounts
 	env.AllServiceAccounts = data.AllServiceAccounts

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -189,6 +189,7 @@ const (
 	HelmType                     = "Helm"
 	OperatorType                 = "Operator"
 	ContainerType                = "Container"
+	CatalogSourceType            = "Catalog Source"
 	ContainerImageType           = "Container Image"
 	NodeType                     = "Node"
 	OCPClusterType               = "OCP Cluster"
@@ -306,6 +307,16 @@ func NewOperatorReportObject(aNamespace, aOperatorName, aReason string, isCompli
 	out = NewReportObject(aReason, OperatorType, isCompliant)
 	out.AddField(Namespace, aNamespace)
 	out.AddField(Name, aOperatorName)
+	return out
+}
+
+// NewCatalogSourceReportObject creates a new ReportObject for a catalog source.
+// It takes the namespace, catalog source name, reason, and compliance status as input parameters.
+// It returns the created ReportObject.
+func NewCatalogSourceReportObject(aNamespace, aCatalogSourceName, aReason string, isCompliant bool) (out *ReportObject) {
+	out = NewReportObject(aReason, CatalogSourceType, isCompliant)
+	out.AddField(Namespace, aNamespace)
+	out.AddField(Name, aCatalogSourceName)
 	return out
 }
 
@@ -633,6 +644,15 @@ func GetNoHugepagesPodsSkipFn(env *provider.TestEnvironment) func() (bool, strin
 	return func() (bool, string) {
 		if len(env.GetHugepagesPods()) == 0 {
 			return true, "no pods requesting hugepages found"
+		}
+		return false, ""
+	}
+}
+
+func GetNoCatalogSourcesSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		if len(env.AllCatalogSources) == 0 {
+			return true, "no catalog sources found"
 		}
 		return false, ""
 	}

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -102,21 +102,22 @@ const (
 	TestRtAppNoExecProbesDocLink                = NoDocLinkFarEdge
 
 	// Operator Test Suite
-	DocOperatorRequirement                              = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements"
-	TestOperatorInstallStatusSucceededIdentifierDocLink = DocOperatorRequirement
-	TestOperatorNoPrivilegesDocLink                     = DocOperatorRequirement
-	TestOperatorIsCertifiedIdentifierDocLink            = DocOperatorRequirement
-	TestOperatorIsInstalledViaOLMIdentifierDocLink      = DocOperatorRequirement
-	TestOperatorHasSemanticVersioningIdentifierDocLink  = DocOperatorRequirement
-	TestOperatorCrdSchemaIdentifierDocLink              = DocOperatorRequirement
-	TestOperatorCrdVersioningIdentifierDocLink          = DocOperatorRequirement
-	TestOperatorSingleCrdOwnerIdentifierDocLink         = DocOperatorRequirement
-	TestOperatorRunAsNonRootDocLink                     = DocOperatorRequirement
-	TestOperatorAutomountTokensDocLink                  = DocOperatorRequirement
-	TestOperatorReadOnlyFilesystemDocLink               = DocOperatorRequirement
-	TestOperatorPodsNoHugepagesDocLink                  = DocOperatorRequirement
-	TestOperatorOlmSkipRangeDocLink                     = DocOperatorRequirement
-	TestMultipleSameOperatorsIdentifierDocLink          = DocOperatorRequirement
+	DocOperatorRequirement                                = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements"
+	TestOperatorInstallStatusSucceededIdentifierDocLink   = DocOperatorRequirement
+	TestOperatorNoPrivilegesDocLink                       = DocOperatorRequirement
+	TestOperatorIsCertifiedIdentifierDocLink              = DocOperatorRequirement
+	TestOperatorIsInstalledViaOLMIdentifierDocLink        = DocOperatorRequirement
+	TestOperatorHasSemanticVersioningIdentifierDocLink    = DocOperatorRequirement
+	TestOperatorCrdSchemaIdentifierDocLink                = DocOperatorRequirement
+	TestOperatorCrdVersioningIdentifierDocLink            = DocOperatorRequirement
+	TestOperatorSingleCrdOwnerIdentifierDocLink           = DocOperatorRequirement
+	TestOperatorRunAsNonRootDocLink                       = DocOperatorRequirement
+	TestOperatorAutomountTokensDocLink                    = DocOperatorRequirement
+	TestOperatorReadOnlyFilesystemDocLink                 = DocOperatorRequirement
+	TestOperatorPodsNoHugepagesDocLink                    = DocOperatorRequirement
+	TestOperatorCatalogSourceBundleCountIdentifierDocLink = DocOperatorRequirement
+	TestOperatorOlmSkipRangeDocLink                       = DocOperatorRequirement
+	TestMultipleSameOperatorsIdentifierDocLink            = DocOperatorRequirement
 
 	// Observability Test Suite
 	TestLoggingIdentifierDocLink                            = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-logging"

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -133,6 +133,7 @@ var (
 	TestOperatorSingleCrdOwnerIdentifier              claim.Identifier
 	TestOperatorPodsNoHugepages                       claim.Identifier
 	TestMultipleSameOperatorsIdentifier               claim.Identifier
+	TestOperatorCatalogSourceBundleCountIdentifier    claim.Identifier
 	TestPodNodeSelectorAndAffinityBestPractices       claim.Identifier
 	TestPodHighAvailabilityBestPractices              claim.Identifier
 	TestPodClusterRoleBindingsBestPracticesIdentifier claim.Identifier
@@ -1064,6 +1065,22 @@ that Node's kernel may not have the same hacks.'`,
 			Telco:    Optional,
 			NonTelco: Optional,
 			Extended: Optional,
+		},
+		TagCommon)
+
+	TestOperatorCatalogSourceBundleCountIdentifier = AddCatalogEntry(
+		"catalogsource-bundle-count",
+		common.OperatorTestKey,
+		`Tests operator catalog source bundle count is less than 1000`,
+		OperatorCatalogSourceBundleCountRemediation,
+		NoExceptions,
+		TestOperatorCatalogSourceBundleCountIdentifierDocLink,
+		false,
+		map[string]string{
+			FarEdge:  Mandatory,
+			Telco:    Mandatory,
+			NonTelco: Mandatory,
+			Extended: Mandatory,
 		},
 		TagCommon)
 

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -99,6 +99,8 @@ const (
 
 	OperatorPodsNoHugepagesRemediation = `Ensure that the pods are not using hugepages`
 
+	OperatorCatalogSourceBundleCountRemediation = `Ensure that the Operator's catalog source has a valid bundle count less than 1000.`
+
 	MultipleSameOperatorsRemediation = `Ensure that only one Operator of the same type is installed in the cluster.`
 
 	PodNodeSelectorAndAffinityBestPracticesRemediation = `In most cases, Pod's should not specify their host Nodes through nodeSelector or nodeAffinity. However, there are cases in which workloads require specialized hardware specific to a particular class of Node.`

--- a/tests/operator/catalogsource/catalogsource.go
+++ b/tests/operator/catalogsource/catalogsource.go
@@ -1,0 +1,30 @@
+package catalogsource
+
+import (
+	olmpkgv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
+)
+
+func SkipPMBasedOnChannel(channels []olmpkgv1.PackageChannel, csvName string) bool {
+	// This logic is in place because it is possible for an operator to pull from a multiple package manifests.
+	skipPMBasedOnChannel := true
+	for c := range channels {
+		log.Debug("Comparing channel currentCSV %q with current CSV %q", channels[c].CurrentCSV, csvName)
+		log.Debug("Number of channel entries %d", len(channels[c].Entries))
+		for _, entry := range channels[c].Entries {
+			log.Debug("Comparing entry name %q with current CSV %q", entry.Name, csvName)
+
+			if entry.Name == csvName {
+				log.Debug("Skipping package manifest based on channel entry %q", entry.Name)
+				skipPMBasedOnChannel = false
+				break
+			}
+		}
+
+		if !skipPMBasedOnChannel {
+			break
+		}
+	}
+
+	return skipPMBasedOnChannel
+}

--- a/tests/operator/catalogsource/catalogsource_test.go
+++ b/tests/operator/catalogsource/catalogsource_test.go
@@ -1,0 +1,49 @@
+package catalogsource
+
+import (
+	"testing"
+
+	olmpkgv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSkipPMBasedOnChannel(t *testing.T) {
+	testCases := []struct {
+		testChannels []olmpkgv1.PackageChannel
+		testCSVName  string
+		expected     bool
+	}{
+		{ // Test Case #1 - Do not skip package manifest based on channel entry
+			testChannels: []olmpkgv1.PackageChannel{
+				{
+					CurrentCSV: "test-csv.v1.0.0",
+					Entries: []olmpkgv1.ChannelEntry{
+						{
+							Name: "test-csv.v1.0.0",
+						},
+					},
+				},
+			},
+			testCSVName: "test-csv.v1.0.0",
+			expected:    false,
+		},
+		{ // Test Case #2 - Skip package manifest based on channel entry
+			testChannels: []olmpkgv1.PackageChannel{
+				{
+					CurrentCSV: "test-csv.v1.0.0",
+					Entries: []olmpkgv1.ChannelEntry{
+						{
+							Name: "test-csv.v1.0.0",
+						},
+					},
+				},
+			},
+			testCSVName: "test-csv.v1.0.1",
+			expected:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expected, SkipPMBasedOnChannel(tc.testChannels, tc.testCSVName))
+	}
+}

--- a/tests/operator/helper.go
+++ b/tests/operator/helper.go
@@ -50,17 +50,3 @@ func SplitCsv(csv string) CsvResult {
 	}
 	return result
 }
-
-func GetCsvVersion(csvName string) CsvNameVersion {
-	// Split by comma to separate components
-	// example-operator.v1.0.0 -> example-operator, v1.0.0
-	parts := strings.Split(csvName, ".v")
-	var result CsvNameVersion
-
-	result.Name = parts[0]
-
-	if len(parts) > 1 {
-		result.Version = parts[1]
-	}
-	return result
-}

--- a/tests/operator/helper.go
+++ b/tests/operator/helper.go
@@ -28,6 +28,11 @@ type CsvResult struct {
 	Namespace string
 }
 
+type CsvNameVersion struct {
+	Name    string
+	Version string
+}
+
 // splitCsv splits the input string to extract namecsv and namespace.
 func SplitCsv(csv string) CsvResult {
 	// Split by comma to separate components
@@ -42,6 +47,20 @@ func SplitCsv(csv string) CsvResult {
 		} else {
 			result.NameCsv = part
 		}
+	}
+	return result
+}
+
+func GetCsvVersion(csvName string) CsvNameVersion {
+	// Split by comma to separate components
+	// example-operator.v1.0.0 -> example-operator, v1.0.0
+	parts := strings.Split(csvName, ".v")
+	var result CsvNameVersion
+
+	result.Name = parts[0]
+
+	if len(parts) > 1 {
+		result.Version = parts[1]
 	}
 	return result
 }

--- a/tests/operator/helper.go
+++ b/tests/operator/helper.go
@@ -28,11 +28,6 @@ type CsvResult struct {
 	Namespace string
 }
 
-type CsvNameVersion struct {
-	Name    string
-	Version string
-}
-
 // splitCsv splits the input string to extract namecsv and namespace.
 func SplitCsv(csv string) CsvResult {
 	// Split by comma to separate components

--- a/tests/operator/helper_test.go
+++ b/tests/operator/helper_test.go
@@ -20,7 +20,11 @@ Package operator provides CNFCERT tests used to validate operator CNF facets.
 
 package operator
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func TestSplitCsv(t *testing.T) {
 	tests := []struct {
@@ -65,5 +69,29 @@ func TestSplitCsv(t *testing.T) {
 				t.Errorf("splitCsv(%q) got namespace %q, want %q", tt.input, result.Namespace, tt.expectedNs)
 			}
 		})
+	}
+}
+
+func TestGetCsvVersion(t *testing.T) {
+	testCases := []struct {
+		input       string
+		expectedCsv CsvNameVersion
+	}{
+		{
+			input:       "example-operator.v1.0.0",
+			expectedCsv: CsvNameVersion{Name: "example-operator", Version: "1.0.0"},
+		},
+		{
+			input:       "another-operator.v2.3.1",
+			expectedCsv: CsvNameVersion{Name: "another-operator", Version: "2.3.1"},
+		},
+		{
+			input:       "no-version",
+			expectedCsv: CsvNameVersion{Name: "no-version", Version: ""},
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.expectedCsv, GetCsvVersion(testCase.input))
 	}
 }

--- a/tests/operator/helper_test.go
+++ b/tests/operator/helper_test.go
@@ -22,8 +22,6 @@ package operator
 
 import (
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSplitCsv(t *testing.T) {
@@ -69,29 +67,5 @@ func TestSplitCsv(t *testing.T) {
 				t.Errorf("splitCsv(%q) got namespace %q, want %q", tt.input, result.Namespace, tt.expectedNs)
 			}
 		})
-	}
-}
-
-func TestGetCsvVersion(t *testing.T) {
-	testCases := []struct {
-		input       string
-		expectedCsv CsvNameVersion
-	}{
-		{
-			input:       "example-operator.v1.0.0",
-			expectedCsv: CsvNameVersion{Name: "example-operator", Version: "1.0.0"},
-		},
-		{
-			input:       "another-operator.v2.3.1",
-			expectedCsv: CsvNameVersion{Name: "another-operator", Version: "2.3.1"},
-		},
-		{
-			input:       "no-version",
-			expectedCsv: CsvNameVersion{Name: "no-version", Version: ""},
-		},
-	}
-
-	for _, testCase := range testCases {
-		assert.Equal(t, testCase.expectedCsv, GetCsvVersion(testCase.input))
 	}
 }

--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -492,12 +492,17 @@ func testOperatorCatalogSourceBundleCount(check *checksdb.Check, env *provider.T
 				// The name and namespace match.  Lookup the bundle count.
 				bundleCount := provider.GetCatalogSourceBundleCount(env, catalogSource)
 
-				if bundleCount > bundleCountLimit {
-					check.LogError("CatalogSource %q has more than "+bundleCountLimitStr+" ("+strconv.Itoa(bundleCount)+") referenced images", catalogSource.Name)
-					nonCompliantObjects = append(nonCompliantObjects, testhelper.NewCatalogSourceReportObject(catalogSource.Namespace, catalogSource.Name, "CatalogSource has more than "+bundleCountLimitStr+" referenced images", false))
+				if bundleCount == -1 {
+					check.LogError("Failed to get bundle count for CatalogSource %q", catalogSource.Name)
+					nonCompliantObjects = append(nonCompliantObjects, testhelper.NewCatalogSourceReportObject(catalogSource.Namespace, catalogSource.Name, "Failed to get bundle count", false))
 				} else {
-					check.LogInfo("CatalogSource %q has less than "+bundleCountLimitStr+" ("+strconv.Itoa(bundleCount)+") referenced images", catalogSource.Name)
-					compliantObjects = append(compliantObjects, testhelper.NewCatalogSourceReportObject(catalogSource.Namespace, catalogSource.Name, "CatalogSource has less than "+bundleCountLimitStr+" referenced images", true))
+					if bundleCount > bundleCountLimit {
+						check.LogError("CatalogSource %q has more than "+bundleCountLimitStr+" ("+strconv.Itoa(bundleCount)+") referenced images", catalogSource.Name)
+						nonCompliantObjects = append(nonCompliantObjects, testhelper.NewCatalogSourceReportObject(catalogSource.Namespace, catalogSource.Name, "CatalogSource has more than "+bundleCountLimitStr+" referenced images", false))
+					} else {
+						check.LogInfo("CatalogSource %q has less than "+bundleCountLimitStr+" ("+strconv.Itoa(bundleCount)+") referenced images", catalogSource.Name)
+						compliantObjects = append(compliantObjects, testhelper.NewCatalogSourceReportObject(catalogSource.Namespace, catalogSource.Name, "CatalogSource has less than "+bundleCountLimitStr+" referenced images", true))
+					}
 				}
 
 				log.Debug("Adding catalog source %q to list of already reported", catalogSource.Name)

--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -466,15 +466,8 @@ func testOperatorCatalogSourceBundleCount(check *checksdb.Check, env *provider.T
 		catalogSourceCheckComplete := false
 		check.LogInfo("Checking bundle count for operator %q", op.Csv.Name)
 
-		cvi := GetCsvVersion(op.Csv.Name)
-
 		// Search through packagemanifests to match the name of the CSV.
 		for _, pm := range env.AllPackageManifests {
-			// Skip all package manifests that do not match the name of the CSV.
-			if pm.Name != cvi.Name {
-				continue
-			}
-
 			// Skip package manifests based on channel entries.
 			if catalogsource.SkipPMBasedOnChannel(pm.Status.Channels, op.Csv.Name) {
 				log.Debug("Skipping package manifest %q based on channel", pm.Name)

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "debugTag": "v0.0.10",
+  "debugTag": "v0.0.11",
   "claimFormat": "v0.5.0",
   "parserTag": "v0.5.0"
 }


### PR DESCRIPTION
Adds a test for operator image bundles.  They must have a bundleCount less than 1000 images.  This is new from the v1.6 document.