### PR TITLE
Remove legacy RunAsUser vars

### DIFF
--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -111,7 +111,6 @@ const (
 	TestOperatorCrdSchemaIdentifierDocLink              = DocOperatorRequirement
 	TestOperatorCrdVersioningIdentifierDocLink          = DocOperatorRequirement
 	TestOperatorSingleCrdOwnerIdentifierDocLink         = DocOperatorRequirement
-	TestOperatorRunAsUserIDDocLink                      = DocOperatorRequirement
 	TestOperatorRunAsNonRootDocLink                     = DocOperatorRequirement
 	TestOperatorAutomountTokensDocLink                  = DocOperatorRequirement
 	TestOperatorReadOnlyFilesystemDocLink               = DocOperatorRequirement

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -128,7 +128,6 @@ var (
 	TestOperatorOlmSkipRange                          claim.Identifier
 	TestOperatorAutomountTokens                       claim.Identifier
 	TestOperatorRunAsNonRoot                          claim.Identifier
-	TestOperatorRunAsUserID                           claim.Identifier
 	TestOperatorCrdVersioningIdentifier               claim.Identifier
 	TestOperatorCrdSchemaIdentifier                   claim.Identifier
 	TestOperatorSingleCrdOwnerIdentifier              claim.Identifier

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -87,8 +87,6 @@ const (
 
 	OperatorCrdSchemaIdentifierRemediation = `Ensure that the Operator CRD is defined with OpenAPI spec.`
 
-	OperatorRunAsUserID = `Ensure that the user ID of the pods is not 0.`
-
 	OperatorRunAsNonRoot = `Ensure that the pods are running as non root.`
 
 	OperatorAutomountTokens = `Ensure that the pods have the automount service account token disabled.`


### PR DESCRIPTION
Follow up to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2479

These are leftover variables that are unused from when these tests were part of the `operator` suite specifically.