### PR TITLE
Modify compatibility matrix for 4.18

### DIFF
--- a/pkg/compatibility/compatibility.go
+++ b/pkg/compatibility/compatibility.go
@@ -50,33 +50,43 @@ type VersionInfo struct {
 }
 
 var (
-	ocpBetaVersions   = []string{"4.13", "4.14", "4.15", "4.16", "4.17", "4.18"}
+	ocpBetaVersions   = []string{"4.13", "4.14", "4.15", "4.16", "4.17", "4.18", "4.19", "4.20"}
 	ocpLifeCycleDates = map[string]VersionInfo{
 		// TODO: Adjust all of these periodically to make sure they are up to date with the lifecycle
 		// update documentation.
 
 		// Full Support
+		"4.18": {
+			GADate:  time.Date(2025, 2, 25, 0, 0, 0, 0, time.UTC), // February 25, 2025
+			FSEDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),  // June 1, 2025
+			MSEDate: time.Date(2028, 2, 25, 0, 0, 0, 0, time.UTC), // February 25, 2028
+			// Note: FSEDate (Release of 4.19 + 3 months) is currently a "guess".  Update when available.
+
+			// OS Compatibility
+			MinRHCOSVersion:      "4.18",
+			RHELVersionsAccepted: []string{"8.4", "8.5"},
+		},
 		"4.17": {
 			GADate:  time.Date(2024, 10, 1, 0, 0, 0, 0, time.UTC), // October 1, 2024
 			FSEDate: time.Date(2025, 4, 27, 0, 0, 0, 0, time.UTC), // April 27, 2025
-			MSEDate: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),  // April 1, 2026
+			MSEDate: time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),  // April 1, 2026 - This is the end of "Term 2" extended update support.
 			// Note: FSEDate (Release of 4.18 + 3 months) is currently a "guess".  Update when available.
 
 			// OS Compatibility
 			MinRHCOSVersion:      "4.17",
 			RHELVersionsAccepted: []string{"8.4", "8.5"},
 		},
+
+		// Maintenance Support
 		"4.16": {
-			GADate:  time.Date(2024, 6, 27, 0, 0, 0, 0, time.UTC),  // June 27, 2024
-			FSEDate: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),   // January 1, 2025
-			MSEDate: time.Date(2025, 12, 27, 0, 0, 0, 0, time.UTC), // December 27, 2025
+			GADate:  time.Date(2024, 6, 27, 0, 0, 0, 0, time.UTC), // June 27, 2024
+			FSEDate: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),  // January 1, 2025
+			MSEDate: time.Date(2027, 6, 27, 0, 0, 0, 0, time.UTC), // June 27, 2027 - This is the end of "Term 2" extended update support.
 
 			// OS Compatibility
 			MinRHCOSVersion:      "4.16",
 			RHELVersionsAccepted: []string{"8.4", "8.5"},
 		},
-
-		// Maintenance Support
 		"4.15": {
 			GADate:  time.Date(2024, 2, 27, 0, 0, 0, 0, time.UTC), // February 27, 2024
 			FSEDate: time.Date(2025, 9, 27, 0, 0, 0, 0, time.UTC), // September 27, 2025
@@ -89,7 +99,7 @@ var (
 		"4.14": {
 			GADate:  time.Date(2023, 10, 31, 0, 0, 0, 0, time.UTC), // October 31, 2023
 			FSEDate: time.Date(2024, 5, 27, 0, 0, 0, 0, time.UTC),  // May 27, 2024
-			MSEDate: time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC),   // May 1, 2025
+			MSEDate: time.Date(2026, 10, 31, 0, 0, 0, 0, time.UTC), // October 31, 2026 - This is the end of "Term 2" extended update support.
 
 			// OS Compatibility
 			MinRHCOSVersion:      "4.14",
@@ -113,6 +123,7 @@ var (
 			MinRHCOSVersion:      "4.12",
 			RHELVersionsAccepted: []string{"8.4", "8.5"},
 		},
+		// End of life
 		"4.11": {
 			GADate:  time.Date(2022, 8, 10, 0, 0, 0, 0, time.UTC), // August 10, 2022
 			FSEDate: time.Date(2023, 4, 17, 0, 0, 0, 0, time.UTC), // April 17, 2023
@@ -131,8 +142,6 @@ var (
 			MinRHCOSVersion:      "4.10",
 			RHELVersionsAccepted: []string{"8.4", "8.5"},
 		},
-
-		// End of life
 		"4.9": {
 			GADate:  time.Date(2021, 10, 18, 0, 0, 0, 0, time.UTC), // October 18, 2021
 			FSEDate: time.Date(2022, 6, 10, 0, 0, 0, 0, time.UTC),  // June 10, 2022


### PR DESCRIPTION
The compatibility matrix needed an update to add support for 4.18 as well as modifying the "end-of-life" dates for 4.16 and 4.14 to match the extended support end date.

### New OCP Versions Added:
* Added lifecycle details for OCP version `4.18`, including GA, FSE, and MSE dates, along with OS compatibility information.

### Lifecycle Date Updates:
* Updated the MSE date for OCP version `4.16` to reflect the extended update support until June 27, 2027.
* Updated the MSE date for OCP version `4.14` to October 31, 2026, indicating the end of "Term 2" extended update support.

### Documentation Enhancements:
* Explicitly labeled the lifecycle phase for OCP versions `4.11` and `4.9` as "End of life" for better clarity. [[1]](diffhunk://#diff-33f81f50b577289c31d6f178303b6fb3a71a1b97dea625a18651a65d398a9b75R126) [[2]](diffhunk://#diff-33f81f50b577289c31d6f178303b6fb3a71a1b97dea625a18651a65d398a9b75L134-L135)