### PR TITLE
CSVs autodiscovery fix.

### DIFF
--- a/.github/workflows/qe-ocp-pre-main.yaml
+++ b/.github/workflows/qe-ocp-pre-main.yaml
@@ -90,7 +90,7 @@ jobs:
         with:
           repository: ${{ env.QE_REPO }}
           path: certsuite-qe
-          ref: fix_install_source_tc
+          ref: main
 
       - name: Preemptively potential QE namespaces
         run: ./scripts/delete-namespaces.sh

--- a/.github/workflows/qe-ocp-pre-main.yaml
+++ b/.github/workflows/qe-ocp-pre-main.yaml
@@ -90,7 +90,7 @@ jobs:
         with:
           repository: ${{ env.QE_REPO }}
           path: certsuite-qe
-          ref: main
+          ref: fix_install_source_tc
 
       - name: Preemptively potential QE namespaces
         run: ./scripts/delete-namespaces.sh


### PR DESCRIPTION
PR #2479 fixed the autodiscovery of operator's pods and also added them to the pods-under-test list. The problem is that, when using namespace discovery mode, it was also adding every cluster-wide operator's controller pods to that list.

With this change, the operator (controller's pod) must be running in one of the configured/test namespaces in order to consider that CSV as part of the operators under test.