### PR TITLE
Update Go to v1.24.0

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,10 +13,10 @@ runs:
         echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
       shell: bash
 
-    - name: Set up Go 1.23
+    - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: 1.23.6
+        go-version-file: go.mod
         cache: false
 
     - name: Disable default go problem matcher

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -45,10 +45,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Go 1.23
+      - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 1.23.6
+          go-version-file: go.mod
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
 
-      - name: Set up Go 1.23
+      - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 1.23.6
+          go-version-file: go.mod
 
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -41,18 +41,18 @@ jobs:
       SHELL: /bin/bash
 
     steps:
-      - name: Set up Go 1.23
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: 1.23.6
-
-      - name: Disable default go problem matcher
-        run: echo "::remove-matcher owner=go::"
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Disable default go problem matcher
+        run: echo "::remove-matcher owner=go::"
 
       - name: Install yaml dependency
         uses: ./.github/actions/install-yaml-dep
@@ -116,18 +116,18 @@ jobs:
       SHELL: /bin/bash
 
     steps:
-      - name: Set up Go 1.23
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: 1.23.6
-
-      - name: Disable default go problem matcher
-        run: echo "::remove-matcher owner=go::"
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Disable default go problem matcher
+        run: echo "::remove-matcher owner=go::"
 
       - name: Install yaml dependency
         uses: ./.github/actions/install-yaml-dep
@@ -188,19 +188,18 @@ jobs:
           mkdir -p /home/runner/.docker
           touch ${PFLT_DOCKERCONFIG}
           echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
-
-      - name: Set up Go 1.23
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: 1.23.6
-
-      - name: Disable default go problem matcher
-        run: echo "::remove-matcher owner=go::"
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
+
+      - name: Disable default go problem matcher
+        run: echo "::remove-matcher owner=go::"
 
       - name: Install yaml dependency
         uses: ./.github/actions/install-yaml-dep
@@ -290,17 +289,17 @@ jobs:
           touch ${PFLT_DOCKERCONFIG}
           echo '{ "auths": {} }' >> ${PFLT_DOCKERCONFIG}
 
-      # needed by depends-on-action
-      - name: Set up Go 1.23
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: 1.23.6
-
       # Perform smoke tests using a Certsuite container.
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.sha }}
+
+      # needed by depends-on-action
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
 
       - name: Setup partner cluster
         uses: ./.github/actions/setup-partner-cluster

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Go 1.23
+      - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 1.23.6
+          go-version-file: go.mod
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"

--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -27,10 +27,10 @@ jobs:
       - name: Execute `make update-rhcos-versions`
         run: make update-rhcos-versions
 
-      - name: Set up Go 1.23
+      - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 1.23.6
+          go-version-file: go.mod
 
         # This prevents any failures due to the updated rhcos_versions_map file from
         # making it into the PR phase.

--- a/.github/workflows/upload-release-assets.yaml
+++ b/.github/workflows/upload-release-assets.yaml
@@ -12,14 +12,13 @@ jobs:
     name: Upload release assets
     runs-on: ubuntu-22.04
     steps:
-
-      - name: Set up Go 1.23
-        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
-        with:
-          go-version: 1.23.6
-
       - name: Check out code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Go
+        uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: go.mod
 
       - name: Build Certsuite binary (x86_64)
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN \
 ENV \
 	GO_DL_URL=https://golang.org/dl \
 	GOPATH=/root/go
-ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.23.6.linux-amd64.tar.gz
-ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.23.6.linux-arm64.tar.gz
+ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.24.0.linux-amd64.tar.gz
+ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.24.0.linux-arm64.tar.gz
 
 # Determine the CPU architecture and download the appropriate Go binary
 # We only build our binaries on x86_64 and aarch64 platforms, so it is not necessary
@@ -32,11 +32,11 @@ RUN \
 	if [ "$(uname -m)" = x86_64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_x86_64} --quiet \
 		&& rm -rf /usr/local/go \
-		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.23.6.linux-amd64.tar.gz; \
+		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.24.0.linux-amd64.tar.gz; \
 	elif [ "$(uname -m)" = aarch64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_aarch64} --quiet \
 		&& rm -rf /usr/local/go \
-		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.23.6.linux-arm64.tar.gz; \
+		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.24.0.linux-arm64.tar.gz; \
 	else \
 		echo "CPU architecture is not supported." && exit 1; \
 	fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-best-practices-for-k8s/certsuite
 
-go 1.23.6
+go 1.24.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.3.1

--- a/internal/clientsholder/command.go
+++ b/internal/clientsholder/command.go
@@ -19,7 +19,6 @@ package clientsholder
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
@@ -40,7 +39,7 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 	var buffOut bytes.Buffer
 	var buffErr bytes.Buffer
 
-	log.Debug(fmt.Sprintf("execute command on ns=%s, pod=%s container=%s, cmd: %s", ctx.GetNamespace(), ctx.GetPodName(), ctx.GetContainerName(), strings.Join(commandStr, " ")))
+	log.Debug("execute command on ns=%s, pod=%s container=%s, cmd: %s", ctx.GetNamespace(), ctx.GetPodName(), ctx.GetContainerName(), strings.Join(commandStr, " "))
 	req := clientsholder.K8sClient.CoreV1().RESTClient().
 		Post().
 		Namespace(ctx.GetNamespace()).

--- a/internal/results/archiver.go
+++ b/internal/results/archiver.go
@@ -19,7 +19,7 @@ const (
 )
 
 func generateZipFileName() string {
-	return fmt.Sprintf(time.Now().Format(tarGzFileNamePrefixLayout) + "-" + tarGzFileNameSuffix)
+	return time.Now().Format(tarGzFileNamePrefixLayout) + "-" + tarGzFileNameSuffix
 }
 
 // Helper function to get the tar file header from a file.

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -81,10 +81,10 @@ func (c *Container) GetUID() (string, error) {
 		uid = split[len(split)-1]
 	}
 	if uid == "" {
-		log.Debug(fmt.Sprintf("could not find uid of %s/%s/%s\n", c.Namespace, c.Podname, c.Name))
+		log.Debug("could not find uid of %s/%s/%s\n", c.Namespace, c.Podname, c.Name)
 		return "", errors.New("cannot determine container UID")
 	}
-	log.Debug(fmt.Sprintf("uid of %s/%s/%s=%s\n", c.Namespace, c.Podname, c.Name, uid))
+	log.Debug("uid of %s/%s/%s=%s\n", c.Namespace, c.Podname, c.Name, uid)
 	return uid, nil
 }
 
@@ -137,7 +137,7 @@ func (c *Container) SetPreflightResults(preflightImageCache map[string]Preflight
 	}
 
 	// Take all of the Preflight logs and stick them into our log.
-	log.Info(logbytes.String())
+	log.Info("%s", logbytes.String())
 
 	// Store the Preflight test results into the container's PreflightResults var and into the cache.
 	resultsDB := GetPreflightResultsDB(&results)

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -119,7 +119,7 @@ func (op *Operator) SetPreflightResults(env *TestEnvironment) error {
 	}
 
 	// Take all of the preflight logs and stick them into our log.
-	log.Info(logbytes.String())
+	log.Info("%s", logbytes.String())
 
 	e := os.RemoveAll("artifacts/")
 	if e != nil {

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -752,7 +752,7 @@ func testAutomountServiceToken(check *checksdb.Check, env *provider.TestEnvironm
 		client := clientsholder.GetClientsHolder()
 		podPassed, newMsg := rbac.EvaluateAutomountTokens(client.K8sClient.CoreV1(), put)
 		if !podPassed {
-			check.LogError(newMsg)
+			check.LogError("%s", newMsg)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, newMsg, false))
 		} else {
 			check.LogInfo("Pod %q does not have automount service tokens set to true", put)

--- a/tests/lifecycle/suite.go
+++ b/tests/lifecycle/suite.go
@@ -582,7 +582,7 @@ func testPodsRecreation(check *checksdb.Check, env *provider.TestEnvironment) { 
 	needsPostMortemInfo := true
 	defer func() {
 		if needsPostMortemInfo {
-			check.LogDebug(postmortem.Log())
+			check.LogDebug("%s", postmortem.Log())
 		}
 		// Since we are possible exiting early, we need to make sure we set the result at the end of the function.
 		check.SetResult(compliantObjects, nonCompliantObjects)

--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -165,7 +165,7 @@ func testOnlySingleOrMultiNamespacedOperatorsAllowedInTenantNamespaces(check *ch
 
 		if err != nil {
 			msg := fmt.Sprintf("Operator namespace %s check got error %v", operatorNamespace, err)
-			check.LogError(msg)
+			check.LogError("%s", msg)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNamespacedReportObject(msg, testhelper.Namespace, false, operatorNamespace))
 			continue
 		}

--- a/tests/platform/hugepages/hugepages.go
+++ b/tests/platform/hugepages/hugepages.go
@@ -290,7 +290,7 @@ func logMcKernelArgumentsHugepages(hugepagesPerSize map[int]int, defhugepagesz i
 	for size, count := range hugepagesPerSize {
 		sb.WriteString(fmt.Sprintf(", size=%dkB - count=%d", size, count))
 	}
-	log.Info(sb.String())
+	log.Info("%s", sb.String())
 }
 
 // getMcHugepagesFromMcKernelArguments gets the hugepages params from machineconfig's kernelArguments


### PR DESCRIPTION
https://go.dev/doc/go1.24

Changes:
- Using `go-version-file` option thanks to @acornett21 
- Go 1.24.x now complains if you don't properly format your strings so this is now fixed.