### PR TITLE
update test run docs to remove ./ for clarity

### DIFF
--- a/docs/cluster-deploy/README.md
+++ b/docs/cluster-deploy/README.md
@@ -58,7 +58,7 @@ patches:
       - op: replace
         path: /spec/containers/0/args/1
         value: |
-          ./certsuite run -l 'preflight' ; sleep inf
+          certsuite run -l 'preflight' ; sleep inf
   - target:
       version: v1
       kind: Pod
@@ -67,5 +67,5 @@ patches:
       - op: replace
         path: /spec/containers/0/args/1
         value: |
-          ./certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context' ; sleep inf
+          certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context' ; sleep inf
 ```

--- a/docs/cluster-deploy/certsuite.yaml
+++ b/docs/cluster-deploy/certsuite.yaml
@@ -127,7 +127,7 @@ spec:
       args:
         - "-c"
         - |
-          ./certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context' --intrusive=false ; sleep inf
+          certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context' --intrusive=false ; sleep inf
       volumeMounts:
         - name: config-volume
           mountPath: /usr/certsuite/config

--- a/docs/cluster-deploy/kustomization.yaml
+++ b/docs/cluster-deploy/kustomization.yaml
@@ -23,7 +23,7 @@ resources:
 #       - op: replace
 #         path: /spec/containers/0/args/1
 #         value: |
-#           ./certsuite run -l 'preflight' ; sleep inf
+#           certsuite run -l 'preflight' ; sleep inf
 
 # Uncomment the next lines (patches) in order to allow intrusive TCs to run.
 # patches:
@@ -35,4 +35,4 @@ resources:
 #       - op: replace
 #         path: /spec/containers/0/args/1
 #         value: |
-#           ./certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context'; sleep inf
+#           certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context'; sleep inf

--- a/docs/test-run.md
+++ b/docs/test-run.md
@@ -6,7 +6,7 @@ The Test Suite can be run using the Certsuite tool directly or through a contain
 To run the Test Suite direct use:
 
 ```shell
-./certsuite run -l <label-filter> -c <certsuite-config> -k <kubeconfig> -o <output-dir> [<flags>]
+certsuite run -l <label-filter> -c <certsuite-config> -k <kubeconfig> -o <output-dir> [<flags>]
 ```
 
 If the _kubeconfig_ is not provided the value of the `KUBECONFIG` environment variable will be taken by default.
@@ -54,7 +54,7 @@ To skip intrusive tests which may disrupt cluster operations, issue the
 following:
 
 ```shell
-./certsuite run --intrusive=false
+certsuite run --intrusive=false
 ```
 
 The intrusive test cases are:
@@ -67,7 +67,7 @@ The intrusive test cases are:
 Likewise, to enable intrusive tests, set the following:
 
 ```shell
-./certsuite run --intrusive=true
+certsuite run --intrusive=true
 ```
 
 Intrusive tests are enabled by default.


### PR DESCRIPTION
## Motivation
A follow up to the below, where it was pointed out the docs should be updated, since it wasn't clear that for a container the binary was in $PATH.
- #2903

## Changes
Remove references to `./` in the `test-run` page. It still makes sense to keep this in the developer pages/guide.

Test-Hints: no-check