### PR TITLE
Update GolangCI-lint to v1.62.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -127,6 +127,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.60.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.62.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
 CLAIM_FORMAT_VERSION=$(shell script/get-claim-version.sh)
-GOLANGCI_VERSION=v1.60.3
+GOLANGCI_VERSION=v1.62.2
 LINKER_CERTSUITE_RELEASE_FLAGS=-X github.com/redhat-best-practices-for-k8s/certsuite/pkg/versions.GitCommit=${GIT_COMMIT}
 LINKER_CERTSUITE_RELEASE_FLAGS+= -X github.com/redhat-best-practices-for-k8s/certsuite/pkg/versions.GitRelease=${GIT_RELEASE}
 LINKER_CERTSUITE_RELEASE_FLAGS+= -X github.com/redhat-best-practices-for-k8s/certsuite/pkg/versions.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/pkg/provider/containers_test.go
+++ b/pkg/provider/containers_test.go
@@ -207,7 +207,7 @@ func TestIsTagEmpty(t *testing.T) {
 	}
 }
 
-func TestIsreadOnlyRootFilessystem(t *testing.T) {
+func TestIsreadOnlyRootFilesystem(t *testing.T) {
 	trueVal := true
 	falseVal := false
 	testCases := []struct {


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.62.2