### PR TITLE
Cleanup images in 4.18 runs

### DIFF
--- a/.github/workflows/qe-ocp-418-intrusive.yaml
+++ b/.github/workflows/qe-ocp-418-intrusive.yaml
@@ -118,6 +118,10 @@ jobs:
           max_attempts: 3
           command: cd ${GITHUB_WORKSPACE}/certsuite-qe; FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE} CERTSUITE_IMAGE=${{env.CERTSUITE_IMAGE_NAME}} CERTSUITE_IMAGE_TAG=${{env.TEST_CERTSUITE_IMAGE_TAG}} JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=false ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true make test-features
 
+      - name: Cleanup images before next job to save space
+        run: |
+          docker rmi -f ${{env.TEST_CERTSUITE_IMAGE_NAME}}:${{env.TEST_CERTSUITE_IMAGE_TAG}}
+
       - name: Build the binary
         run: make build-certsuite-tool
 

--- a/.github/workflows/qe-ocp-418.yaml
+++ b/.github/workflows/qe-ocp-418.yaml
@@ -117,6 +117,10 @@ jobs:
           max_attempts: 3
           command: cd ${GITHUB_WORKSPACE}/certsuite-qe; FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE} CERTSUITE_IMAGE=${{env.TEST_CERTSUITE_IMAGE_NAME}} CERTSUITE_IMAGE_TAG=${{env.TEST_CERTSUITE_IMAGE_TAG}} JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true make test-features
 
+      - name: Cleanup images before next job to save space
+        run: |
+          docker rmi -f ${{env.TEST_CERTSUITE_IMAGE_NAME}}:${{env.TEST_CERTSUITE_IMAGE_TAG}}
+
       - name: Build the binary
         run: make build-certsuite-tool
 


### PR DESCRIPTION
This pull request introduces a cleanup step in two GitHub Actions workflows to optimize disk space usage by removing Docker images after they are no longer needed. 

Enhancements to workflows:

* [`.github/workflows/qe-ocp-418-intrusive.yaml`](diffhunk://#diff-6f51a6efe331a185a86bf75986d3b9fa18a340a00080a4d075469d6719f5739aR121-R124): Added a step to clean up Docker images (`TEST_CERTSUITE_IMAGE_NAME` and `TEST_CERTSUITE_IMAGE_TAG`) before the next job runs, ensuring efficient use of disk space.
* [`.github/workflows/qe-ocp-418.yaml`](diffhunk://#diff-c08ac0e5886c9b068215f1837fb2a43f2aaafa9594d22dadb6edea3ca9944ff7R120-R123): Added a similar cleanup step to remove Docker images after testing, preventing unnecessary disk space consumption.