### PR TITLE
fix for RunAsNonRoot check

### DIFF
--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -27,6 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/stringhelper"
 	corev1 "k8s.io/api/core/v1"
 
 	"github.com/redhat-openshift-ecosystem/openshift-preflight/artifacts"
@@ -194,9 +195,12 @@ func (c *Container) IsReadOnlyRootFilesystem(logger *log.Logger) bool {
 	return *c.Container.SecurityContext.ReadOnlyRootFilesystem
 }
 
-func (c *Container) IsContainerRunAsNonRoot(podRunAsNonRoot bool) bool {
+func (c *Container) IsContainerRunAsNonRoot(podRunAsNonRoot *bool) (isContainerRunAsNonRoot bool, reason string) {
 	if c.SecurityContext != nil && c.SecurityContext.RunAsNonRoot != nil {
-		return *c.SecurityContext.RunAsNonRoot
+		return *c.SecurityContext.RunAsNonRoot, fmt.Sprintf("RunAsNonRoot is set to %t at the container level, overriding a %v value defined at pod level.", *c.SecurityContext.RunAsNonRoot, stringhelper.BoolToString(podRunAsNonRoot))
 	}
-	return podRunAsNonRoot
+	if podRunAsNonRoot != nil {
+		return *podRunAsNonRoot, fmt.Sprintf("RunAsNonRoot is set to nil at container level and inheriting a %t value from the pod level RunAsNonRoot setting.", *podRunAsNonRoot)
+	}
+	return false, "RunAsNonRoot set to nil at pod and container level"
 }

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -194,9 +194,9 @@ func (c *Container) IsReadOnlyRootFilesystem(logger *log.Logger) bool {
 	return *c.Container.SecurityContext.ReadOnlyRootFilesystem
 }
 
-func (c *Container) IsContainerRunAsNonRoot() bool {
+func (c *Container) IsContainerRunAsNonRoot(podRunAsNonRoot bool) bool {
 	if c.SecurityContext != nil && c.SecurityContext.RunAsNonRoot != nil {
 		return *c.SecurityContext.RunAsNonRoot
 	}
-	return false
+	return podRunAsNonRoot
 }

--- a/pkg/provider/containers_test.go
+++ b/pkg/provider/containers_test.go
@@ -249,9 +249,10 @@ func TestIsContainerRunAsNonRoot(t *testing.T) {
 	trueVal := true
 	falseVal := false
 	tests := []struct {
-		name      string
-		container Container
-		expected  bool
+		name       string
+		container  Container
+		podDefault bool
+		expected   bool
 	}{
 		{
 			name: "Container set to run as non-root",
@@ -262,7 +263,8 @@ func TestIsContainerRunAsNonRoot(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			podDefault: false,
+			expected:   true,
 		},
 		{
 			name: "Container set to not run as non-root",
@@ -273,13 +275,26 @@ func TestIsContainerRunAsNonRoot(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			podDefault: true,
+			expected:   false,
+		},
+		{
+			name: "Container set to not run as non-root",
+			container: Container{
+				Container: &corev1.Container{
+					SecurityContext: &corev1.SecurityContext{
+						RunAsNonRoot: nil,
+					},
+				},
+			},
+			podDefault: false,
+			expected:   false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.container.IsContainerRunAsNonRoot()
+			result := tt.container.IsContainerRunAsNonRoot(tt.podDefault)
 			if result != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, result)
 			}

--- a/pkg/provider/containers_test.go
+++ b/pkg/provider/containers_test.go
@@ -249,10 +249,11 @@ func TestIsContainerRunAsNonRoot(t *testing.T) {
 	trueVal := true
 	falseVal := false
 	tests := []struct {
-		name       string
-		container  Container
-		podDefault bool
-		expected   bool
+		name           string
+		container      Container
+		podDefault     *bool
+		expected       bool
+		expectedReason string
 	}{
 		{
 			name: "Container set to run as non-root",
@@ -263,8 +264,9 @@ func TestIsContainerRunAsNonRoot(t *testing.T) {
 					},
 				},
 			},
-			podDefault: false,
-			expected:   true,
+			podDefault:     &falseVal,
+			expected:       true,
+			expectedReason: "RunAsNonRoot is set to true at the container level, overriding a false value defined at pod level.",
 		},
 		{
 			name: "Container set to not run as non-root",
@@ -275,8 +277,9 @@ func TestIsContainerRunAsNonRoot(t *testing.T) {
 					},
 				},
 			},
-			podDefault: true,
-			expected:   false,
+			podDefault:     &trueVal,
+			expected:       false,
+			expectedReason: "RunAsNonRoot is set to false at the container level, overriding a true value defined at pod level.",
 		},
 		{
 			name: "Container set to not run as non-root",
@@ -287,16 +290,33 @@ func TestIsContainerRunAsNonRoot(t *testing.T) {
 					},
 				},
 			},
-			podDefault: false,
-			expected:   false,
+			podDefault:     &falseVal,
+			expected:       false,
+			expectedReason: "RunAsNonRoot is set to nil at container level and inheriting a false value from the pod level RunAsNonRoot setting.",
+		},
+		{
+			name: "nil at pod and true at container",
+			container: Container{
+				Container: &corev1.Container{
+					SecurityContext: &corev1.SecurityContext{
+						RunAsNonRoot: &trueVal,
+					},
+				},
+			},
+			podDefault:     nil,
+			expected:       true,
+			expectedReason: "RunAsNonRoot is set to true at the container level, overriding a nil value defined at pod level.",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.container.IsContainerRunAsNonRoot(tt.podDefault)
+			result, reason := tt.container.IsContainerRunAsNonRoot(tt.podDefault)
 			if result != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+			if reason != tt.expectedReason {
+				t.Errorf("expectedReason %v, got %v", tt.expectedReason, reason)
 			}
 		})
 	}

--- a/pkg/provider/pods_test.go
+++ b/pkg/provider/pods_test.go
@@ -529,15 +529,99 @@ func TestIsRunAsNonRoot(t *testing.T) {
 			pod: &Pod{
 				Pod: &corev1.Pod{
 					Spec: corev1.PodSpec{
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot: boolPtr(true),
+						},
+					},
+				},
+				Containers: []*Container{
+					{
+						Container: &corev1.Container{
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: boolPtr(true),
+							},
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "One container with RunAsNonRoot set to false",
+			pod: &Pod{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
 							{
 								SecurityContext: &corev1.SecurityContext{
 									RunAsNonRoot: boolPtr(true),
 								},
 							},
+							{
+								SecurityContext: &corev1.SecurityContext{
+									RunAsNonRoot: boolPtr(false),
+								},
+							},
 						},
 						SecurityContext: &corev1.PodSecurityContext{
 							RunAsNonRoot: boolPtr(true),
+						},
+					},
+				},
+				Containers: []*Container{
+					{
+						Container: &corev1.Container{
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: boolPtr(true),
+							},
+						},
+					},
+					{
+						Container: &corev1.Container{
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: boolPtr(false),
+							},
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "One container with RunAsNonRoot non set (nil)",
+			pod: &Pod{
+				Pod: &corev1.Pod{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								SecurityContext: &corev1.SecurityContext{
+									RunAsNonRoot: boolPtr(true),
+								},
+							},
+							{
+								SecurityContext: &corev1.SecurityContext{
+									RunAsNonRoot: nil,
+								},
+							},
+						},
+						SecurityContext: &corev1.PodSecurityContext{
+							RunAsNonRoot: boolPtr(true),
+						},
+					},
+				},
+				Containers: []*Container{
+					{
+						Container: &corev1.Container{
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: boolPtr(true),
+							},
+						},
+					},
+					{
+						Container: &corev1.Container{
+							SecurityContext: &corev1.SecurityContext{
+								RunAsNonRoot: nil,
+							},
 						},
 					},
 				},
@@ -561,8 +645,8 @@ func TestIsRunAsNonRoot(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := tt.pod.IsRunAsNonRoot()
-			if result != tt.expected {
+			result := tt.pod.GetRunAsNonRootFalseContainers(map[string]bool{})
+			if (len(result) == 0) != tt.expected {
 				t.Errorf("expected %v, got %v", tt.expected, result)
 			}
 		})

--- a/pkg/stringhelper/stringhelper.go
+++ b/pkg/stringhelper/stringhelper.go
@@ -17,6 +17,7 @@
 package stringhelper
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -64,4 +65,11 @@ func RemoveEmptyStrings(s []string) []string {
 		}
 	}
 	return r
+}
+
+func BoolToString(b *bool) string {
+	if b == nil {
+		return "nil"
+	}
+	return fmt.Sprintf("%t", *b)
 }

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -398,14 +398,14 @@ func testSecConRunAsNonRoot(check *checksdb.Check, env *provider.TestEnvironment
 		check.LogInfo("Testing Pod %q in namespace %q", put.Name, put.Namespace)
 		nonCompliantContainers := put.GetRunAsNonRootFalseContainers(knownContainersToSkip)
 		if len(nonCompliantContainers) == 0 {
-			check.LogInfo("Pod %q is running as non-root", put.Name)
-			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is running as non-root", true))
+			check.LogInfo("Pod %q is configured with RunAsNonRoot SCC parameter set to true for all of its containers", put.Name)
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is configured with RunAsNonRoot SCC parameter set to true for all of its containers", true))
 		} else {
-			check.LogError("Pod %q might be running as root", put.Name)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod might be running as root", false))
+			check.LogError("Pod %q is configured with RunAsNonRoot SCC parameter set to false for some of its containers", put.Name)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is configured with RunAsNonRoot SCC parameter set to false for some of its containers", false))
 			for _, cut := range nonCompliantContainers {
-				check.LogError("Container %q in Pod %q might be running as root", cut.Name, put.Name)
-				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(put.Namespace, put.Name, cut.Name, "Container might be running as root", false))
+				check.LogError("Container %q in Pod %q is configured with RunAsNonRoot SCC parameter set to false", cut.Name, put.Name)
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(put.Namespace, put.Name, cut.Name, "Container is configured with RunAsNonRoot SCC parameter set to false", false))
 			}
 		}
 	}

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -396,33 +396,19 @@ func testSecConRunAsNonRoot(check *checksdb.Check, env *provider.TestEnvironment
 
 	for _, put := range env.Pods {
 		check.LogInfo("Testing Pod %q in namespace %q", put.Name, put.Namespace)
-		if put.IsRunAsNonRoot() {
+		nonCompliantContainers := put.GetRunAsNonRootFalseContainers(knownContainersToSkip)
+		if len(nonCompliantContainers) == 0 {
 			check.LogInfo("Pod %q is running as non-root", put.Name)
 			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is running as non-root", true))
 		} else {
-			check.LogError("Pod %q is running as root", put.Name)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is running as root", false))
-		}
-
-		// We are looking through both the containers and the pods separately to make compliant and non-compliant objects.
-		for _, cut := range put.Containers {
-			check.LogInfo("Testing Container %q", cut)
-			if knownContainersToSkip[cut.Name] {
-				check.LogInfo("Skipping container %q in Pod %q", cut.Name, put.Name)
-				compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(cut.Namespace, cut.Name, "Container is allowed to run as root", true))
-				continue
-			}
-
-			if cut.IsContainerRunAsNonRoot() {
-				check.LogInfo("Container %q in Pod %q is running as non-root", cut.Name, put.Name)
-				compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(cut.Namespace, cut.Name, "Container is running as non-root", true))
-			} else {
-				check.LogError("Container %q in Pod %q is running as root", cut.Name, put.Name)
-				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Container is running as root", false))
+			check.LogError("Pod %q might be running as root", put.Name)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod might be running as root", false))
+			for _, cut := range nonCompliantContainers {
+				check.LogError("Container %q in Pod %q might be running as root", cut.Name, put.Name)
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(put.Namespace, put.Name, cut.Name, "Container might be running as root", false))
 			}
 		}
 	}
-
 	check.SetResult(compliantObjects, nonCompliantObjects)
 }
 


### PR DESCRIPTION
In the current test, the check we check RunAsNonRoot separately for pods then for its containers. However the pod RunAsNonRoot is just a default value for containers so it should not be checked separately. The pod value for RunAsNonRoot is used only if the RunAsNonRoot is not present in the container (nil). 
This PR changes the logic of the test to use the pod configuration as a default value for the container.

see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container

> Set the security context for a Container
> To specify security settings for a Container, include the securityContext field in the Container manifest. The securityContext field is a [SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.31/#securitycontext-v1-core) object. Security settings that you specify for a Container apply only to the individual Container, and they override settings made at the Pod level when there is overlap. Container settings do not affect the Pod's Volumes.