### PR TITLE
Remove UBI patterns

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,9 +30,6 @@ updates:
       interval: weekly
     groups:
       docker-images:
-        patterns: 
-          - "registry.access.redhat.com/ubi9/*"
-          - "registry.access.redhat.com/ubi8/*"
         update-types: [ "major", "minor", "patch" ]
   - package-ecosystem: github-actions
     directory: /
@@ -54,7 +51,4 @@ updates:
       interval: weekly
     groups:
       docker-images:
-        patterns: 
-          - "registry.access.redhat.com/ubi9/*"
-          - "registry.access.redhat.com/ubi8/*"
         update-types: [ "major", "minor", "patch" ]


### PR DESCRIPTION
The updater seems to be throwing this message:
```
updater | 2025/03/28 15:45:54 WARN <job_988588101> Please check your configuration as there are groups where no dependencies match:
- docker-images
```