### PR TITLE
Enable bundle cache for OCP nightlies

### DIFF
--- a/.github/workflows/qe-ocp-hosted.yml
+++ b/.github/workflows/qe-ocp-hosted.yml
@@ -82,9 +82,10 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.4
+        uses: palmsoftware/quick-ocp@v0.0.5
         with:
           ocpPullSecret: $OCP_PULL_SECRET
+          bundleCache: true
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
       


### PR DESCRIPTION
https://github.com/palmsoftware/quick-ocp/releases/tag/v0.0.5 has a new feature that enables caching and speeds up runs.