### PR TITLE
Adjust exception process for requests-and-limits test

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -347,10 +347,10 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Property|Description|
 |---|---|
 |Unique ID|access-control-requests-and-limits|
-|Description|Check that containers have resource requests and limits specified in their spec.|
+|Description|Check that containers have resource requests and limits specified in their spec. Set proper QoS class and resource requests/limits based on container use case.|
 |Suggested Remediation|Add requests and limits to your container spec. See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits|
 |Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#redhat-best-practices-for-k8s-requests/limits|
-|Exception Process|There is no documented exception process for this.|
+|Exception Process|Exceptions possible for platform and infrastructure containers. Must identify which container needs access and document why with details.|
 |Tags|telco,access-control|
 |**Scenario**|**Optional/Mandatory**|
 |Extended|Mandatory|

--- a/tests/identifiers/exceptions.go
+++ b/tests/identifiers/exceptions.go
@@ -51,4 +51,7 @@ const (
 	AffiliatedCert = NoDocumentedProcess + " " + `A partner can run the Red Hat Best Practices Test Suite before passing other certifications (Container/Operator/HelmChart) but the affiliated certification test cases in the Red Hat Best Practices Test Suite must be re-run once the other certifications have been granted.` //nolint:lll
 
 	OperatorSkipRangeExceptionProcess = `If there is not a version of the operator that needs to be skipped, then an exception will be granted.`
+
+	// Exceptions for requests and limits test
+	RequestsAndLimitsExceptionProcess = `Exceptions possible for platform and infrastructure containers. Must identify which container needs access and document why with details.`
 )

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -1616,9 +1616,9 @@ that Node's kernel may not have the same hacks.'`,
 	TestPodRequestsAndLimitsIdentifier = AddCatalogEntry(
 		"requests-and-limits",
 		common.AccessControlTestKey,
-		`Check that containers have resource requests and limits specified in their spec.`,
+		`Check that containers have resource requests and limits specified in their spec. Set proper QoS class and resource requests/limits based on container use case.`,
 		RequestsAndLimitsRemediation,
-		NoDocumentedProcess,
+		RequestsAndLimitsExceptionProcess,
 		TestPodRequestsAndLimitsIdentifierDocLink,
 		true,
 		map[string]string{


### PR DESCRIPTION
Change the exception process and description in the catalog for the access-control-requests-and-limits test.

TestDallasWorkload: tnf-test-cnf-green