### PR TITLE
ci: reduce workers to improve stability

### DIFF
--- a/.github/actions/setup-partner-cluster/action.yml
+++ b/.github/actions/setup-partner-cluster/action.yml
@@ -20,7 +20,7 @@ runs:
       with:
         disableDefaultCni: true
         numControlPlaneNodes: 1
-        numWorkerNodes: 3
+        numWorkerNodes: 2
         installOLM: true
         removeDefaultStorageClass: true
         removeControlPlaneTaint: true


### PR DESCRIPTION
Bringing down the number of workers deployed in the CI environment to see if it improves stability.  Especially since we allow workload to run on the control-plane nodes as well.