### PR TITLE
Add OS to tarball artifact name

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -248,7 +248,7 @@ jobs:
         with:
           name: smoke-tests
           path: |
-            certsuite-out/*.tar.gz
+            certsuite-out-${{ matrix.os }}/*.tar.gz
 
       - name: Check the smoke test results against the expected results template
         run: ./certsuite check results --log-file="certsuite-out/certsuite.log"
@@ -265,7 +265,7 @@ jobs:
         with:
           name: preflight-smoke-tests
           path: |
-            certsuite-out/*.tar.gz
+            certsuite-out-${{ matrix.os }}/*.tar.gz
 
       - name: Remove tarball(s) to save disk space
         run: rm -f certsuite-out/*.tar.gz


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3c37def2-518f-433b-9075-dedafba3e666)

Adding the `os` to the name of the file uploaded at the end of the Smoke Test runs.