### PR TITLE
operator: add openAPI3 schema unit tests

### DIFF
--- a/tests/operator/openapi/openapi.go
+++ b/tests/operator/openapi/openapi.go
@@ -1,0 +1,23 @@
+package openapi
+
+import (
+	"strings"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func IsCRDDefinedWithOpenAPI3Schema(crd *apiextv1.CustomResourceDefinition) bool {
+	for _, version := range crd.Spec.Versions {
+		crdSchema := version.Schema.String()
+
+		containsOpenAPIV3SchemaSubstr := strings.Contains(strings.ToLower(crdSchema),
+			strings.ToLower(testhelper.OpenAPIV3Schema))
+
+		if containsOpenAPIV3SchemaSubstr {
+			return true
+		}
+	}
+
+	return false
+}

--- a/tests/operator/openapi/openapi_test.go
+++ b/tests/operator/openapi/openapi_test.go
@@ -1,0 +1,68 @@
+package openapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiextv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+)
+
+func TestIsCRDDefinedWithOpenAPI3Schema(t *testing.T) {
+	testCases := []struct {
+		testCRD        *apiextv1.CustomResourceDefinition
+		expectedOutput bool
+	}{
+		{
+			testCRD: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Versions: []apiextv1.CustomResourceDefinitionVersion{
+						{
+							Schema: &apiextv1.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextv1.JSONSchemaProps{},
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: true,
+		},
+		{
+			testCRD: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Versions: []apiextv1.CustomResourceDefinitionVersion{
+						{
+							Schema: &apiextv1.CustomResourceValidation{},
+						},
+					},
+				},
+			},
+			expectedOutput: true,
+		},
+		{
+			testCRD: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Versions: []apiextv1.CustomResourceDefinitionVersion{
+						{
+							Schema: &apiextv1.CustomResourceValidation{
+								OpenAPIV3Schema: &apiextv1.JSONSchemaProps{},
+							},
+						},
+					},
+				},
+			},
+			expectedOutput: true,
+		},
+		{
+			testCRD: &apiextv1.CustomResourceDefinition{
+				Spec: apiextv1.CustomResourceDefinitionSpec{
+					Versions: nil,
+				},
+			},
+			expectedOutput: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedOutput, IsCRDDefinedWithOpenAPI3Schema(tc.testCRD))
+	}
+}

--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -24,6 +24,7 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/common"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/identifiers"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/operator/catalogsource"
+	"github.com/redhat-best-practices-for-k8s/certsuite/tests/operator/openapi"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/operator/phasecheck"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
@@ -169,21 +170,7 @@ func testOperatorCrdOpenAPISpec(check *checksdb.Check, env *provider.TestEnviron
 	var nonCompliantObjects []*testhelper.ReportObject
 
 	for _, crd := range env.Crds {
-		isCrdDefinedWithOpenAPI3Schema := false
-
-		for _, version := range crd.Spec.Versions {
-			crdSchema := version.Schema.String()
-
-			containsOpenAPIV3SchemaSubstr := strings.Contains(strings.ToLower(crdSchema),
-				strings.ToLower(testhelper.OpenAPIV3Schema))
-
-			if containsOpenAPIV3SchemaSubstr {
-				isCrdDefinedWithOpenAPI3Schema = true
-				break
-			}
-		}
-
-		if isCrdDefinedWithOpenAPI3Schema {
+		if openapi.IsCRDDefinedWithOpenAPI3Schema(crd) {
 			check.LogInfo("Operator CRD %s is defined with OpenAPIV3 schema ", crd.Name)
 			compliantObjects = append(compliantObjects, testhelper.NewOperatorReportObject(crd.Namespace, crd.Name,
 				"Operator CRD is defined with OpenAPIV3 schema ", true).AddField(testhelper.OpenAPIV3Schema, crd.Name))


### PR DESCRIPTION
Breaks logic for this test out into `IsCRDDefinedWithOpenAPI3Schema` function with corresponding unit tests.