### PR TITLE
Making Operator tenant test case optional

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -24,11 +24,11 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |platform-alteration|14|
 |preflight|18|
 
-### Extended specific tests only: 12
+### Extended specific tests only: 13
 
 |Mandatory|Optional|
 |---|---|
-|9|3|
+|10|3|
 
 ### Far-Edge specific tests only: 9
 
@@ -36,11 +36,11 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |---|---|
 |8|1|
 
-### Non-Telco specific tests only: 71
+### Non-Telco specific tests only: 70
 
 |Mandatory|Optional|
 |---|---|
-|44|27|
+|43|27|
 
 ### Telco specific tests only: 27
 
@@ -1351,16 +1351,16 @@ Tags|common,operator
 Property|Description
 ---|---
 Unique ID|operator-single-or-multi-namespaced-allowed-in-tenant-namespaces
-Description|Verifies that only single/multi namespaced operators are installed in a tenant-dedicated namespace. The test fails if this namespace contains any installed operator with Own/All-namespaced install mode, unlabeled operators, operands of any operator installed elswhere, or pods unrelated to any operator.
+Description|Verifies that only single/multi namespaced operators are installed in a tenant-dedicated namespace. The test fails if this namespace contains any installed operator with Own/All-namespaced install mode, unlabeled operators, operands of any operator installed elsewhere, or pods unrelated to any operator.
 Suggested Remediation|Ensure that operator with install mode SingleNamespaced or MultiNamespaced only is installed in the tenant namespace. Any installed operator with different install mode (AllNamespaced or OwnNamespaced) or pods not belonging to any operator must not be present in this namespace.
 Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-cnf-operator-requirements
 Exception Process|No exceptions
-Tags|common,operator
+Tags|extended,operator
 |**Scenario**|**Optional/Mandatory**|
 |Extended|Mandatory|
-|Far-Edge|Mandatory|
-|Non-Telco|Mandatory|
-|Telco|Mandatory|
+|Far-Edge|Optional|
+|Non-Telco|Optional|
+|Telco|Optional|
 
 ### performance
 

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -966,12 +966,12 @@ that Node's kernel may not have the same hacks.'`,
 		TestSingleOrMultiNamespacedOperatorInstallationInTenantNamespaceDocLink,
 		false,
 		map[string]string{
-			FarEdge:  Mandatory,
-			Telco:    Mandatory,
-			NonTelco: Mandatory,
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
 			Extended: Mandatory,
 		},
-		TagCommon)
+		TagExtended)
 
 	TestOperatorHasSemanticVersioningIdentifier = AddCatalogEntry(
 		"semantic-versioning",


### PR DESCRIPTION
The Following test case `single-or-multi-namespaced-allowed-in-tenant-namespaces` is only mandatory in the extended scenario. Updated the catalog to reflect this.
Catalog updated also picked up the latest testcase