### PR TITLE
podhelper: add GetTopOwner unit tests

### DIFF
--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -167,6 +167,15 @@ func SetTestK8sClientsHolder(k8sClient kubernetes.Interface) {
 	clientsHolder.ready = true
 }
 
+func SetTestK8sDynamicClientsHolder(dynamicClient dynamic.Interface) {
+	clientsHolder.DynamicClient = dynamicClient
+	clientsHolder.ready = true
+}
+
+func SetTestClientGroupResources(groupResources []*metav1.APIResourceList) {
+	clientsHolder.GroupResources = groupResources
+}
+
 func ClearTestClientsHolder() {
 	clientsHolder.K8sClient = nil
 	clientsHolder.ready = false

--- a/pkg/podhelper/podhelper.go
+++ b/pkg/podhelper/podhelper.go
@@ -22,7 +22,12 @@ type TopOwner struct {
 // Get the list of top owners of pods
 func GetPodTopOwner(podNamespace string, podOwnerReferences []metav1.OwnerReference) (topOwners map[string]TopOwner, err error) {
 	topOwners = make(map[string]TopOwner)
-	err = followOwnerReferences(clientsholder.GetClientsHolder().GroupResources, clientsholder.GetClientsHolder().DynamicClient, topOwners, podNamespace, podOwnerReferences)
+	err = followOwnerReferences(
+		clientsholder.GetClientsHolder().GroupResources,
+		clientsholder.GetClientsHolder().DynamicClient,
+		topOwners,
+		podNamespace,
+		podOwnerReferences)
 	if err != nil {
 		return topOwners, fmt.Errorf("could not get top owners, err: %v", err)
 	}


### PR DESCRIPTION
Created two new test helper functions to help with spoofing the `DynamicClient` and `GroupResources` of the clientsholder struct:
- `SetTestK8sDynamicClientsHolder`
- `SetTestClientGroupResources`

It's only a test with a single case because we're already testing `followOwnerReferences()` but I think it gets the job done where I'm attempting to find the top owner of a pod owned by a deployment. 

Bonus: Added specific unit tests for function `SearchAPIResource` as well.