### PR TITLE
Skip access-control-sys-nice-realtime-capability if there's no nodes using realtime kernel.

### DIFF
--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -26,7 +26,6 @@ testCases:
     - access-control-service-type
     - access-control-ssh-daemons
     - access-control-sys-admin-capability-check
-    - access-control-sys-nice-realtime-capability
     - lifecycle-affinity-required-pods
     - lifecycle-container-prestop
     - lifecycle-container-poststart
@@ -67,6 +66,7 @@ testCases:
     - affiliated-certification-container-is-certified-digest     # test container image is not certified
   skip:
     - access-control-sys-ptrace-capability
+    - access-control-sys-nice-realtime-capability
     - affiliated-certification-helm-version
     - affiliated-certification-helmchart-is-certified
     - affiliated-certification-operator-is-certified

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -686,6 +686,21 @@ func GetNoOperatorCrdsSkipFn(env *provider.TestEnvironment) func() (bool, string
 	}
 }
 
+// The returned func returns true (skip) if there isn't any node using realtime kernel type.
+func GetNoNodesWithRealtimeKernelSkipFn(env *provider.TestEnvironment) func() (bool, string) {
+	return func() (bool, string) {
+		for i := range env.Nodes {
+			node := env.Nodes[i]
+
+			if node.IsRTKernel() {
+				return false, ""
+			}
+		}
+
+		return true, "no nodes with realtime kernel type found"
+	}
+}
+
 func ResultObjectsToString(compliantObject, nonCompliantObject []*ReportObject) (string, error) {
 	reason := FailureReasonOut{
 		CompliantObjectsOut:    compliantObject,

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -218,6 +218,7 @@ func LoadChecks() {
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestSYSNiceRealtimeCapabilityIdentifier)).
 		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env)).
+		WithSkipCheckFn(testhelper.GetNoNodesWithRealtimeKernelSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testSYSNiceRealtimeCapability(c, &env)
 			return nil


### PR DESCRIPTION
There's no point in running this check if there isn't any node using realtime kernel, so I added a custom skip function for it.

Anyway, if nodes with realtime kernel exist, it's still possible/compliant to deploy workload pods in non-realtime kernel nodes, irrespective of the sys_nice cap. For pods deployed in realtime kernel nodes, it's mandatory for this cap to be set at container level.