### PR TITLE
Update operator-sdk to v1.41.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV \
 
 # Download operator-sdk binary
 ENV \
-	OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.40.0 \
+	OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.41.1 \
 	OSDK_BIN=/usr/local/osdk/bin
 
 RUN \


### PR DESCRIPTION
https://github.com/operator-framework/operator-sdk/releases/tag/v1.41.1

Related to:
- https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/pull/575