### PR TITLE
updating dependabot config to be weekly and group go dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,17 +4,22 @@ updates:
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      prod-dependencies:
+        dependency-type: "production"
   - package-ecosystem: docker
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
 
   - package-ecosystem: docker
     directory: /.github/actions/documentation
     schedule:
-      interval: daily
+      interval: weekly


### PR DESCRIPTION
## Motivation
There are alot of PR's from this repo on a daily basis that create alot of noise. Switching to weekly, and grouping the go dependencies into one PR should cut down on the noise.

## Changes
- Setting interval to `weekly` instead of `daily`.
- Adding `groups` field to `gomod` dependencies.