### PR TITLE
Add 4.18 to beta versions slice

### DIFF
--- a/pkg/compatibility/compatibility.go
+++ b/pkg/compatibility/compatibility.go
@@ -50,7 +50,7 @@ type VersionInfo struct {
 }
 
 var (
-	ocpBetaVersions   = []string{"4.13", "4.14", "4.15", "4.16", "4.17"}
+	ocpBetaVersions   = []string{"4.13", "4.14", "4.15", "4.16", "4.17", "4.18"}
 	ocpLifeCycleDates = map[string]VersionInfo{
 		// TODO: Adjust all of these periodically to make sure they are up to date with the lifecycle
 		// update documentation.


### PR DESCRIPTION
Follow up to #2613 

The beta versions slice needed to be adjusted as well.