### PR TITLE
ci: prevent forks from running nightly crons

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -27,6 +27,7 @@ permissions:
 
 jobs:
   analyze:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     name: Analyze
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   preflight-unstable:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: ubuntu-22.04
     env:
       SHELL: /bin/bash

--- a/.github/workflows/qe-hosted-arm.yml
+++ b/.github/workflows/qe-hosted-arm.yml
@@ -28,6 +28,7 @@ jobs:
   # Build the image used for testing first, then pass the reference to the QE tests.
   # This saves time and resources by not building the image in each QE suite.
   build-image-for-qe:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: ubuntu-22.04-arm
     steps:
       - name: Check out code

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -27,6 +27,7 @@ jobs:
   # Build the image used for testing first, then pass the reference to the QE tests.
   # This saves time and resources by not building the image in each QE suite.
   build-image-for-qe:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code

--- a/.github/workflows/qe-ocp-414-intrusive.yaml
+++ b/.github/workflows/qe-ocp-414-intrusive.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   pull-unstable-image:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: qe-ocp-414
     env:
       SHELL: /bin/bash

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   pull-unstable-image:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: qe-ocp-414
     env:
       SHELL: /bin/bash

--- a/.github/workflows/qe-ocp-415-intrusive.yaml
+++ b/.github/workflows/qe-ocp-415-intrusive.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   pull-unstable-image:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: qe-ocp
     env:
       SHELL: /bin/bash

--- a/.github/workflows/qe-ocp-415.yaml
+++ b/.github/workflows/qe-ocp-415.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   pull-unstable-image:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: qe-ocp
     env:
       SHELL: /bin/bash

--- a/.github/workflows/qe-ocp-416-intrusive.yaml
+++ b/.github/workflows/qe-ocp-416-intrusive.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   pull-unstable-image:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: qe-ocp-416
     env:
       SHELL: /bin/bash

--- a/.github/workflows/qe-ocp-416.yaml
+++ b/.github/workflows/qe-ocp-416.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   pull-unstable-image:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: qe-ocp-416
     env:
       SHELL: /bin/bash

--- a/.github/workflows/qe-ocp-417-intrusive.yaml
+++ b/.github/workflows/qe-ocp-417-intrusive.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   pull-unstable-image:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: qe-ocp-417
     env:
       SHELL: /bin/bash

--- a/.github/workflows/qe-ocp-417.yaml
+++ b/.github/workflows/qe-ocp-417.yaml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   pull-unstable-image:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: qe-ocp-417
     env:
       SHELL: /bin/bash

--- a/.github/workflows/qe-ocp-arm-416.yaml
+++ b/.github/workflows/qe-ocp-arm-416.yaml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   build-arm-image-for-qe:
-    if: github.event.pull_request.user.login!='dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'self-hosted-disable')
+    if: github.event.pull_request.user.login!='dependabot[bot]' && !contains(github.event.pull_request.labels.*.name, 'self-hosted-disable') && github.repository_owner == 'redhat-best-practices-for-k8s'
     runs-on: qe-ocp-arm1
     steps:
       - name: Check out code

--- a/.github/workflows/qe-ocp-hosted.yml
+++ b/.github/workflows/qe-ocp-hosted.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   build-and-store:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     # build and store the image
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,6 +19,7 @@ permissions: read-all
 
 jobs:
   analysis:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     name: Scorecard analysis
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -36,6 +36,7 @@ env:
 
 jobs:
   test-and-push-tnf-image-main:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     name: 'Test and push the `certsuite` image'
     runs-on: ubuntu-22.04
     env:

--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   update-certification:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
     permissions:
       contents: write  # for peter-evans/create-pull-request to create branch
       pull-requests: write  # for peter-evans/create-pull-request to create a PR


### PR DESCRIPTION
Related to: https://github.com/openshift-kni/eco-goinfra/pull/961

We had a discussion in the eco-go* maintainers meeting about preventing forks from running the crons that were in the github YAMLs.  This should do the trick here too.