### PR TITLE
operator: add scc permissions unit tests

### DIFF
--- a/tests/operator/access/access.go
+++ b/tests/operator/access/access.go
@@ -1,0 +1,39 @@
+package access
+
+import (
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+)
+
+func PermissionsHaveBadRule(clusterPermissions []v1alpha1.StrategyDeploymentPermissions) bool {
+	badRuleFound := false
+	for permissionIndex := range clusterPermissions {
+		permission := &clusterPermissions[permissionIndex]
+		for ruleIndex := range permission.Rules {
+			rule := &permission.Rules[ruleIndex]
+
+			// Check whether the rule is for the security api group.
+			securityGroupFound := false
+			for _, group := range rule.APIGroups {
+				if group == "*" || group == "security.openshift.io" {
+					securityGroupFound = true
+					break
+				}
+			}
+
+			if !securityGroupFound {
+				continue
+			}
+
+			// Now check whether it grants some access to securitycontextconstraint resources.
+			for _, resource := range rule.Resources {
+				if resource == "*" || resource == "securitycontextconstraints" {
+					// Keep reviewing other permissions' rules so we can log all the failing ones in the claim file.
+					badRuleFound = true
+					break
+				}
+			}
+		}
+	}
+
+	return badRuleFound
+}

--- a/tests/operator/access/access_test.go
+++ b/tests/operator/access/access_test.go
@@ -1,0 +1,57 @@
+package access
+
+import (
+	"testing"
+
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/stretchr/testify/assert"
+	rbacv1 "k8s.io/api/rbac/v1"
+)
+
+func TestPermissionsHaveBadRule(t *testing.T) {
+	generateSDP := func(apiGroups []string, resources []string) v1alpha1.StrategyDeploymentPermissions {
+		return v1alpha1.StrategyDeploymentPermissions{
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: apiGroups,
+					Resources: resources,
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testClusterPermissions []v1alpha1.StrategyDeploymentPermissions
+		expectedResult         bool
+	}{
+		{ // SCC granted - this is a bad rule
+			testClusterPermissions: []v1alpha1.StrategyDeploymentPermissions{
+				generateSDP([]string{"security.openshift.io"}, []string{"*"}),
+			},
+			expectedResult: true,
+		},
+		{ // SCC granted - this is a bad rule
+			testClusterPermissions: []v1alpha1.StrategyDeploymentPermissions{
+				generateSDP([]string{"security.openshift.io"}, []string{"securitycontextconstraints"}),
+			},
+			expectedResult: true,
+		},
+		{ // SCC granted - this is a bad rule
+			testClusterPermissions: []v1alpha1.StrategyDeploymentPermissions{
+				generateSDP([]string{"security.openshift.io"}, []string{"*"}),
+				generateSDP([]string{"security.openshift.io"}, []string{"securitycontextconstraints"}),
+			},
+			expectedResult: true,
+		},
+		{ // No bad rule
+			testClusterPermissions: []v1alpha1.StrategyDeploymentPermissions{
+				generateSDP([]string{"security.heathytest.io"}, []string{"*"}),
+			},
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedResult, PermissionsHaveBadRule(tc.testClusterPermissions))
+	}
+}


### PR DESCRIPTION
Broke the logic out from the test to its own func called `PermissionsHaveBadRule` and wrote some unit tests around it.