### PR TITLE
updating default logging level to info

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -61,7 +61,7 @@ func SetupLogger(logWriter io.Writer, level string) {
 	logLevel, err := parseLevel(level)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Could not parse log level, err: %v. Defaulting to DEBUG.", err)
-		globalLogLevel = slog.LevelDebug
+		globalLogLevel = slog.LevelInfo
 	} else {
 		globalLogLevel = logLevel
 	}


### PR DESCRIPTION
- Moving from default of `DEBUG` to `INFO` to reduce the noise in the logs