### PR TITLE
Fix for access-control-security-context-non-root-user-id-check

### DIFF
--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -197,10 +197,26 @@ func (c *Container) IsReadOnlyRootFilesystem(logger *log.Logger) bool {
 
 func (c *Container) IsContainerRunAsNonRoot(podRunAsNonRoot *bool) (isContainerRunAsNonRoot bool, reason string) {
 	if c.SecurityContext != nil && c.SecurityContext.RunAsNonRoot != nil {
-		return *c.SecurityContext.RunAsNonRoot, fmt.Sprintf("RunAsNonRoot is set to %t at the container level, overriding a %v value defined at pod level.", *c.SecurityContext.RunAsNonRoot, stringhelper.BoolToString(podRunAsNonRoot))
+		return *c.SecurityContext.RunAsNonRoot, fmt.Sprintf("RunAsNonRoot is set to %t at the container level, overriding a %v value defined at pod level.",
+			*c.SecurityContext.RunAsNonRoot, stringhelper.PointerToString(podRunAsNonRoot))
 	}
+
 	if podRunAsNonRoot != nil {
 		return *podRunAsNonRoot, fmt.Sprintf("RunAsNonRoot is set to nil at container level and inheriting a %t value from the pod level RunAsNonRoot setting.", *podRunAsNonRoot)
 	}
+
 	return false, "RunAsNonRoot set to nil at pod and container level"
+}
+
+func (c *Container) IsContainerRunAsNonRootUserID(podRunAsNonRootUserID *int64) (isContainerRunAsNonRootUserID bool, reason string) {
+	if c.SecurityContext != nil && c.SecurityContext.RunAsUser != nil {
+		return *c.SecurityContext.RunAsUser != 0, fmt.Sprintf("RunAsUser is set to %v at the container level, overriding a %s value defined at pod level.",
+			*c.SecurityContext.RunAsUser, stringhelper.PointerToString(podRunAsNonRootUserID))
+	}
+
+	if podRunAsNonRootUserID != nil {
+		return *podRunAsNonRootUserID != 0, fmt.Sprintf("RunAsUser is set to nil at container level and inheriting a %v value from the pod level RunAsUser setting.", *podRunAsNonRootUserID)
+	}
+
+	return false, "RunAsUser set to nil at pod and container level"
 }

--- a/pkg/stringhelper/stringhelper.go
+++ b/pkg/stringhelper/stringhelper.go
@@ -67,9 +67,35 @@ func RemoveEmptyStrings(s []string) []string {
 	return r
 }
 
-func BoolToString(b *bool) string {
-	if b == nil {
+// PointerToString returns the default string representation of the value pointer by p, mainly
+// used in log traces to print k8s resources' pointer fields.
+// If p is a nil pointer, no matter the type, it will return the string "nil".
+//
+// # Example 1
+//
+//	var b* bool
+//	PointerToString(b) -> returns "nil"
+//
+// # Example 2
+//
+//	b := true
+//	bTrue := &b
+//	PointerToString(bTrue) -> returns "true"
+//
+// # Example 3
+//
+//	var num *int
+//	PointerToString(num) -> returns "nil"
+//
+// # Example 4
+//
+//	num := 1984
+//	num1984 := &num
+//	PointerToString(num1984) -> returns "1984"
+func PointerToString[T any](p *T) string {
+	if p == nil {
 		return "nil"
+	} else {
+		return fmt.Sprint(*p)
 	}
-	return fmt.Sprintf("%t", *b)
 }

--- a/pkg/stringhelper/stringhelper_test.go
+++ b/pkg/stringhelper/stringhelper_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"k8s.io/utils/ptr"
 )
 
 type otherString string
@@ -187,5 +188,50 @@ func TestSubSlice(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert.Equal(t, tc.expectedOutput, SubSlice(tc.testSliceA, tc.testSliceB))
+	}
+}
+
+func TestPointerToString(t *testing.T) {
+	const wantNil = "nil"
+
+	var want string
+
+	// pointer to bool
+	var boolPointer *bool
+	want = wantNil
+	if got := PointerToString(boolPointer); got != want {
+		t.Errorf("PointerToString() = %v, want %v", got, want)
+	}
+
+	boolPointer = ptr.To(true)
+	want = "true"
+	if got := PointerToString(boolPointer); got != want {
+		t.Errorf("PointerToString() = %v, want %v", got, want)
+	}
+
+	// pointer to number
+	var numPointer *int64
+	want = wantNil
+	if got := PointerToString(numPointer); got != want {
+		t.Errorf("PointerToString() = %v, want %v", got, want)
+	}
+
+	numPointer = ptr.To(int64(1984))
+	want = "1984"
+	if got := PointerToString(numPointer); got != want {
+		t.Errorf("PointerToString() = %v, want %v", got, want)
+	}
+
+	// pointer to string
+	var stringPointer *string
+	want = "nil"
+	if got := PointerToString(stringPointer); got != want {
+		t.Errorf("PointerToString() = %v, want %v", got, want)
+	}
+
+	stringPointer = ptr.To("hello, world!")
+	want = "hello, world!"
+	if got := PointerToString(stringPointer); got != want {
+		t.Errorf("PointerToString() = %v, want %v", got, want)
 	}
 }

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -355,37 +355,23 @@ func testBpfCapability(check *checksdb.Check, env *provider.TestEnvironment) {
 func testSecConRootUserID(check *checksdb.Check, env *provider.TestEnvironment) {
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject
+
 	for _, put := range env.Pods {
-		check.LogInfo("Testing Pod %q", put)
-		if put.IsRunAsUserID(0) {
-			check.LogError("Root user detected (RunAsUser uid=0) in Pod %q", put)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Root User detected (RunAsUser uid=0)", false))
+		check.LogInfo("Testing Pod %q in namespace %q", put.Name, put.Namespace)
+		nonCompliantContainers, nonComplianceReason := put.GetRunAsNonRootUserIDContainers(knownContainersToSkip)
+		if len(nonCompliantContainers) == 0 {
+			check.LogInfo("Pod %q is configured with RunAsUser SCC parameter different than 0 for all of its containers", put.Name)
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is configured with RunAsUser SCC parameter different than 0 for all of its containers", true))
 		} else {
-			check.LogInfo("Non-root user detected in Pod %q", put)
-			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Root User not detected (RunAsUser uid=0)", true))
-		}
-
-		for _, cut := range put.Containers {
-			check.LogInfo("Testing Container %q", cut)
-			if knownContainersToSkip[cut.Name] {
-				check.LogInfo("Skipping container %q in Pod %q", cut.Name, put.Name)
-				compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, cut.Name, "Container is allowed to run as root", true))
-				continue
-			}
-
-			// Check the container level RunAsUser parameter
-			if cut.SecurityContext != nil && cut.SecurityContext.RunAsUser != nil {
-				if *(cut.SecurityContext.RunAsUser) == 0 {
-					check.LogError("Root user detected (RunAsUser uid=0) in Container %q (%q)", cut.Name, put)
-					nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(put.Namespace, put.Name, cut.Name, "Root User detected (RunAsUser uid=0)", false))
-				} else {
-					check.LogInfo("Non-root user detected (RunAsUser uid=0) in Container %q (%q)", cut, put)
-					compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(put.Namespace, put.Name, cut.Name, "Root User not detected (RunAsUser uid=0)", true))
-				}
+			check.LogError("Pod %q is configured with RunAsUser SCC parameter equal to 0 for some of its containers", put.Name)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is configured with RunAsNonRoot SCC parameter set to false for some of its containers", false))
+			for index := range nonCompliantContainers {
+				check.LogError("In Container %q of Pod %q, %s", nonCompliantContainers[index].Name, put.Name, nonComplianceReason[index])
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(put.Namespace, put.Name,
+					nonCompliantContainers[index].Name, fmt.Sprintf("In Container %q of Pod %q, %s", nonCompliantContainers[index].Name, put.Name, nonComplianceReason[index]), false))
 			}
 		}
 	}
-
 	check.SetResult(compliantObjects, nonCompliantObjects)
 }
 


### PR DESCRIPTION
This test case had the same issue that was fixed here: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2557
With the prior implementation, the test case failed if pod's level SCC's runAsUser was set to 0 but container's SCC runAsUser was set to any non-zero value, like 1001. This should pass as container's SCC runAsUser value takes precedence over pod's one.

I followed the same approach: the field RunAsUser in container's SCC takes precedence over pod's level one.

Also, replaced the helper function stringhelper.BoolToString with stringhelper.PointerToString(), which works for any type now, as long as it has a stringer method implementation.