### PR TITLE
Operand pods autodiscovery

### DIFF
--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -62,6 +62,7 @@ type DiscoveredTestData struct {
 	AllPods                []corev1.Pod
 	ProbePods              []corev1.Pod
 	CSVToPodListMap        map[types.NamespacedName][]*corev1.Pod
+	OperandPods            []*corev1.Pod
 	ResourceQuotaItems     []corev1.ResourceQuota
 	PodDisruptionBudgets   []policyv1.PodDisruptionBudget
 	NetworkPolicies        []networkingv1.NetworkPolicy
@@ -133,7 +134,7 @@ func createLabels(labelStrings []string) (labelObjects []labelObject) {
 
 // DoAutoDiscover finds objects under test
 //
-//nolint:funlen
+//nolint:funlen,gocyclo
 func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData {
 	oc := clientsholder.GetClientsHolder()
 
@@ -196,6 +197,17 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	data.CSVToPodListMap, err = getOperatorCsvPods(data.Csvs)
 	if err != nil {
 		log.Fatal("Failed to get the operator pods, err: %v", err)
+	}
+
+	// Best effort mode autodiscovery for operand (running-only) pods.
+	pods, _ := findPodsByLabels(oc.K8sClient.CoreV1(), nil, data.Namespaces)
+	if err != nil {
+		log.Fatal("Failed to get running pods, err: %v", err)
+	}
+
+	data.OperandPods, err = getOperandPodsFromTestCsvs(data.Csvs, pods)
+	if err != nil {
+		log.Fatal("Failed to get operand pods, err: %v", err)
 	}
 
 	openshiftVersion, err := getOpenshiftVersion(oc.OcpClient)
@@ -354,4 +366,62 @@ func getPodsOwnedByCsv(csvName, operatorNamespace string, client *clientsholder.
 		}
 	}
 	return managedPods, nil
+}
+
+// getOperandPodsFromTestCsvs returns a subset of pods whose owner CRs are managed by any of the testCsvs.
+func getOperandPodsFromTestCsvs(testCsvs []*olmv1Alpha.ClusterServiceVersion, pods []corev1.Pod) ([]*corev1.Pod, error) {
+	// Helper var to store all the managed crds from the operators under test
+	// They map key is "Kind.group/version" or "Kind.APIversion", which should be the same.
+	//   e.g.: "Subscription.operators.coreos.com/v1alpha1"
+	crds := map[string]*olmv1Alpha.ClusterServiceVersion{}
+
+	// First, iterate on each testCsv to fill the helper crds map.
+	for _, csv := range testCsvs {
+		ownedCrds := csv.Spec.CustomResourceDefinitions.Owned
+
+		if len(ownedCrds) == 0 {
+			continue
+		}
+
+		for i := range ownedCrds {
+			crd := &ownedCrds[i]
+
+			_, group, found := strings.Cut(crd.Name, ".")
+			if !found {
+				return nil, fmt.Errorf("failed to parse resources and group form crd name %q", crd.Name)
+			}
+
+			log.Info("CSV %q owns crd %v", csv.Name, crd.Kind+"/"+group+"/"+crd.Version)
+			crds[crd.Kind+"/"+group+"/"+crd.Version] = csv
+		}
+	}
+
+	// Now, iterate on every pod in the list to check whether they're owned by any of the CRs that
+	// the csvs are managing.
+	operandPods := []*corev1.Pod{}
+	for i := range pods {
+		pod := &pods[i]
+		owners, err := podhelper.GetPodTopOwner(pod.Namespace, pod.OwnerReferences)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get top owners of pod %v/%v: %v", pod.Namespace, pod.Name, err)
+		}
+
+		for _, owner := range owners {
+			versionedCrd := owner.Kind + "/" + owner.APIVersion
+
+			var csv *olmv1Alpha.ClusterServiceVersion
+			if csv = crds[versionedCrd]; csv == nil {
+				// The owner is not a CR or it's not a CR owned by any operator under test
+				continue
+			}
+
+			log.Info("Pod %v/%v has owner CR %s of CRD %q (CSV %v)", pod.Namespace, pod.Name,
+				owner.Name, versionedCrd, csv.Name)
+
+			operandPods = append(operandPods, pod)
+			break
+		}
+	}
+
+	return operandPods, nil
 }

--- a/pkg/podhelper/podhelper.go
+++ b/pkg/podhelper/podhelper.go
@@ -65,9 +65,12 @@ func followOwnerReferences(resourceList []*metav1.APIResourceList, dynamicClient
 		// if no owner references, we have reached the top record it
 		if len(ownerReferences) == 0 {
 			topOwners[ownerRef.Name] = TopOwner{APIVersion: ownerRef.APIVersion, Kind: ownerRef.Kind, Name: ownerRef.Name, Namespace: namespace}
-			return nil
-		} else {
-			return followOwnerReferences(resourceList, dynamicClient, topOwners, namespace, ownerReferences)
+			continue
+		}
+
+		err = followOwnerReferences(resourceList, dynamicClient, topOwners, namespace, ownerReferences)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -49,6 +49,7 @@ type Pod struct {
 	SkipNetTests            bool
 	SkipMultusNetTests      bool
 	IsOperator              bool
+	IsOperand               bool
 }
 
 func NewPod(aPod *corev1.Pod) (out Pod) {


### PR DESCRIPTION
This change adds an autodiscovery mechanism for operand pods that "belong" to CSVs/Operators under test. This is a separate and complementary way to the by-label/by-namespace already existing discovery modes.

Usually, operands are deployed by operators by means of a CR. Ideally, operators designers should also flag that CR as owner of those operand pods that are deployed in the cluster.

The autodiscovery mechanism for operand pods creates a list of CRDs owned by the CSVs under test. Then, it iterates over every pod found in the configured namespaces in order to get whether its owner is a CR of any of those CRD types. If so, it's added to the list of pods under test if it wasn't already there.