### PR TITLE
Add support for PPC64LE and S390x image builds

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -428,7 +428,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.CERTSUITE_IMAGE_NAME_LEGACY }}:${{ env.CERTSUITE_IMAGE_TAG }}
@@ -471,7 +471,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.CERTSUITE_IMAGE_NAME }}:${{ env.CERTSUITE_IMAGE_TAG }}

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -134,7 +134,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{env.CERTSUITE_IMAGE_NAME}}:${{ env.CERTSUITE_VERSION }}
@@ -246,7 +246,7 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{env.CERTSUITE_IMAGE_NAME_LEGACY}}:${{ env.CERTSUITE_VERSION }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,6 @@ RUN \
 	&& dnf clean all --assumeyes --disableplugin=subscription-manager \
 	&& rm -rf /var/cache/yum
 
-# Set environment specific variables
-ENV \
-	OPERATOR_SDK_X86_FILENAME=operator-sdk_linux_amd64 \
-	OPERATOR_SDK_ARM_FILENAME=operator-sdk_linux_arm64
-
 # Install Go binary and set the PATH
 ENV \
 	GO_DL_URL=https://golang.org/dl \
@@ -31,6 +26,8 @@ ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.23.5.linux-amd64.tar.gz
 ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.23.5.linux-arm64.tar.gz
 
 # Determine the CPU architecture and download the appropriate Go binary
+# We only build our binaries on x86_64 and aarch64 platforms, so it is not necessary
+# to support other architectures.
 RUN \
 	if [ "$(uname -m)" = x86_64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_x86_64} --quiet \
@@ -45,6 +42,14 @@ RUN \
 	fi
 ENV PATH=${PATH}:"/usr/local/go/bin":${GOPATH}/"bin"
 
+
+# Set environment specific variables
+ENV \
+	OPERATOR_SDK_X86_FILENAME=operator-sdk_linux_amd64 \
+	OPERATOR_SDK_ARM_FILENAME=operator-sdk_linux_arm64 \
+	OPERATOR_SDK_PPC64LE_FILENAME=operator-sdk_linux_ppc64le \
+	OPERATOR_SDK_S390X_FILENAME=operator-sdk_linux_s390x
+
 # Download operator-sdk binary
 ENV \
 	OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.39.1 \
@@ -53,21 +58,45 @@ ENV \
 RUN \
 	mkdir -p ${OSDK_BIN}
 
+ARG TARGETARCH
+ARG TARGETOS
+ARG TARGETPLATFORM
+
+RUN \
+ # echo the architecture for debugging
+ echo "TARGETARCH: $TARGETARCH" \
+ && echo "TARGETOS: $TARGETOS" \
+ && echo "TARGETPLATFORM: $TARGETPLATFORM"
+
 # hadolint ignore=DL4001
 RUN \
-	if [ "$(uname -m)" = x86_64 ]; then \
+	if [ "$TARGETARCH" = x86_64 ] || [ "$TARGETARCH" = amd64 ]; then \
 		curl \
 			--location \
 			--remote-name \
 			${OPERATOR_SDK_DL_URL}/${OPERATOR_SDK_X86_FILENAME} \
 			&& mv ${OPERATOR_SDK_X86_FILENAME} ${OSDK_BIN}/operator-sdk \
 			&& chmod +x ${OSDK_BIN}/operator-sdk; \
-	elif [ "$(uname -m)" = aarch64 ]; then \
+	elif [ "$TARGETARCH" = aarch64 ] || [ "$TARGETARCH" = arm64 ]; then \
 		curl \
 			--location \
 			--remote-name \
 			${OPERATOR_SDK_DL_URL}/${OPERATOR_SDK_ARM_FILENAME} \
 			&& mv ${OPERATOR_SDK_ARM_FILENAME} ${OSDK_BIN}/operator-sdk \
+			&& chmod +x ${OSDK_BIN}/operator-sdk; \
+	elif [ "$TARGETARCH" = ppc64le ]; then \
+		curl \
+			--location \
+			--remote-name \
+			${OPERATOR_SDK_DL_URL}/${OPERATOR_SDK_PPC64LE_FILENAME} \
+			&& mv ${OPERATOR_SDK_PPC64LE_FILENAME} ${OSDK_BIN}/operator-sdk \
+			&& chmod +x ${OSDK_BIN}/operator-sdk; \
+	elif [ "$TARGETARCH" = s390x ]; then \
+		curl \
+			--location \
+			--remote-name \
+			${OPERATOR_SDK_DL_URL}/${OPERATOR_SDK_S390X_FILENAME} \
+			&& mv ${OPERATOR_SDK_S390X_FILENAME} ${OSDK_BIN}/operator-sdk \
 			&& chmod +x ${OSDK_BIN}/operator-sdk; \
 	else \
 		echo "CPU architecture is not supported." && exit 1; \
@@ -78,13 +107,17 @@ COPY . ${CERTSUITE_SRC_DIR}
 WORKDIR ${CERTSUITE_SRC_DIR}
 
 # Build the certsuite binary
-RUN make build-certsuite-tool \
+RUN \
+	# Set the GOARCH and GOOS based on the TARGETPLATFORM
+	export GOARCH=$TARGETARCH \
+	&& export GOOS=$TARGETOS \
+	&& make build-certsuite-tool \
 	&& cp certsuite ${CERTSUITE_DIR}
 
 # Switch contexts back to the root CERTSUITE directory
 WORKDIR ${CERTSUITE_DIR}
 
-# Remove most of the build artefacts
+# Remove most of the build artifacts
 RUN \
 	dnf remove --assumeyes --disableplugin=subscription-manager gcc git wget \
 	&& dnf clean all --assumeyes --disableplugin=subscription-manager \
@@ -120,7 +153,6 @@ ENV \
 	CERTSUITE_OFFLINE_DB=/usr/offline-db \
 	OCT_DB_PATH=/usr/oct/cmd/tnf/fetch
 COPY --from=db ${OCT_DB_PATH} ${CERTSUITE_OFFLINE_DB}
-
 
 ENV PATH="${OSDK_BIN}:${PATH}"
 WORKDIR ${CERTSUITE_DIR}

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # There are four main groups of operations provided by this Makefile: build,
 # clean, run and tasks.
 #
-# Build operations will create artefacts from code. This includes things such
+# Build operations will create artifacts from code. This includes things such
 # as binaries, mock files, or catalogs of CNF tests.
 #
 # Clean operations remove the results of the build tasks, or other files not


### PR DESCRIPTION
Most of the changes relate to having to download the correct version of the operator SDK binary to install in the image for preflight.

There are docker build variables like `TARGETARCH` that let you target architectures directly.

I suppose this is a disclaimer, but we have no way of actually _testing_ this change right now on those environments.

Builds on work done in:
- https://github.com/redhat-best-practices-for-k8s/privileged-daemonset/pull/247 
- https://github.com/redhat-best-practices-for-k8s/certsuite-probe/pull/16
- https://github.com/redhat-best-practices-for-k8s/oct/pull/269
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2736