### PR TITLE
Fix for test case access-control-sys-nice-realtime-capability.

### DIFF
--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -822,7 +822,7 @@ func testSYSNiceRealtimeCapability(check *checksdb.Check, env *provider.TestEnvi
 			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container is not running on a realtime kernel enabled node", true))
 			continue
 		}
-		if !strings.Contains(cut.SecurityContext.Capabilities.String(), "SYS_NICE") {
+		if !isContainerCapabilitySet(cut.SecurityContext.Capabilities, "SYS_NICE") {
 			check.LogError("Container %q has been found running on a realtime kernel enabled node without SYS_NICE capability.", cut)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container is running on a realtime kernel enabled node without SYS_NICE capability", false))
 		} else {


### PR DESCRIPTION
The check was incorrectly testing the presence of the capability with the Capabilities.String(), which includes both add and drop ones, producing false negatives when the required capability is in the drop list.

This fix is the same as the one applied in PR #2352 for other access-control tcs.