### PR TITLE
script: Add check for 'oc' client

### DIFF
--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -25,6 +25,18 @@ jobs:
         with:
           ref: main
 
+      - name: Check and install 'oc' OpenShift client
+        run: |
+          if ! command -v oc &> /dev/null; then
+            echo "'oc' not found, installing..."
+            curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
+            tar -xvf openshift-client-linux.tar.gz
+            sudo mv oc kubectl /usr/local/bin/
+            rm openshift-client-linux.tar.gz
+          else
+            echo "'oc' is already installed."
+          fi
+
       - name: Execute `make update-rhcos-versions`
         run: make update-rhcos-versions
 


### PR DESCRIPTION
The RHCOP map job was failing:

https://github.com/redhat-best-practices-for-k8s/certsuite/actions/runs/14721502972/job/41316072020#step:3:293

This change adds a check to install the `oc` client if missing.  

It's failing because the new change to the ubuntu-24.04 runners don't have the openshift-cli installed by default anymore for some reason.