### PR TITLE
Further updates to RHCOS job; add 4.19 and 4.20

### DIFF
--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -4,6 +4,9 @@ on:
   # Triggers the workflow every day
   schedule:
     - cron: "0 0 * * *"
+  # pull_request:
+  #   branches:
+  #     - main
   workflow_dispatch:
 permissions:
   contents: read
@@ -29,10 +32,11 @@ jobs:
         run: |
           if ! command -v oc &> /dev/null; then
             echo "'oc' not found, installing..."
-            curl -LO https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
-            tar -xvf openshift-client-linux.tar.gz
-            sudo mv oc kubectl /usr/local/bin/
-            rm openshift-client-linux.tar.gz
+            TEMP_DIR=$(mktemp -d)
+            curl -Lo $TEMP_DIR/openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz
+            tar -xvf $TEMP_DIR/openshift-client-linux.tar.gz -C $TEMP_DIR
+            sudo mv $TEMP_DIR/oc $TEMP_DIR/kubectl /usr/local/bin/
+            rm -rf $TEMP_DIR
           else
             echo "'oc' is already installed."
           fi

--- a/script/rhcos_versions.sh
+++ b/script/rhcos_versions.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o pipefail
 
-CHANNELS=(4.18 4.17 4.16 4.15 4.14 4.13 4.12 4.11 4.10 4.9 4.8 4.7 4.6 4.5)
+CHANNELS=(4.20 4.19 4.18 4.17 4.16 4.15 4.14 4.13 4.12 4.11 4.10 4.9 4.8 4.7 4.6 4.5)
 CHANNEL_TYPES=(stable candidate)
 
 # Keep track of the number of failures we see from the 'oc adm' calls.


### PR DESCRIPTION
Follow up to #2939 

### Workflow improvements:

* [`.github/workflows/update-rhcos-mapping.yml`](diffhunk://#diff-2d1a584ee822c30599041287a454454f095a481b9b36b4ca1245ef0c672a2cb9L32-R39): Updated the installation script for the `oc` CLI to use a temporary directory for downloading and extracting files, ensuring better cleanup and avoiding potential conflicts for the README.md.

### Channel updates:

* [`script/rhcos_versions.sh`](diffhunk://#diff-3dea480ebe3843b10c2201ee2d777ff376105b6f9fc88429e3542d65f86cc656L5-R5): Added support for OpenShift channels `4.20` and `4.19` to the `CHANNELS` array.