### PR TITLE
Fix for operator-single-crd-owner test case.

### DIFF
--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -317,9 +317,19 @@ func testOperatorSingleCrdOwner(check *checksdb.Check, env *provider.TestEnviron
 	for i := range env.Operators {
 		operator := env.Operators[i]
 		ownedCrds := operator.Csv.Spec.CustomResourceDefinitions.Owned
+
+		// Helper map to filter out different versions of the same CRD name.
+		uniqueOnwnedCrds := map[string]struct{}{}
 		for j := range ownedCrds {
-			crdOwners[ownedCrds[j].Name] = append(crdOwners[ownedCrds[j].Name], operator.Name)
+			uniqueOnwnedCrds[ownedCrds[j].Name] = struct{}{}
 		}
+
+		// Now we can append the operator as CRD owner
+		for crdName := range uniqueOnwnedCrds {
+			crdOwners[crdName] = append(crdOwners[crdName], operator.Name)
+		}
+
+		check.LogInfo("CRDs owned by operator %s: %+v", operator.Name, uniqueOnwnedCrds)
 	}
 
 	// Flag those that are owned by more than one operator


### PR DESCRIPTION
As reported in issue https://github.com/redhat-best-practices-for-k8s/certsuite/issues/2593, the test case operator-single-crd-owner might produce false positives.

The original implementation didn't handle cases where a single CRD name can have more than one version.

I was able to test the false positive (original code) and this fix in OCP 4.16.3 with package "amq-broker-rhel8" which also owns same CRD with different versions.