### PR TITLE
Remove 'main' push trigger from CRC YAML

### DIFF
--- a/.github/workflows/qe-ocp-hosted.yml
+++ b/.github/workflows/qe-ocp-hosted.yml
@@ -3,8 +3,6 @@
 name: CRC Tests
 
 on:
-  push:
-    branches: [ main ]
   schedule:
     - cron: '0 0 * * *'
   workflow_dispatch:


### PR DESCRIPTION
This was adding too many jobs to our 20 slot free tier runners.