### PR TITLE
platform-alteration: add test for cluster operator health

### DIFF
--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -100,6 +100,7 @@ testCases:
     - performance-rt-apps-no-exec-probes
     - platform-alteration-base-image
     - platform-alteration-boot-params
+    - platform-alteration-cluster-operator-health
     - platform-alteration-hugepages-config
     - platform-alteration-hugepages-1g-only
     - platform-alteration-hugepages-2m-only

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -78,6 +78,7 @@ type DiscoveredTestData struct {
 	AllInstallPlans              []*olmv1Alpha.InstallPlan
 	AllCatalogSources            []*olmv1Alpha.CatalogSource
 	AllPackageManifests          []*olmPkgv1.PackageManifest
+	ClusterOperators             []configv1.ClusterOperator
 	SriovNetworks                []sriovNetworkOp.SriovNetwork
 	SriovNetworkNodePolicies     []sriovNetworkOp.SriovNetworkNodePolicy
 	AllSriovNetworks             []sriovNetworkOp.SriovNetwork
@@ -208,6 +209,11 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	data.Csvs = findOperatorsByLabels(oc.OlmClient.OperatorsV1alpha1(), operatorsUnderTestLabelsObjects, config.TargetNameSpaces)
 	data.Subscriptions = findSubscriptions(oc.OlmClient.OperatorsV1alpha1(), data.Namespaces)
 	data.HelmChartReleases = getHelmList(oc.RestConfig, data.Namespaces)
+
+	data.ClusterOperators, err = findClusterOperators(oc.OcpClient.ClusterOperators())
+	if err != nil {
+		log.Fatal("Failed to get cluster operators, err: %v", err)
+	}
 
 	// Get all operator pods
 	data.CSVToPodListMap, err = getOperatorCsvPods(data.Csvs)

--- a/pkg/autodiscover/autodiscover_clusteroperators.go
+++ b/pkg/autodiscover/autodiscover_clusteroperators.go
@@ -1,0 +1,25 @@
+package autodiscover
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func findClusterOperators(client clientconfigv1.ClusterOperatorInterface) ([]configv1.ClusterOperator, error) {
+	clusterOperators, err := client.List(context.TODO(), metav1.ListOptions{})
+	if err != nil && !k8serrors.IsNotFound(err) {
+		return nil, err
+	}
+
+	if k8serrors.IsNotFound(err) {
+		log.Debug("ClusterOperator CR not found in the cluster")
+		return nil, nil
+	}
+
+	return clusterOperators.Items, nil
+}

--- a/pkg/autodiscover/autodiscover_clusteroperators_test.go
+++ b/pkg/autodiscover/autodiscover_clusteroperators_test.go
@@ -1,0 +1,48 @@
+package autodiscover
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	fakeClientConfigv1 "github.com/openshift/client-go/config/clientset/versioned/fake"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFindClusterOperators(t *testing.T) {
+	generateClusterOperator := func(name string, availableStatus configv1.ConditionStatus, degradedStatus configv1.ConditionStatus, progressingStatus configv1.ConditionStatus) *configv1.ClusterOperator {
+		return &configv1.ClusterOperator{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
+			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{
+						Type:   configv1.OperatorAvailable,
+						Status: availableStatus,
+					},
+					{
+						Type:   configv1.OperatorDegraded,
+						Status: degradedStatus,
+					},
+					{
+						Type:   configv1.OperatorProgressing,
+						Status: progressingStatus,
+					},
+				},
+			},
+		}
+	}
+
+	// Generate a test object, store it to the fake client, and then retrieve it.
+	testObject := generateClusterOperator("test-cluster-operator", configv1.ConditionTrue, configv1.ConditionFalse, configv1.ConditionFalse)
+
+	client := fakeClientConfigv1.NewClientset(testObject)
+	clusterOperators, err := findClusterOperators(client.ConfigV1().ClusterOperators())
+
+	// Assert that the test object was retrieved successfully.
+	assert.Nil(t, err)
+	assert.Len(t, clusterOperators, 1)
+	assert.Equal(t, testObject.Name, clusterOperators[0].Name)
+	assert.Equal(t, testObject.Status.Conditions, clusterOperators[0].Status.Conditions)
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -28,6 +28,7 @@ import (
 
 	nadClient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	sriovNetworkOp "github.com/k8snetworkplumbingwg/sriov-network-operator/api/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	mcv1 "github.com/openshift/api/machineconfiguration/v1"
 	olmv1 "github.com/operator-framework/api/pkg/operators/v1"
 	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -127,6 +128,7 @@ type TestEnvironment struct { // rename this with testTarget
 	SriovNetworkNodePolicies     []sriovNetworkOp.SriovNetworkNodePolicy
 	AllSriovNetworkNodePolicies  []sriovNetworkOp.SriovNetworkNodePolicy
 	NetworkAttachmentDefinitions []nadClient.NetworkAttachmentDefinition
+	ClusterOperators             []configv1.ClusterOperator
 	IstioServiceMeshFound        bool
 	ValidProtocolNames           []string
 	DaemonsetFailedToSpawn       bool
@@ -259,6 +261,7 @@ func buildTestEnvironment() { //nolint:funlen,gocyclo
 	env.AllCatalogSources = data.AllCatalogSources
 	env.AllPackageManifests = data.AllPackageManifests
 	env.AllOperators = createOperators(data.AllCsvs, data.AllSubscriptions, data.AllPackageManifests, data.AllInstallPlans, data.AllCatalogSources, false, true)
+	env.ClusterOperators = data.ClusterOperators
 	env.AllCsvs = data.AllCsvs
 	env.AllOperatorsSummary = getSummaryAllOperators(env.AllOperators)
 	env.AllCrds = data.AllCrds

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -188,6 +188,7 @@ const (
 	PodType                      = "Pod"
 	HelmType                     = "Helm"
 	OperatorType                 = "Operator"
+	ClusterOperatorType          = "Cluster Operator"
 	ContainerType                = "Container"
 	CatalogSourceType            = "Catalog Source"
 	ContainerImageType           = "Container Image"
@@ -307,6 +308,12 @@ func NewOperatorReportObject(aNamespace, aOperatorName, aReason string, isCompli
 	out = NewReportObject(aReason, OperatorType, isCompliant)
 	out.AddField(Namespace, aNamespace)
 	out.AddField(Name, aOperatorName)
+	return out
+}
+
+func NewClusterOperatorReportObject(aClusterOperatorName, aReason string, isCompliant bool) (out *ReportObject) {
+	out = NewReportObject(aReason, ClusterOperatorType, isCompliant)
+	out.AddField(Name, aClusterOperatorName)
 	return out
 }
 

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -72,6 +72,7 @@ const (
 	TestNodeOperatingSystemIdentifierDocLink = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-host-os"
 	TestIsRedHatReleaseIdentifierDocLink     = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-base-images"
 	TestIsSELinuxEnforcingIdentifierDocLink  = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-pod-security"
+	TestClusterOperatorHealthDocLink         = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements"
 
 	// Lifecycle Suite
 	TestAffinityRequiredPodsDocLink                    = "https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-high-level-cnf-expectations"

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -83,6 +83,7 @@ var (
 	TestHelmVersionIdentifier                                        claim.Identifier
 	TestPodHugePages2M                                               claim.Identifier
 	TestPodHugePages1G                                               claim.Identifier
+	TestClusterOperatorHealth                                        claim.Identifier
 	TestHyperThreadEnable                                            claim.Identifier
 	TestReservedExtendedPartnerPorts                                 claim.Identifier
 	TestAffinityRequiredPods                                         claim.Identifier
@@ -1449,6 +1450,22 @@ that Node's kernel may not have the same hacks.'`,
 			Telco:    Mandatory,
 			NonTelco: Mandatory,
 			Extended: Mandatory,
+		},
+		TagCommon)
+
+	TestClusterOperatorHealth = AddCatalogEntry(
+		"cluster-operator-health",
+		common.PlatformAlterationTestKey,
+		`Tests that all cluster operators are healthy.`,
+		ClusterOperatorHealthRemediation,
+		NoExceptions,
+		TestClusterOperatorHealthDocLink,
+		false,
+		map[string]string{
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
+			Extended: Optional,
 		},
 		TagCommon)
 

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -22,6 +22,8 @@ const (
 
 	IsRedHatReleaseRemediation = `Build a new container image that is based on UBI (Red Hat Universal Base Image).`
 
+	ClusterOperatorHealthRemediation = `Ensure each cluster operator is in an 'Available' state. If an operator is not in an 'Available' state, investigate the operator's logs and events to determine the cause of the failure.`
+
 	NodeOperatingSystemRemediation = `Please update your workers to a version that is supported by your version of OpenShift`
 
 	SecConNonRootUserRemediation = `Change the pod and containers "runAsUser" uid to something other than root(0)`

--- a/tests/platform/clusteroperator/clusteroperator.go
+++ b/tests/platform/clusteroperator/clusteroperator.go
@@ -1,0 +1,19 @@
+package clusteroperator
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
+)
+
+func IsClusterOperatorAvailable(co *configv1.ClusterOperator) bool {
+	// Loop through the conditions, looking for the 'Available' state.
+	for _, condition := range co.Status.Conditions {
+		if condition.Type == configv1.OperatorAvailable {
+			log.Info("ClusterOperator %q is in an 'Available' state", co.Name)
+			return true
+		}
+	}
+
+	log.Info("ClusterOperator %q is not in an 'Available' state", co.Name)
+	return false
+}

--- a/tests/platform/clusteroperator/clusteroperator_test.go
+++ b/tests/platform/clusteroperator/clusteroperator_test.go
@@ -1,0 +1,56 @@
+package clusteroperator
+
+import (
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestIsClusterOperatorAvailable(t *testing.T) {
+	generateClusterOperator := func(
+		availableStatus configv1.ConditionStatus,
+		degradedStatus configv1.ConditionStatus,
+		progressingStatus configv1.ConditionStatus) *configv1.ClusterOperator {
+		return &configv1.ClusterOperator{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-cluster-operator",
+			},
+			Status: configv1.ClusterOperatorStatus{
+				Conditions: []configv1.ClusterOperatorStatusCondition{
+					{
+						Type:   configv1.OperatorAvailable,
+						Status: availableStatus,
+					},
+					{
+						Type:   configv1.OperatorDegraded,
+						Status: degradedStatus,
+					},
+					{
+						Type:   configv1.OperatorProgressing,
+						Status: progressingStatus,
+					},
+				},
+			},
+		}
+	}
+
+	testCases := []struct {
+		testAvailableStatus   configv1.ConditionStatus
+		testDegradedStatus    configv1.ConditionStatus
+		testProgressingStatus configv1.ConditionStatus
+		expectedResult        bool
+	}{
+		{
+			testAvailableStatus:   configv1.ConditionTrue,
+			testDegradedStatus:    configv1.ConditionFalse,
+			testProgressingStatus: configv1.ConditionFalse,
+			expectedResult:        true,
+		},
+	}
+
+	for _, tc := range testCases {
+		assert.Equal(t, tc.expectedResult, IsClusterOperatorAvailable(generateClusterOperator(tc.testAvailableStatus, tc.testDegradedStatus, tc.testProgressingStatus)))
+	}
+}


### PR DESCRIPTION
Adds a new test named `cluster-operator-health` to the `platform-alteration` suite that does a simple Availability check for all of the cluster operators.  To pass this test, they all need to be `Available: True`.  If operators are in a `Progressing`, `Degraded`, or any other state, it will not be a compliant object.

This only runs on OCP clusters and will skip on Kubernetes clusters.