### PR TITLE
Avoid URL previews in slack msgs for alerts.

### DIFF
--- a/.github/actions/slack-webhook-sender/action.yml
+++ b/.github/actions/slack-webhook-sender/action.yml
@@ -17,9 +17,9 @@ runs:
       shell: bash
       env:
         MESSAGE: ${{ inputs.message }}
-        REPO_URL: 'https://github.com/${{ github.repository }}'
-        COMMIT_URL: 'https://github.com/${{ github.repository }}/commit/${{ github.sha }}'
-        JOB_URL: 'https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}'
+        REPO_URL: 'github.com/${{ github.repository }}'
+        COMMIT_URL: 'github.com/${{ github.repository }}/commit/${{ github.sha }}'
+        JOB_URL: 'github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/attempts/${{ github.run_attempt }}'
         ATTEMPT: ${{ github.run_attempt }}
       run: |
           data="{                              \


### PR DESCRIPTION
Removing the protocol in the url should avoid slack to create the link previews.

Ref: https://slack.com/help/articles/204399343-Share-links-and-set-preview-preferences#:~:text=Turn%20off%20link%20previews&text=Select%20Preferences%20from%20the%20menu,text%20previews%20of%20linked%20websites.

Test-Hints: no-check