### PR TITLE
Updates on cluster deploy kustomize and README

### DIFF
--- a/docs/cluster-deploy/README.md
+++ b/docs/cluster-deploy/README.md
@@ -38,13 +38,13 @@ oc kustomize k8s/ | oc apply -f -
 
 The `kustomization` tool used by `oc` will parse the content of the [./kustomization.yaml](kustomization.yaml) file, which consists of a set of "transformers" over the resources defined in [./certsuite.yaml](certsuite.yaml).
 
-By default, that command will deploy the Cert Suite Pod without any mutation: it will be deployed in the same namespace and with the same configuration than using the `oc apply -f k8s/certsuite.yaml`.
+By default, that command will deploy the Cert Suite Pod without any mutation: it will be deployed in the same namespace and with the same configuration than using the `oc apply -f cluster-deploy/certsuite.yaml`.
 
 But there are the three example of modifications included in [./kustomization.yaml](kustomization.yaml) that can be used out of the box that can be handy:
 
 1. The namespace and the prefix/suffix of each resource's name. By default, the [./certsuite.yaml](certsuite.yaml) uses the namespace "certsuite" to deploy all the reources (except the cluster role and the cluster role binding), but this can be changed uncommenting the line that starts with `namespace:`. It's highly recommended to uncomment at least one of suffixName/prefixName so unique cluster role & cluster role-bindings can be created for each CertSuite Pod. This way, you could run more than one CertSuite Pod in the same cluster!.
 2. The (ginkgo) labels expression, in case you want to run different test cases. Uncomment the object that starts with "patches:". The commented example changes the command to use the "preflight" label only.
-3. Configuring the --intrusive Flag. Uncomment the last object that starts with "patches:". The commented example changes the --intrusive to true, so all the intrusive TCs will run in case the lifecycle TCs are selected to run by the appropriate labels.
+3. Configuring the --intrusive Flag. Uncomment the last object that starts with "patches:". The commented example removes the `--intrusive=false` cli flag, so all the intrusive TCs will run in case the lifecycle TCs are selected to run by the appropriate labels.
 
 In case both (1) and (2) wants to be used, just create a list of patches like this:
 
@@ -67,5 +67,5 @@ patches:
       - op: replace
         path: /spec/containers/0/args/1
         value: |
-        ./certsuite run -l 'preflight' --intrusive=true ; sleep inf
+          ./certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context' ; sleep inf
 ```

--- a/docs/cluster-deploy/certsuite.yaml
+++ b/docs/cluster-deploy/certsuite.yaml
@@ -37,53 +37,53 @@ metadata:
   name: certsuite-config
   namespace: certsuite
 data:
-  certsuite_config.yaml: |
+  certsuite_config.yml: |
     targetNameSpaces:
-      - name: certsuite
+      - name: tnf
     podsUnderTestLabels:
       - "redhat-best-practices-for-k8s.com/generic: target"
-    # deprecated operator label ("redhat-best-practices-for-k8s.com/operator:"") still configured by default, no need to add it here
     operatorsUnderTestLabels:
+      - "redhat-best-practices-for-k8s.com/operator:target"
       - "redhat-best-practices-for-k8s.com/operator1:new"
+      - "cnf/test:cr-scale-operator"
     targetCrdFilters:
       - nameSuffix: "group1.test.com"
         scalable: false
       - nameSuffix: "redhat-best-practices-for-k8s.com"
         scalable: false
-      - nameSuffix: "tutorial.my.domain"
+      - nameSuffix: "memcacheds.cache.example.com"
         scalable: true
     managedDeployments:
-      - name: jack
+      - name: memcached-sample
     managedStatefulsets:
-      - name: jack
-    certifiedcontainerinfo:
-      - name: rocketchat/rocketchat
-        repository: registry.connect.redhat.com
-        tag: 0.56.0-1 # optional, "latest" assumed if empty
-        digest: # if set, takes precedence over tag. e.g. "sha256:aa34453a6417f8f76423ffd2cf874e9c4a1a5451ac872b78dc636ab54a0ebbc3"
-      - name: rocketchat/rocketchat
-        repository: registry.connect.redhat.com
-        tag: 0.56.0-1
-        digest: sha256:03f7f2499233a302351821d6f78f0e813c3f749258184f4133144558097c57b0
-    checkDiscoveredContainerCertificationStatus: false
+      - name: memcached-sample
     acceptedKernelTaints:
       - module: vboxsf
       - module: vboxguest
     skipScalingTestDeployments:
       - name: deployment1
-        namespace: certsuite
+        namespace: tnf
     skipScalingTestStatefulsets:
       - name: statefulset1
-        namespace: certsuite
+        namespace: tnf
     skipHelmChartList:
       - name: coredns
     validProtocolNames:
       - "http3"
       - "sctp"
     servicesignorelist:
-      - "hazelcast-platform-controller-manager-service"
-      - "hazelcast-platform-webhook-service"
       - "new-pro-controller-manager-metrics-service"
+      - "mysql"
+    executedBy: ""
+    partnerName: ""
+    collectorAppPassword: ""
+    collectorAppEndpoint: "http://claims-collector.cnf-certifications.sysdeseng.com"
+    connectAPIConfig:
+      baseURL: "https://access.redhat.com/hydra/cwe/rest/v1.0"
+      apiKey: ""
+      projectID: ""
+      proxyURL: ""
+      proxyPort: ""
 
 ---
 apiVersion: v1

--- a/docs/cluster-deploy/kustomization.yaml
+++ b/docs/cluster-deploy/kustomization.yaml
@@ -23,7 +23,7 @@ resources:
 #       - op: replace
 #         path: /spec/containers/0/args/1
 #         value: |
-#           ./certsuite.sh -l 'preflight' ; sleep inf
+#           ./certsuite run -l 'preflight' ; sleep inf
 
 # Uncomment the next lines (patches) in order to allow intrusive TCs to run.
 # patches:
@@ -35,4 +35,4 @@ resources:
 #       - op: replace
 #         path: /spec/containers/0/args/1
 #         value: |
-#           ./certsuite.sh -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context' --intrusive=true ; sleep inf
+#           ./certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context'; sleep inf


### PR DESCRIPTION
Kustomize sections updated to use "certsuite run" instead of certsuite.sh.

Also:
- Configmap field name updated for extension 'yml' instead of 'yaml'. Also, the content has been updated to match config/certsuite_config.yml
- By default, the certsuite will add the intrusive=false to avoid intrusive test cases. The kustomize (commented) section was updated to remove it completely so they can run if needed/wanted.