### PR TITLE
Add 4.18 to the RHCOS script

### DIFF
--- a/script/rhcos_versions.sh
+++ b/script/rhcos_versions.sh
@@ -3,7 +3,7 @@
 set -x
 set -e
 
-CHANNELS=(4.17 4.16 4.15 4.14 4.13 4.12 4.11 4.10 4.9 4.8 4.7 4.6 4.5 4.4 4.3 4.2 4.1)
+CHANNELS=(4.18 4.17 4.16 4.15 4.14 4.13 4.12 4.11 4.10 4.9 4.8 4.7 4.6 4.5 4.4 4.3 4.2 4.1)
 CHANNEL_TYPES=(stable candidate)
 
 rm -f ./tests/platform/operatingsystem/files/rhcos_version_map &>/dev/null


### PR DESCRIPTION
`4.18` candidates are starting to show up in the mirrors.  Time to add this to the daily script.