### PR TITLE
golangci-lint: migration to v2

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -71,9 +71,8 @@ jobs:
         uses: mfinelli/setup-shfmt@1a143389339b48c4b48ae3cdc058f3dbe336a701 # v3.0.2
 
       - name: Golangci-lint
-        uses: golangci/golangci-lint-action@4696ba8babb6127d732c3c6dde519db15edab9ea # v6.3.3
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
-          version: v1.64
           args: --timeout 10m0s
 
       - name: Checkmake

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,121 +1,109 @@
-linters-settings:
-  dupl:
-    threshold: 100
-  funlen:
-    lines: 60
-    statements: 45
-  goconst:
-    min-len: 4
-    min-occurrences: 2
-  gocritic:
-    enabled-tags:
-      - diagnostic
-      - experimental
-      - opinionated
-      - performance
-      - style
-    disabled-checks:
-      - whyNoLint
-    settings: 
-      tooManyResultsChecker:
-        # Maximum number of results.
-        # Default: 5
-        maxResults: 10
-  gocyclo:
-    min-complexity: 20
-  govet:
-    disable:
-      - printf
-  gosec:
-    excludes: 
-      - G115
-  lll:
-    line-length: 250
-  nolintlint:
-    allow-unused: false # report any unused nolint directives
-    require-explanation: false # do not require an explanation for nolint directives
-    require-specific: true # require nolint directives to be specific about which linter is being skipped
-  exhaustive:
-    default-signifies-exhaustive: true
+version: "2"
 linters:
-  # please, do not use `enable-all`: it's deprecated and will be removed soon.
-  # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
   enable:
     - bodyclose
+    - copyloopvar
     - dogsled
     - errcheck
     - exhaustive
-    - copyloopvar
     - funlen
     - goconst
     - gocritic
     - gocyclo
-    - gofmt
-    - goimports
-    - mnd
     - goprintffuncname
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - lll
     - misspell
+    - mnd
     - nolintlint
     - rowserrcheck
     - staticcheck
-    - stylecheck
-    - typecheck
     - unconvert
     - unparam
     - unused
     - whitespace
-  # do not enable:
-  # - asciicheck
-  # - depguard
-  # - dupl
-  # - gochecknoglobals
-  # - gochecknoinits
-  # - gocognit
-  # - godot
-  # - godox
-  # - goerr113
-  # - maligned
-  # - nakedret
-  # - nestif
-  # - noctx
-  # - prealloc
-  # - revive
-  # - copyloopvar
-  # - testpackage
-  # - wsl
-issues:
-  # Excluding configuration per-path, per-linter, per-text and per-source
-  exclude-rules:
-    # Ignore magic numbers, inline strings and function length in tests.
-    - path: _test\.go
-      linters:
-        - mnd
-        - goconst
-        - funlen
-    - path: config/config.go
-      linters:
-        - mnd
-    - path: _scaling.go
-      linters:
-        - gocritic
-    - path: hugepages.go
-      linters:
-        - mnd
-    - path: scheduling.go
-      linters:
-        - mnd
-    # Ignore line length for string assignments (do not try and wrap regex definitions)
-    - linters:
-        - lll
-      source: "^(.*= (\".*\"|`.*`))$"
-    # https://github.com/go-critic/go-critic/issues/926
-    - linters:
-        - gocritic
-      text: "unnecessaryDefer:"
-    # Ignore static strings in tests
+  settings:
+    dupl:
+      threshold: 100
+    exhaustive:
+      default-signifies-exhaustive: true
+    funlen:
+      lines: 60
+      statements: 45
+    goconst:
+      min-len: 4
+      min-occurrences: 2
+    gocritic:
+      disabled-checks:
+        - whyNoLint
+      enabled-tags:
+        - diagnostic
+        - experimental
+        - opinionated
+        - performance
+        - style
+      settings:
+        tooManyResultsChecker:
+          maxResults: 10
+    gocyclo:
+      min-complexity: 20
+    gosec:
+      excludes:
+        - G115
+    govet:
+      disable:
+        - printf
+    lll:
+      line-length: 250
+    nolintlint:
+      require-explanation: false
+      require-specific: true
+      allow-unused: false
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - funlen
+          - goconst
+          - mnd
+        path: _test\.go
+      - linters:
+          - mnd
+        path: config/config.go
+      - linters:
+          - gocritic
+        path: _scaling.go
+      - linters:
+          - mnd
+        path: hugepages.go
+      - linters:
+          - mnd
+        path: scheduling.go
+      - linters:
+          - lll
+        source: ^(.*= (".*"|`.*`))$
+      - linters:
+          - gocritic
+        text: 'unnecessaryDefer:'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ GIT_COMMIT=$(shell script/create-version-files.sh)
 GIT_RELEASE=$(shell script/get-git-release.sh)
 GIT_PREVIOUS_RELEASE=$(shell script/get-git-previous-release.sh)
 CLAIM_FORMAT_VERSION=$(shell script/get-claim-version.sh)
-GOLANGCI_VERSION=v1.64.3
+GOLANGCI_VERSION=v2.0.1
 LINKER_CERTSUITE_RELEASE_FLAGS=-X github.com/redhat-best-practices-for-k8s/certsuite/pkg/versions.GitCommit=${GIT_COMMIT}
 LINKER_CERTSUITE_RELEASE_FLAGS+= -X github.com/redhat-best-practices-for-k8s/certsuite/pkg/versions.GitRelease=${GIT_RELEASE}
 LINKER_CERTSUITE_RELEASE_FLAGS+= -X github.com/redhat-best-practices-for-k8s/certsuite/pkg/versions.GitPreviousRelease=${GIT_PREVIOUS_RELEASE}

--- a/cmd/certsuite/claim/show/csv/csv.go
+++ b/cmd/certsuite/claim/show/csv/csv.go
@@ -153,7 +153,7 @@ func buildCSV(claimScheme *claim.Schema, cnfType string, catalogMap map[string]c
 	}
 
 	opVers := ""
-	for i, op := range claimScheme.Claim.Configurations.TestOperators {
+	for i, op := range claimScheme.Claim.TestOperators {
 		if i == 0 {
 			opVers = op.Version
 		} else {

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -219,7 +219,7 @@ func GetClientConfigFromRestConfig(restConfig *rest.Config) *clientcmdapi.Config
 		Clusters: map[string]*clientcmdapi.Cluster{
 			"default-cluster": {
 				Server:               restConfig.Host,
-				CertificateAuthority: restConfig.TLSClientConfig.CAFile,
+				CertificateAuthority: restConfig.CAFile,
 			},
 		},
 		Contexts: map[string]*clientcmdapi.Context{

--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -135,7 +135,7 @@ func getAllNamespaces(oc corev1client.CoreV1Interface) (allNs []string, err erro
 		return allNs, fmt.Errorf("error getting all namespaces, err: %v", err)
 	}
 	for index := range nsList.Items {
-		allNs = append(allNs, nsList.Items[index].ObjectMeta.Name)
+		allNs = append(allNs, nsList.Items[index].Name)
 	}
 	return allNs, nil
 }

--- a/pkg/autodiscover/autodiscover_pods.go
+++ b/pkg/autodiscover/autodiscover_pods.go
@@ -61,7 +61,7 @@ func findPodsByLabels(oc corev1client.CoreV1Interface, labels []labelObject, nam
 		}
 		// Filter out any pod set to be deleted
 		for i := 0; i < len(pods.Items); i++ {
-			if pods.Items[i].ObjectMeta.DeletionTimestamp == nil && pods.Items[i].Status.Phase == corev1.PodRunning {
+			if pods.Items[i].DeletionTimestamp == nil && pods.Items[i].Status.Phase == corev1.PodRunning {
 				runningPods = append(runningPods, pods.Items[i])
 			}
 			allPods = append(allPods, pods.Items[i])

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -58,7 +58,7 @@ func FindCrObjectByNameByNamespace(scalesGetter scale.ScalesGetter, ns, name str
 func isDeploymentsPodsMatchingAtLeastOneLabel(labels []labelObject, namespace string, deployment *appsv1.Deployment) bool {
 	for _, aLabelObject := range labels {
 		log.Debug("Searching pods in deployment %q found in ns %q using label %s=%s", deployment.Name, namespace, aLabelObject.LabelKey, aLabelObject.LabelValue)
-		if deployment.Spec.Template.ObjectMeta.Labels[aLabelObject.LabelKey] == aLabelObject.LabelValue {
+		if deployment.Spec.Template.Labels[aLabelObject.LabelKey] == aLabelObject.LabelValue {
 			log.Info("Deployment %s found in ns=%s", deployment.Name, namespace)
 			return true
 		}
@@ -106,7 +106,7 @@ func findDeploymentsByLabels(
 func isStatefulSetsMatchingAtLeastOneLabel(labels []labelObject, namespace string, statefulSet *appsv1.StatefulSet) bool {
 	for _, aLabelObject := range labels {
 		log.Debug("Searching pods in statefulset %q found in ns %q using label %s=%s", statefulSet.Name, namespace, aLabelObject.LabelKey, aLabelObject.LabelValue)
-		if statefulSet.Spec.Template.ObjectMeta.Labels[aLabelObject.LabelKey] == aLabelObject.LabelValue {
+		if statefulSet.Spec.Template.Labels[aLabelObject.LabelKey] == aLabelObject.LabelValue {
 			log.Info("StatefulSet %s found in ns=%s", statefulSet.Name, namespace)
 			return true
 		}

--- a/pkg/podhelper/podhelper_test.go
+++ b/pkg/podhelper/podhelper_test.go
@@ -108,19 +108,19 @@ func Test_followOwnerReferences(t *testing.T) {
 	client := k8sDynamicFake.NewSimpleDynamicClient(scheme, rep1, dep1, csv1, node1, pod1)
 
 	// Spoof the get functions
-	client.Fake.AddReactor("get", "ClusterServiceVersion", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+	client.AddReactor("get", "ClusterServiceVersion", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, csv1, nil
 	})
-	client.Fake.AddReactor("get", "Deployment", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+	client.AddReactor("get", "Deployment", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, dep1, nil
 	})
-	client.Fake.AddReactor("get", "ReplicaSet", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+	client.AddReactor("get", "ReplicaSet", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, rep1, nil
 	})
-	client.Fake.AddReactor("get", "Node", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+	client.AddReactor("get", "Node", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, node1, nil
 	})
-	client.Fake.AddReactor("get", "Pod", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+	client.AddReactor("get", "Pod", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, pod1, nil
 	})
 
@@ -225,11 +225,11 @@ func TestGetTopOwners(t *testing.T) {
 	client := k8sDynamicFake.NewSimpleDynamicClient(k8sscheme.Scheme, testDeployment, testPod)
 
 	// Spoof the get functions
-	client.Fake.AddReactor("get", "Deployment", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+	client.AddReactor("get", "Deployment", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, testDeployment, nil
 	})
 
-	client.Fake.AddReactor("get", "Pod", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+	client.AddReactor("get", "Pod", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 		return true, testPod, nil
 	})
 

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -189,10 +189,10 @@ func (c *Container) IsTagEmpty() bool {
 
 func (c *Container) IsReadOnlyRootFilesystem(logger *log.Logger) bool {
 	logger.Info("Testing Container %q", c)
-	if c.Container.SecurityContext == nil || c.Container.SecurityContext.ReadOnlyRootFilesystem == nil {
+	if c.SecurityContext == nil || c.SecurityContext.ReadOnlyRootFilesystem == nil {
 		return false
 	}
-	return *c.Container.SecurityContext.ReadOnlyRootFilesystem
+	return *c.SecurityContext.ReadOnlyRootFilesystem
 }
 
 func (c *Container) IsContainerRunAsNonRoot(podRunAsNonRoot *bool) (isContainerRunAsNonRoot bool, reason string) {

--- a/pkg/provider/isolation.go
+++ b/pkg/provider/isolation.go
@@ -87,7 +87,7 @@ func LoadBalancingDisabled(p *Pod) bool {
 	cpuLoadBalancingDisabled := false
 	irqLoadBalancingDisabled := false
 
-	if v, ok := p.ObjectMeta.Annotations["cpu-load-balancing.crio.io"]; ok {
+	if v, ok := p.Annotations["cpu-load-balancing.crio.io"]; ok {
 		if v == disableVar {
 			cpuLoadBalancingDisabled = true
 		} else {
@@ -97,7 +97,7 @@ func LoadBalancingDisabled(p *Pod) bool {
 		log.Debug("Annotation cpu-load-balancing.crio.io is missing.")
 	}
 
-	if v, ok := p.ObjectMeta.Annotations["irq-load-balancing.crio.io"]; ok {
+	if v, ok := p.Annotations["irq-load-balancing.crio.io"]; ok {
 		if v == disableVar {
 			irqLoadBalancingDisabled = true
 		} else {

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -169,7 +169,8 @@ func createOperators(csvs []*olmv1Alpha.ClusterServiceVersion,
 	uniqueCsvs := getUniqueCsvListByName(csvs)
 
 	for _, csv := range uniqueCsvs {
-		if !(csv.Status.Phase == olmv1Alpha.CSVPhaseSucceeded || !succeededRequired) {
+		// Skip CSVs that are not in the Succeeded phase if the flag is set.
+		if csv.Status.Phase != olmv1Alpha.CSVPhaseSucceeded && succeededRequired {
 			continue
 		}
 		op := &Operator{Name: csv.Name, Namespace: csv.Namespace}

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -194,7 +194,7 @@ func (p *Pod) ContainsIstioProxy() bool {
 
 func (p *Pod) CreatedByDeploymentConfig() (bool, error) {
 	oc := clientsholder.GetClientsHolder()
-	for _, podOwner := range p.ObjectMeta.GetOwnerReferences() {
+	for _, podOwner := range p.GetOwnerReferences() {
 		if podOwner.Kind == replicationController {
 			replicationControllers, err := oc.K8sClient.CoreV1().ReplicationControllers(p.Namespace).Get(context.TODO(), podOwner.Name, metav1.GetOptions{})
 			if err != nil {
@@ -495,7 +495,7 @@ func (p *Pod) IsUsingClusterRoleBinding(clusterRoleBindings []rbacv1.ClusterRole
 	logger *log.Logger) (bool, string, error) {
 	// This function accepts a list of clusterRoleBindings and checks to see if the pod's service account is
 	// tied to any of them.  If it is, then it returns true, otherwise it returns false.
-	logger.Info("Pod %q is using service account %q", p, p.Pod.Spec.ServiceAccountName)
+	logger.Info("Pod %q is using service account %q", p, p.Spec.ServiceAccountName)
 
 	// Loop through the service accounts in the namespace, looking for a match between the pod serviceAccountName and
 	// the service account name.  If there is a match, check to make sure that the SA is not a 'subject' of the cluster
@@ -503,8 +503,8 @@ func (p *Pod) IsUsingClusterRoleBinding(clusterRoleBindings []rbacv1.ClusterRole
 	for crbIndex := range clusterRoleBindings {
 		for _, subject := range clusterRoleBindings[crbIndex].Subjects {
 			if subject.Kind == rbacv1.ServiceAccountKind &&
-				subject.Name == p.Pod.Spec.ServiceAccountName && subject.Namespace == p.Pod.Namespace {
-				logger.Error("Pod %q has service account %q that is tied to cluster role binding %q", p.Pod.Name, p.Pod.Spec.ServiceAccountName, clusterRoleBindings[crbIndex].Name)
+				subject.Name == p.Spec.ServiceAccountName && subject.Namespace == p.Namespace {
+				logger.Error("Pod %q has service account %q that is tied to cluster role binding %q", p.Name, p.Spec.ServiceAccountName, clusterRoleBindings[crbIndex].Name)
 				return true, clusterRoleBindings[crbIndex].RoleRef.Name, nil
 			}
 		}
@@ -514,10 +514,10 @@ func (p *Pod) IsUsingClusterRoleBinding(clusterRoleBindings []rbacv1.ClusterRole
 }
 
 func (p *Pod) IsRunAsUserID(uid int64) bool {
-	if p.Pod.Spec.SecurityContext == nil || p.Pod.Spec.SecurityContext.RunAsUser == nil {
+	if p.Spec.SecurityContext == nil || p.Spec.SecurityContext.RunAsUser == nil {
 		return false
 	}
-	return *p.Pod.Spec.SecurityContext.RunAsUser == uid
+	return *p.Spec.SecurityContext.RunAsUser == uid
 }
 
 // Returns the list of containers that have the securityContext.runAsNonRoot set to false and securityContext.runAsUser set to zero.
@@ -528,13 +528,13 @@ func (p *Pod) GetRunAsNonRootFalseContainers(knownContainersToSkip map[string]bo
 	// Check pod-level security context this will be set by default for containers
 	// If not already configured at the container level
 	var podRunAsNonRoot *bool
-	if p.Pod.Spec.SecurityContext != nil && p.Pod.Spec.SecurityContext.RunAsNonRoot != nil {
-		podRunAsNonRoot = p.Pod.Spec.SecurityContext.RunAsNonRoot
+	if p.Spec.SecurityContext != nil && p.Spec.SecurityContext.RunAsNonRoot != nil {
+		podRunAsNonRoot = p.Spec.SecurityContext.RunAsNonRoot
 	}
 
 	var podRunAsUserID *int64
-	if p.Pod.Spec.SecurityContext != nil && p.Pod.Spec.SecurityContext.RunAsUser != nil {
-		podRunAsUserID = p.Pod.Spec.SecurityContext.RunAsUser
+	if p.Spec.SecurityContext != nil && p.Spec.SecurityContext.RunAsUser != nil {
+		podRunAsUserID = p.Spec.SecurityContext.RunAsUser
 	}
 
 	// Check each container for the RunAsNonRoot parameter.

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -279,7 +279,7 @@ func buildTestEnvironment() { //nolint:funlen,gocyclo
 	env.AllServiceAccounts = data.AllServiceAccounts
 	env.AllServiceAccountsMap = make(map[string]*corev1.ServiceAccount)
 	for i := 0; i < len(data.AllServiceAccounts); i++ {
-		mapIndex := data.AllServiceAccounts[i].ObjectMeta.Namespace + data.AllServiceAccounts[i].ObjectMeta.Name
+		mapIndex := data.AllServiceAccounts[i].Namespace + data.AllServiceAccounts[i].Name
 		env.AllServiceAccountsMap[mapIndex] = data.AllServiceAccounts[i]
 	}
 	// Pods

--- a/pkg/provider/statefulsets_test.go
+++ b/pkg/provider/statefulsets_test.go
@@ -119,7 +119,7 @@ func TestGetUpdatedStatefulset(t *testing.T) {
 	for _, tc := range testCases {
 		// Create a fake client to mock API calls.
 		client := &fake.Clientset{}
-		client.Fake.AddReactor("get", "statefulsets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		client.AddReactor("get", "statefulsets", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testPod",

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -585,7 +585,7 @@ func testPodRoleBindings(check *checksdb.Check, env *provider.TestEnvironment) {
 	for _, put := range env.Pods {
 		check.LogInfo("Testing Pod %q", put)
 		podIsCompliant := true
-		if put.Pod.Spec.ServiceAccountName == defaultServiceAccount {
+		if put.Spec.ServiceAccountName == defaultServiceAccount {
 			check.LogError("Pod %q has an empty or default serviceAccountName", put)
 			// Add the pod to the non-compliant list
 			nonCompliantObjects = append(nonCompliantObjects,

--- a/tests/lifecycle/scaling/deployment_scaling_test.go
+++ b/tests/lifecycle/scaling/deployment_scaling_test.go
@@ -159,11 +159,11 @@ func TestScaleHpaDeploymentFunc(t *testing.T) {
 		var runtimeObjects []runtime.Object
 		runtimeObjects = append(runtimeObjects, tempDP, hpatest)
 		c := k8sfake.NewSimpleClientset(runtimeObjects...)
-		c.Fake.AddReactor("get", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		c.AddReactor("get", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, hpatest, nil
 		})
 
-		c.Fake.AddReactor("update", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		c.AddReactor("update", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, hpatest, nil
 		})
 
@@ -238,11 +238,11 @@ func TestScaleHpaDeploymentHelper(t *testing.T) {
 
 		// Spoof the get and update functions
 		client := k8sfake.Clientset{}
-		client.Fake.AddReactor("get", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		client.AddReactor("get", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, runtimeObjs[0], tc.getResult
 		})
 
-		client.Fake.AddReactor("update", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		client.AddReactor("update", "horizontalpodautoscalers", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, runtimeObjs[0], tc.updateResult
 		})
 
@@ -308,11 +308,11 @@ func TestScaleDeploymentHelper(t *testing.T) {
 
 		// Spoof the get and update functions
 		client := k8sfake.Clientset{}
-		client.Fake.AddReactor("get", "deployments", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		client.AddReactor("get", "deployments", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, runtimeObjs[0], tc.getResult
 		})
 
-		client.Fake.AddReactor("update", "deployments", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+		client.AddReactor("update", "deployments", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
 			return true, runtimeObjs[0], tc.updateResult
 		})
 

--- a/tests/observability/suite.go
+++ b/tests/observability/suite.go
@@ -386,7 +386,7 @@ func extractUniqueServiceAccountNames(env *provider.TestEnvironment) map[string]
 
 	// Iterate over the service accounts to extract names
 	for _, sa := range env.ServiceAccounts {
-		uniqueServiceAccountNames[sa.ObjectMeta.Name] = struct{}{}
+		uniqueServiceAccountNames[sa.Name] = struct{}{}
 	}
 
 	return uniqueServiceAccountNames


### PR DESCRIPTION
https://golangci-lint.run/product/migration-guide/

I migrated the config over to their `v2` style with the `migrate` command.  Also I fixed a number of things it started flagging.