### PR TITLE
fix bin directory to no longer have folders and duplicate binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,11 +142,10 @@ ENV \
 	OSDK_BIN=/usr/local/osdk/bin
 
 # Install the certsuite binary
-COPY --from=build ${CERTSUITE_DIR} ${CERTSUITE_DIR}
-RUN cp ${CERTSUITE_DIR}/certsuite /usr/local/bin
+COPY --from=build ${CERTSUITE_DIR}/certsuite /usr/local/bin/certsuite
 
 # Add operatorsdk binary to image
-COPY --from=build ${OSDK_BIN} ${OSDK_BIN}
+COPY --from=build ${OSDK_BIN} /usr/local/bin/operator-sdk
 
 # Update the CNF containers, helm charts and operators DB
 ENV \
@@ -154,7 +153,6 @@ ENV \
 	OCT_DB_PATH=/usr/oct/cmd/tnf/fetch
 COPY --from=db ${OCT_DB_PATH} ${CERTSUITE_OFFLINE_DB}
 
-ENV PATH="${OSDK_BIN}:${PATH}"
 WORKDIR ${CERTSUITE_DIR}
 ENV SHELL=/bin/bash
 CMD ["certsuite", "-h"]


### PR DESCRIPTION
## Motivation
When trying to figure out where the `certsuite` binary lived in the container, I noticed the `tree` output, had the binary duplicated in two places within the `/usr` location.

## Changes
Fix the duplication, and remove the folders in `/usr/local/bin`, creating a flat directory of all binaries.

Test-Hints: no-check