### PR TITLE
Remove loop-related gocritic nolint entries

### DIFF
--- a/cmd/certsuite/claim/compare/testcases/testcases.go
+++ b/cmd/certsuite/claim/compare/testcases/testcases.go
@@ -34,9 +34,8 @@ type DiffReport struct {
 func getTestCasesResultsMap(testSuiteResults claim.TestSuiteResults) map[string]string {
 	testCaseResults := map[string]string{}
 
-	//nolint:gocritic
-	for _, testCase := range testSuiteResults {
-		testCaseResults[testCase.TestID.ID] = testCase.State
+	for testCase := range testSuiteResults {
+		testCaseResults[testSuiteResults[testCase].TestID.ID] = testSuiteResults[testCase].State
 	}
 
 	return testCaseResults

--- a/pkg/checksdb/checksdb.go
+++ b/pkg/checksdb/checksdb.go
@@ -141,14 +141,13 @@ func recordCheckResult(check *Check) {
 // certsuite-claim's Go Client, results are generalized to map[string]interface{}.
 func GetReconciledResults() map[string]claim.Result {
 	resultMap := make(map[string]claim.Result)
-	//nolint:gocritic
-	for key, val := range resultsDB {
+	for key := range resultsDB {
 		// initializes the result map, if necessary
 		if _, ok := resultMap[key]; !ok {
 			resultMap[key] = claim.Result{}
 		}
 
-		resultMap[key] = val
+		resultMap[key] = resultsDB[key]
 	}
 	return resultMap
 }
@@ -223,9 +222,8 @@ func GetTotalTests() int {
 
 func GetTestsCountByState(state string) int {
 	count := 0
-	//nolint:gocritic
-	for _, results := range resultsDB {
-		if results.State == state {
+	for r := range resultsDB {
+		if resultsDB[r].State == state {
 			count++
 		}
 	}


### PR DESCRIPTION
@greyerof pointed out in another PR to remove my `nolint` for gocritic on a loop so I figured I'd go and clear out the rest of them in the test suite.