### PR TITLE
Fix to disable/enable pre-main self-hosted workflows.

### DIFF
--- a/.github/workflows/qe-ocp-arm-416.yaml
+++ b/.github/workflows/qe-ocp-arm-416.yaml
@@ -3,8 +3,11 @@ name: OCP ARM64 4.16 QE Testing
 on:
   pull_request:
     branches: [ main ]
-  label:
-    types: [deleted]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - unlabeled
   workflow_dispatch:
   # Schedule a daily cron at midnight UTC
   schedule:

--- a/.github/workflows/qe-ocp-pre-main.yaml
+++ b/.github/workflows/qe-ocp-pre-main.yaml
@@ -3,8 +3,11 @@ name: OCP Pre-Main Testing
 on:
   pull_request:
     branches: [ main ]
-  label:
-    types: [deleted]
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - unlabeled
 
 permissions:
   contents: read


### PR DESCRIPTION
I removed the "disable-self-hosted" label from PR #2763 but the pre-main self-hosted workflow jobs didn't run.

As suggested in github docs, the way to trigger the workflow when a label is added removed is using pull_request's activity types.

We did this in the [do-not-merge workflow file](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/.github/workflows/do-not-merge.yaml#L5) and it works well there.

See
https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#label

"If you want to run your workflow when a label is added to or removed from an issue, pull request, or discussion, use the labeled or unlabeled activity types for the issues, pull_request, pull_request_target, or discussion events instead."