### PR TITLE
Catalogsource unit testing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@ require k8s.io/client-go v0.32.0
 require (
 	github.com/mittwald/go-helm-client v0.12.16
 	github.com/openshift/api v3.9.0+incompatible
-	github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f
+	github.com/openshift/client-go v0.0.0-20250106104058-89709a455e2a
 	github.com/operator-framework/api v0.27.0
-	github.com/operator-framework/operator-lifecycle-manager v0.30.0
+	github.com/operator-framework/operator-lifecycle-manager v0.22.0
 	github.com/pkg/errors v0.9.1 // indirect
 	helm.sh/helm/v3 v3.16.4
 	k8s.io/api v0.32.0
@@ -189,9 +189,9 @@ require (
 	go.opentelemetry.io/proto/otlp v1.3.1 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go4.org v0.0.0-20200104003542-c7e774b10ea0 // indirect
-	golang.org/x/crypto v0.31.0 // indirect
+	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa // indirect
-	golang.org/x/net v0.33.0 // indirect
+	golang.org/x/net v0.34.0 // indirect
 	golang.org/x/oauth2 v0.25.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/sys v0.29.0 // indirect
@@ -223,7 +223,7 @@ require (
 	sigs.k8s.io/kube-storage-version-migrator v0.0.6-0.20230721195810-5c8923c5ff96 // indirect
 	sigs.k8s.io/kustomize/api v0.18.0 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.18.1 // indirect
-	sigs.k8s.io/structured-merge-diff/v4 v4.4.2 // indirect
+	sigs.k8s.io/structured-merge-diff/v4 v4.5.0 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
 )
 
@@ -248,9 +248,11 @@ require (
 	golang.org/x/term v0.28.0
 	google.golang.org/api v0.216.0
 	k8s.io/kubectl v0.32.0
-	k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738
+	k8s.io/utils v0.0.0-20241210054802-24370beab758
 )
 
 replace github.com/redhat-openshift-ecosystem/openshift-preflight => github.com/redhat-openshift-ecosystem/openshift-preflight v0.0.0-20241211152839-f787b66d23c7
 
-replace github.com/openshift/api => github.com/openshift/api v0.0.0-20241024191314-684b2b1679ba
+replace github.com/openshift/api => github.com/openshift/api v0.0.0-20250108172834-78bd56dba39b
+
+replace github.com/operator-framework/operator-lifecycle-manager => github.com/operator-framework/operator-lifecycle-manager v0.30.0

--- a/go.sum
+++ b/go.sum
@@ -421,8 +421,6 @@ github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/openshift/api v0.0.0-20250108172834-78bd56dba39b h1:Nt4V9k5pyw2CiUL2L5IFlstvURf+12Z7uSzi/v30UpE=
 github.com/openshift/api v0.0.0-20250108172834-78bd56dba39b/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
-github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f h1:FRc0bVNWprihWS0GqQWzb3dY4dkCwpOP3mDw5NwSoR4=
-github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f/go.mod h1:KiZi2mJRH1TOJ3FtBDYS6YvUL30s/iIXaGSUrSa36mo=
 github.com/openshift/client-go v0.0.0-20250106104058-89709a455e2a h1:8lwO4lGTwHuVXsIeFoW3t7AEBROW5quMj5YjH9jF+98=
 github.com/openshift/client-go v0.0.0-20250106104058-89709a455e2a/go.mod h1:34qRf2MsrJKXKAL8qxIkxZ3O5G+YhOB7foCR04H26JE=
 github.com/openshift/library-go v0.0.0-20231020125025-211b32f1a1f2 h1:TWG/YVRhSvjYq8iIwJ2Wpoopgg0zuh+ZAl1RSm4J8Z0=

--- a/go.sum
+++ b/go.sum
@@ -419,10 +419,12 @@ github.com/opencontainers/image-spec v1.1.0 h1:8SG7/vwALn54lVB/0yZ/MMwhFrPYtpEHQ
 github.com/opencontainers/image-spec v1.1.0/go.mod h1:W4s4sFTMaBeK1BQLXbG4AdM2szdn85PY75RI83NrTrM=
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
-github.com/openshift/api v0.0.0-20241024191314-684b2b1679ba h1:jyeZlKhyeR9mdbQKbTl5oP5nz0vAoy1Q+xn+1PwgODE=
-github.com/openshift/api v0.0.0-20241024191314-684b2b1679ba/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
+github.com/openshift/api v0.0.0-20250108172834-78bd56dba39b h1:Nt4V9k5pyw2CiUL2L5IFlstvURf+12Z7uSzi/v30UpE=
+github.com/openshift/api v0.0.0-20250108172834-78bd56dba39b/go.mod h1:Shkl4HanLwDiiBzakv+con/aMGnVE2MAGvoKp5oyYUo=
 github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f h1:FRc0bVNWprihWS0GqQWzb3dY4dkCwpOP3mDw5NwSoR4=
 github.com/openshift/client-go v0.0.0-20241001162912-da6d55e4611f/go.mod h1:KiZi2mJRH1TOJ3FtBDYS6YvUL30s/iIXaGSUrSa36mo=
+github.com/openshift/client-go v0.0.0-20250106104058-89709a455e2a h1:8lwO4lGTwHuVXsIeFoW3t7AEBROW5quMj5YjH9jF+98=
+github.com/openshift/client-go v0.0.0-20250106104058-89709a455e2a/go.mod h1:34qRf2MsrJKXKAL8qxIkxZ3O5G+YhOB7foCR04H26JE=
 github.com/openshift/library-go v0.0.0-20231020125025-211b32f1a1f2 h1:TWG/YVRhSvjYq8iIwJ2Wpoopgg0zuh+ZAl1RSm4J8Z0=
 github.com/openshift/library-go v0.0.0-20231020125025-211b32f1a1f2/go.mod h1:ZFwNwC3opc/7aOvzUbU95zp33Lbxet48h80ryH3p6DY=
 github.com/openshift/machine-config-operator v0.0.1-0.20231024085435-7e1fb719c1ba h1:WM6K+m2xMAwbQDetKGhV/Rd8yukF3AsU1z74cqoWrz0=
@@ -628,8 +630,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
-golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
+golang.org/x/crypto v0.32.0/go.mod h1:ZnnJkOaASj8g0AjIduWNlq2NRxL0PlBrbKVyZ6V/Ugc=
 golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
 golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -647,8 +649,8 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
-golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
-golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/net v0.34.0 h1:Mb7Mrk043xzHgnRM88suvJFwzVrRfHEHJEl5/71CKw0=
+golang.org/x/net v0.34.0/go.mod h1:di0qlW3YNM5oh6GqDGQr92MyTozJPmybPK4Ev/Gm31k=
 golang.org/x/oauth2 v0.25.0 h1:CY4y7XT9v0cRI9oupztF8AgiIu99L/ksR/Xp/6jrZ70=
 golang.org/x/oauth2 v0.25.0/go.mod h1:XYTD2NtWslqkgxebSiOHnXEap4TF09sJSc7H1sXbhtI=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -769,8 +771,8 @@ k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f h1:GA7//TjRY9yWGy1poLzYYJ
 k8s.io/kube-openapi v0.0.0-20241105132330-32ad38e42d3f/go.mod h1:R/HEjbvWI0qdfb8viZUeVZm0X6IZnxAydC7YU42CMw4=
 k8s.io/kubectl v0.32.0 h1:rpxl+ng9qeG79YA4Em9tLSfX0G8W0vfaiPVrc/WR7Xw=
 k8s.io/kubectl v0.32.0/go.mod h1:qIjSX+QgPQUgdy8ps6eKsYNF+YmFOAO3WygfucIqFiE=
-k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738 h1:M3sRQVHv7vB20Xc2ybTt7ODCeFj6JSWYFzOFnYeS6Ro=
-k8s.io/utils v0.0.0-20241104100929-3ea5e8cea738/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+k8s.io/utils v0.0.0-20241210054802-24370beab758 h1:sdbE21q2nlQtFh65saZY+rRM6x6aJJI8IUa1AmH/qa0=
+k8s.io/utils v0.0.0-20241210054802-24370beab758/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 modernc.org/libc v1.37.6 h1:orZH3c5wmhIQFTXF+Nt+eeauyd+ZIt2BX6ARe+kD+aw=
 modernc.org/libc v1.37.6/go.mod h1:YAXkAZ8ktnkCKaN9sw/UDeUVkGYJ/YquGO4FTi5nmHE=
 modernc.org/mathutil v1.6.0 h1:fRe9+AmYlaej+64JsEEhoWuAYBkOtQiMEU7n/XgfYi4=
@@ -793,7 +795,7 @@ sigs.k8s.io/kustomize/api v0.18.0 h1:hTzp67k+3NEVInwz5BHyzc9rGxIauoXferXyjv5lWPo
 sigs.k8s.io/kustomize/api v0.18.0/go.mod h1:f8isXnX+8b+SGLHQ6yO4JG1rdkZlvhaCf/uZbLVMb0U=
 sigs.k8s.io/kustomize/kyaml v0.18.1 h1:WvBo56Wzw3fjS+7vBjN6TeivvpbW9GmRaWZ9CIVmt4E=
 sigs.k8s.io/kustomize/kyaml v0.18.1/go.mod h1:C3L2BFVU1jgcddNBE1TxuVLgS46TjObMwW5FT9FcjYo=
-sigs.k8s.io/structured-merge-diff/v4 v4.4.2 h1:MdmvkGuXi/8io6ixD5wud3vOLwc1rj0aNqRlpuvjmwA=
-sigs.k8s.io/structured-merge-diff/v4 v4.4.2/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
+sigs.k8s.io/structured-merge-diff/v4 v4.5.0 h1:nbCitCK2hfnhyiKo6uf2HxUPTCodY6Qaf85SbDIaMBk=
+sigs.k8s.io/structured-merge-diff/v4 v4.5.0/go.mod h1:N8f93tFZh9U6vpxwRArLiikrE5/2tiu1w1AGfACIGE4=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=
 sigs.k8s.io/yaml v1.4.0/go.mod h1:Ejl7/uTz7PSA4eKMyQCUTnhZYNmLIl+5c2lQPGR2BPY=

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -163,16 +163,16 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	if err != nil {
 		log.Fatal("Cannot get namespaces, err: %v", err)
 	}
-	data.AllSubscriptions = findSubscriptions(oc.OlmClient, []string{""})
-	data.AllCsvs, err = getAllOperators(oc.OlmClient)
+	data.AllSubscriptions = findSubscriptions(oc.OlmClient.OperatorsV1alpha1(), []string{""})
+	data.AllCsvs, err = getAllOperators(oc.OlmClient.OperatorsV1alpha1())
 	if err != nil {
 		log.Error("Cannot get operators, err: %v", err)
 	}
-	data.AllInstallPlans = getAllInstallPlans(oc.OlmClient)
-	data.AllCatalogSources = getAllCatalogSources(oc.OlmClient)
+	data.AllInstallPlans = getAllInstallPlans(oc.OlmClient.OperatorsV1alpha1())
+	data.AllCatalogSources = getAllCatalogSources(oc.OlmClient.OperatorsV1alpha1())
 	log.Info("Collected %d catalog sources during autodiscovery", len(data.AllCatalogSources))
 
-	data.AllPackageManifests = getAllPackageManifests(oc.OlmPkgClient)
+	data.AllPackageManifests = getAllPackageManifests(oc.OlmPkgClient.PackageManifests(""))
 
 	data.Namespaces = namespacesListToStringList(config.TargetNameSpaces)
 	data.Pods, data.AllPods = findPodsByLabels(oc.K8sClient.CoreV1(), podsUnderTestLabelsObjects, data.Namespaces)
@@ -201,8 +201,8 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	data.Crds = FindTestCrdNames(data.AllCrds, config.CrdFilters)
 
 	data.ScaleCrUnderTest = GetScaleCrUnderTest(data.Namespaces, data.Crds)
-	data.Csvs = findOperatorsByLabels(oc.OlmClient, operatorsUnderTestLabelsObjects, config.TargetNameSpaces)
-	data.Subscriptions = findSubscriptions(oc.OlmClient, data.Namespaces)
+	data.Csvs = findOperatorsByLabels(oc.OlmClient.OperatorsV1alpha1(), operatorsUnderTestLabelsObjects, config.TargetNameSpaces)
+	data.Subscriptions = findSubscriptions(oc.OlmClient.OperatorsV1alpha1(), data.Namespaces)
 	data.HelmChartReleases = getHelmList(oc.RestConfig, data.Namespaces)
 
 	// Get all operator pods

--- a/pkg/autodiscover/autodiscover_operators_test.go
+++ b/pkg/autodiscover/autodiscover_operators_test.go
@@ -5,11 +5,18 @@ package autodiscover
 import (
 	"testing"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/configuration"
 	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+
+	olmv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	fakeolmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+	olmpkgv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	fakeolmpkgv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/client/clientset/versioned/fake"
 )
 
 func TestGetAllNamespaces(t *testing.T) {
@@ -51,5 +58,299 @@ func TestGetAllNamespaces(t *testing.T) {
 		namespaces, err := getAllNamespaces(clientSet.CoreV1())
 		assert.Nil(t, err)
 		assert.Equal(t, tc.expectedNamespaces, namespaces)
+	}
+}
+
+func TestGetAllCatalogSources(t *testing.T) {
+	generateCatalogSource := func(name string) *olmv1alpha1.CatalogSource {
+		return &olmv1alpha1.CatalogSource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+	}
+
+	testCases := []struct {
+		testCatalogSources []string
+	}{
+		{
+			testCatalogSources: []string{"cs1"},
+		},
+		{
+			testCatalogSources: []string{"cs1", "cs2"},
+		},
+		{
+			testCatalogSources: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		// Generate the catalog sources for the test
+		var testRuntimeObjects []runtime.Object
+		for _, n := range tc.testCatalogSources {
+			testRuntimeObjects = append(testRuntimeObjects, generateCatalogSource(n))
+		}
+
+		client := fakeolmv1alpha1.NewSimpleClientset(testRuntimeObjects...)
+		catalogSources := getAllCatalogSources(client.OperatorsV1alpha1())
+		assert.Equal(t, len(tc.testCatalogSources), len(catalogSources))
+		for i := range catalogSources {
+			assert.Equal(t, tc.testCatalogSources[i], catalogSources[i].Name)
+		}
+	}
+}
+
+func TestGetAllInstallPlans(t *testing.T) {
+	generateInstallPlan := func(name string) *olmv1alpha1.InstallPlan {
+		return &olmv1alpha1.InstallPlan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+	}
+
+	testCases := []struct {
+		testInstallPlans []string
+	}{
+		{
+			testInstallPlans: []string{"ip1"},
+		},
+		{
+			testInstallPlans: []string{"ip1", "ip2"},
+		},
+		{
+			testInstallPlans: []string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		// Generate the install plans for the test
+		var testRuntimeObjects []runtime.Object
+		for _, n := range tc.testInstallPlans {
+			testRuntimeObjects = append(testRuntimeObjects, generateInstallPlan(n))
+		}
+
+		client := fakeolmv1alpha1.NewSimpleClientset(testRuntimeObjects...)
+		installPlans := getAllInstallPlans(client.OperatorsV1alpha1())
+		assert.Equal(t, len(tc.testInstallPlans), len(installPlans))
+		for i := range installPlans {
+			assert.Equal(t, tc.testInstallPlans[i], installPlans[i].Name)
+		}
+	}
+}
+
+func TestGetAllPackageManifests(t *testing.T) {
+	generatePackageManifest := func(name string) *olmpkgv1.PackageManifest {
+		return &olmpkgv1.PackageManifest{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+	}
+
+	testCases := []struct {
+		testPackageManifests []string
+	}{
+		{testPackageManifests: []string{"pm1"}},
+		{testPackageManifests: []string{"pm1", "pm2"}},
+		{testPackageManifests: []string{}},
+	}
+
+	for _, tc := range testCases {
+		// Generate the package manifests for the test
+		var testRuntimeObjects []runtime.Object
+		for _, n := range tc.testPackageManifests {
+			testRuntimeObjects = append(testRuntimeObjects, generatePackageManifest(n))
+		}
+
+		client := fakeolmpkgv1.NewSimpleClientset(testRuntimeObjects...)
+		packageManifests := getAllPackageManifests(client.OperatorsV1().PackageManifests(""))
+		assert.Equal(t, len(tc.testPackageManifests), len(packageManifests))
+		for i := range packageManifests {
+			assert.Equal(t, tc.testPackageManifests[i], packageManifests[i].Name)
+		}
+	}
+}
+
+func TestFindSubscriptions(t *testing.T) {
+	generateSubscription := func(name, namespace string) *olmv1alpha1.Subscription {
+		return &olmv1alpha1.Subscription{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	}
+
+	testCases := []struct {
+		testSubscriptions []string
+	}{
+		{testSubscriptions: []string{"sub1"}},
+		{testSubscriptions: []string{"sub1", "sub2"}},
+		{testSubscriptions: []string{}},
+	}
+
+	for _, tc := range testCases {
+		// Generate the subscriptions for the test
+		var testRuntimeObjects []runtime.Object
+		for _, n := range tc.testSubscriptions {
+			testRuntimeObjects = append(testRuntimeObjects, generateSubscription(n, "default"))
+		}
+
+		client := fakeolmv1alpha1.NewSimpleClientset(testRuntimeObjects...)
+		subscriptions := findSubscriptions(client.OperatorsV1alpha1(), []string{""})
+		assert.Equal(t, len(tc.testSubscriptions), len(subscriptions))
+		for i := range subscriptions {
+			assert.Equal(t, tc.testSubscriptions[i], subscriptions[i].Name)
+		}
+	}
+}
+
+func TestGetAllOperators(t *testing.T) {
+	generateClusterServiceVersion := func(name string) *olmv1alpha1.ClusterServiceVersion {
+		return &olmv1alpha1.ClusterServiceVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+		}
+	}
+
+	testCases := []struct {
+		testClusterServiceVersions []string
+	}{
+		{testClusterServiceVersions: []string{"csv1"}},
+		{testClusterServiceVersions: []string{"csv1", "csv2"}},
+		{testClusterServiceVersions: []string{}},
+	}
+
+	for _, tc := range testCases {
+		// Generate the cluster service versions for the test
+		var testRuntimeObjects []runtime.Object
+		for _, n := range tc.testClusterServiceVersions {
+			testRuntimeObjects = append(testRuntimeObjects, generateClusterServiceVersion(n))
+		}
+
+		client := fakeolmv1alpha1.NewSimpleClientset(testRuntimeObjects...)
+		clusterServiceVersions, err := getAllOperators(client.OperatorsV1alpha1())
+		assert.Nil(t, err)
+		assert.Equal(t, len(tc.testClusterServiceVersions), len(clusterServiceVersions))
+		for i := range clusterServiceVersions {
+			assert.Equal(t, tc.testClusterServiceVersions[i], clusterServiceVersions[i].Name)
+		}
+	}
+}
+
+func TestIsIstioServiceMeshInstalled(t *testing.T) {
+	generateDeployment := func(name, namespace string) *appsv1.Deployment {
+		return &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	}
+
+	testCases := []struct {
+		testDeployment *appsv1.Deployment
+		expectedResult bool
+	}{
+		{
+			testDeployment: generateDeployment("istiod", "istio-system"),
+			expectedResult: true,
+		},
+		{
+			testDeployment: generateDeployment("istiod", "default"),
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		// Generate the deployment for the test
+		clientSet := fake.NewSimpleClientset(tc.testDeployment)
+		result := isIstioServiceMeshInstalled(clientSet.AppsV1(), []string{"istio-system"})
+		assert.Equal(t, tc.expectedResult, result)
+	}
+
+	result := isIstioServiceMeshInstalled(nil, []string{"not-istio-system"})
+	assert.False(t, result)
+}
+
+func TestFindOperatorsMatchingAtLeastOneLabel(t *testing.T) {
+	generateClusterServiceVersion := func(name, namespace string) *olmv1alpha1.ClusterServiceVersion {
+		return &olmv1alpha1.ClusterServiceVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"key": "value",
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testClusterServiceVersions []string
+	}{
+		{testClusterServiceVersions: []string{"csv1"}},
+		{testClusterServiceVersions: []string{"csv1", "csv2"}},
+		{testClusterServiceVersions: []string{}},
+	}
+
+	for _, tc := range testCases {
+		// Generate the cluster service versions for the test
+		var testRuntimeObjects []runtime.Object
+		for _, n := range tc.testClusterServiceVersions {
+			testRuntimeObjects = append(testRuntimeObjects, generateClusterServiceVersion(n, "default"))
+		}
+
+		client := fakeolmv1alpha1.NewSimpleClientset(testRuntimeObjects...)
+		labels := []labelObject{{LabelKey: "key", LabelValue: "value"}}
+		clusterServiceVersions := findOperatorsMatchingAtLeastOneLabel(client.OperatorsV1alpha1(), labels, configuration.Namespace{Name: "default"})
+		assert.Equal(t, len(tc.testClusterServiceVersions), len(clusterServiceVersions.Items))
+		for i := range clusterServiceVersions.Items {
+			assert.Equal(t, tc.testClusterServiceVersions[i], clusterServiceVersions.Items[i].Name)
+		}
+	}
+}
+
+func TestFindOperatorsByLabels(t *testing.T) {
+	generateClusterServiceVersion := func(name, namespace string) *olmv1alpha1.ClusterServiceVersion {
+		return &olmv1alpha1.ClusterServiceVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"olm.operatorNamespace": "default",
+				},
+				Labels: map[string]string{
+					"key": "value",
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testClusterServiceVersions []string
+	}{
+		{testClusterServiceVersions: []string{"csv1"}},
+		{testClusterServiceVersions: []string{"csv1", "csv2"}},
+		{testClusterServiceVersions: []string{}},
+	}
+
+	for _, tc := range testCases {
+		// Generate the cluster service versions for the test
+		var testRuntimeObjects []runtime.Object
+		for _, n := range tc.testClusterServiceVersions {
+			testRuntimeObjects = append(testRuntimeObjects, generateClusterServiceVersion(n, "default"))
+		}
+
+		client := fakeolmv1alpha1.NewSimpleClientset(testRuntimeObjects...)
+		labels := []labelObject{{LabelKey: "key", LabelValue: "value"}}
+		namespaces := []configuration.Namespace{{Name: "default"}}
+		clusterServiceVersions := findOperatorsByLabels(client.OperatorsV1alpha1(), labels, namespaces)
+		assert.Equal(t, len(tc.testClusterServiceVersions), len(clusterServiceVersions))
+		for i := range clusterServiceVersions {
+			assert.Equal(t, tc.testClusterServiceVersions[i], clusterServiceVersions[i].Name)
+		}
 	}
 }


### PR DESCRIPTION
Switches the following funcs to use more specific interfaces:
- findOperatorsMatchingAtLeastOneLabel
- getAllOperators
- findOperatorsByLabels
- findSubscriptions
- getAllInstallPlans
- getAllPackageManifests

Pins the version of the `operator-lifecycle-manager` library to v0.30.0.  Updates to the `github.com/openshift/api` library to latest as well.  For some reason, if you try to update the openshift/api library by itself, it downgrades the olm library to v0.27.0 without explanation.