### PR TITLE
Add grouping for 'actions' folder specifically

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,6 +48,40 @@ updates:
           - "actions/*"
           - "docker/*"
         update-types: [ "major", "minor", "patch" ]
+  - package-ecosystem: github-actions
+    directory: /.github/actions/setup-partner-cluster
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: [ "actions/*" ]
+        update-types: [ "major", "minor", "patch" ]
+      docker: 
+        patterns: [ "docker/*" ]
+        update-types: [ "major", "minor", "patch" ]
+      other-actions:
+        patterns: [ "*" ]
+        exclude-patterns: 
+          - "actions/*"
+          - "docker/*"
+        update-types: [ "major", "minor", "patch" ]
+  - package-ecosystem: github-actions
+    directory: /.github/actions/setup
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: [ "actions/*" ]
+        update-types: [ "major", "minor", "patch" ]
+      docker: 
+        patterns: [ "docker/*" ]
+        update-types: [ "major", "minor", "patch" ]
+      other-actions:
+        patterns: [ "*" ]
+        exclude-patterns: 
+          - "actions/*"
+          - "docker/*"
+        update-types: [ "major", "minor", "patch" ]
   - package-ecosystem: docker
     directory: /.github/actions/documentation
     schedule:


### PR DESCRIPTION
Related to: https://github.com/dependabot/dependabot-core/issues/6704

Turns out that there are dependencies under `.github/actions/` that aren't being updated like the others and they need their own specific group.