### PR TITLE
Experiment with arm64 free tier runners

### DIFF
--- a/.github/actions/setup-partner-cluster/action.yml
+++ b/.github/actions/setup-partner-cluster/action.yml
@@ -15,40 +15,15 @@ runs:
         repository: redhat-best-practices-for-k8s/certsuite-sample-workload
         path: certsuite-sample-workload
 
-    - name: Check if /etc/docker/daemon.json exists and if not, create it.
-      shell: bash
-      run: |
-        if [ ! -f /etc/docker/daemon.json ]; then
-          echo '{}' | sudo tee /etc/docker/daemon.json
-        fi
-
-    - name: Bootstrap cluster and docker
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
+    - name: Setup quick-k8s cluster
+      uses: palmsoftware/quick-k8s@v0.0.18
       with:
-        timeout_minutes: 90
-        max_attempts: 3
-        command: cd ${GITHUB_WORKSPACE}/certsuite-sample-workload; make bootstrap-cluster; make bootstrap-docker-ubuntu-local
-
-    - name: Mount docker volume to /mnt/sdb
-      shell: bash
-      run: |
-          df -h
-          lsblk
-          if [ ! -d /mnt/docker-storage ]; then
-            sudo mkdir /mnt/docker-storage
-          fi
-          sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
-          sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
-          cat /etc/docker/daemon.json
-          sudo systemctl restart docker
-          sudo ls -la /mnt/docker-storage
-
-    - name: Run 'make rebuild-cluster'
-      uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0
-      with:
-        timeout_minutes: 90
-        max_attempts: 3
-        command: cd ${GITHUB_WORKSPACE}/certsuite-sample-workload; make rebuild-cluster
+        disableDefaultCni: true
+        numControlPlaneNodes: 1
+        numWorkerNodes: 3
+        installOLM: true
+        removeDefaultStorageClass: true
+        removeControlPlaneTaint: true
 
     - name: Run 'make ${{inputs.make-command}}'
       uses: nick-fields/retry@7152eba30c6575329ac0576536151aca5a72780e # v3.0.0

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
     env:
       SHELL: /bin/bash
 
@@ -173,7 +173,10 @@ jobs:
     name: Run Local Smoke Tests
     needs: precheck-images
     if: needs.precheck-images.result == 'success'
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'
@@ -271,7 +274,10 @@ jobs:
     name: Run Container Smoke Tests
     needs: precheck-images
     if: needs.precheck-images.result == 'success'
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'

--- a/.github/workflows/qe-hosted-arm.yml
+++ b/.github/workflows/qe-hosted-arm.yml
@@ -1,8 +1,9 @@
-name: QE Testing (Ubuntu-hosted on AMD64)
+name: QE Testing (Ubuntu-hosted on ARM64)
 
 on:
-  pull_request:
-    branches: [ main ]
+  # Commented out to avoid running on every PR
+  # pull_request:
+  #   branches: [ main ]
   workflow_dispatch:
   # Schedule a daily cron at midnight UTC
   schedule:
@@ -27,7 +28,7 @@ jobs:
   # Build the image used for testing first, then pass the reference to the QE tests.
   # This saves time and resources by not building the image in each QE suite.
   build-image-for-qe:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     steps:
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -58,7 +59,7 @@ jobs:
           sudo ls -la /mnt/docker-storage
 
       - name: Build temporary image tag for this PR
-        uses: docker/build-push-action@ca877d9245402d1537745e0e356eab47c3520991 # v6.13.0
+        uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6.12.0
         with:
           context: .
           file: ./Dockerfile
@@ -73,7 +74,7 @@ jobs:
           path: /tmp/testimage.tar
 
   qe-testing:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-22.04-arm
     needs: build-image-for-qe
     if: needs.build-image-for-qe.result == 'success' 
     strategy:
@@ -99,17 +100,17 @@ jobs:
       # Download the image from the artifact and load it into the docker daemon.
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 # v3.8.0
-
-      - name: Setup partner cluster
-        uses: ./.github/actions/setup-partner-cluster
-        with:
-          make-command: 'install-for-qe'
-
+        
       - name: Download image from artifact
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:
           name: testimage
           path: /tmp
+
+      - name: Setup partner cluster
+        uses: ./.github/actions/setup-partner-cluster
+        with:
+          make-command: 'install-for-qe'
 
       - name: Load image into docker
         run: docker load --input /tmp/testimage.tar


### PR DESCRIPTION
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

`ubuntu-22.04-arm` runners are now available.  Checking to see what breaks if we run our workflows against them.