### PR TITLE
Reorganize autodiscover files

### DIFF
--- a/pkg/autodiscover/autodiscover_nads.go
+++ b/pkg/autodiscover/autodiscover_nads.go
@@ -1,0 +1,26 @@
+package autodiscover
+
+import (
+	"context"
+
+	nadClient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getNetworkAttachmentDefinitions(client *clientsholder.ClientsHolder, namespaces []string) ([]nadClient.NetworkAttachmentDefinition, error) {
+	var nadList []nadClient.NetworkAttachmentDefinition
+
+	for _, ns := range namespaces {
+		nad, err := client.CNCFNetworkingClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(ns).List(context.TODO(), metav1.ListOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			return nil, err
+		}
+
+		// Append the list of networkAttachmentDefinitions to the nadList slice
+		nadList = append(nadList, nad.Items...)
+	}
+
+	return nadList, nil
+}

--- a/pkg/autodiscover/autodiscover_nads_test.go
+++ b/pkg/autodiscover/autodiscover_nads_test.go
@@ -1,0 +1,1 @@
+package autodiscover

--- a/pkg/autodiscover/autodiscover_sriov.go
+++ b/pkg/autodiscover/autodiscover_sriov.go
@@ -1,0 +1,40 @@
+package autodiscover
+
+import (
+	"context"
+
+	sriovNetworkOp "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func getSriovNetworks(client *clientsholder.ClientsHolder, namespaces []string) (sriovNetworks []sriovNetworkOp.SriovNetwork, err error) {
+	var sriovNetworkList []sriovNetworkOp.SriovNetwork
+
+	for _, ns := range namespaces {
+		snl, err := client.SriovNetworkingClient.SriovNetworks(ns).List(context.TODO(), metav1.ListOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			return nil, err
+		}
+
+		// Append the list of sriovNetworks to the sriovNetworks slice
+		sriovNetworkList = append(sriovNetworkList, snl.Items...)
+	}
+	return sriovNetworkList, nil
+}
+
+func getSriovNetworkNodePolicies(client *clientsholder.ClientsHolder, namespaces []string) (sriovNetworkNodePolicies []sriovNetworkOp.SriovNetworkNodePolicy, err error) {
+	var sriovNetworkNodePolicyList []sriovNetworkOp.SriovNetworkNodePolicy
+
+	for _, ns := range namespaces {
+		snnp, err := client.SriovNetworkingClient.SriovNetworkNodePolicies(ns).List(context.TODO(), metav1.ListOptions{})
+		if err != nil && !kerrors.IsNotFound(err) {
+			return nil, err
+		}
+
+		// Append the list of sriovNetworkNodePolicies to the sriovNetworkNodePolicies slice
+		sriovNetworkNodePolicyList = append(sriovNetworkNodePolicyList, snnp.Items...)
+	}
+	return sriovNetworkNodePolicyList, nil
+}


### PR DESCRIPTION
Break some functions from the `autodiscover.go` out to their own corresponding files.  No functional changes to these functions.

New files:
- autodiscover_nads.go
- autodiscover_sriov.go

Funcs moved:
- autodiscover_operators.go