### PR TITLE
Update and consolidate semver library

### DIFF
--- a/cmd/certsuite/pkg/claim/claim_test.go
+++ b/cmd/certsuite/pkg/claim/claim_test.go
@@ -14,11 +14,11 @@ func TestIsClaimFormatVersionSupported(t *testing.T) {
 		// Invalid version strings
 		{
 			claimFormatVersion: "",
-			expectedError:      `claim file version "" is not valid: Invalid Semantic Version`,
+			expectedError:      `claim file version "" is not valid: invalid semantic version`,
 		},
 		{
 			claimFormatVersion: "v0.v0.2",
-			expectedError:      `claim file version "v0.v0.2" is not valid: Invalid Semantic Version`,
+			expectedError:      `claim file version "v0.v0.2" is not valid: invalid semantic version`,
 		},
 		{
 			claimFormatVersion: "v0.0.0",

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/redhat-best-practices-for-k8s/certsuite
 go 1.24.4
 
 require (
-	github.com/Masterminds/semver v1.5.0
-	github.com/Masterminds/semver/v3 v3.3.1
+	github.com/Masterminds/semver/v3 v3.4.0
 	github.com/blang/semver/v4 v4.0.0
 	github.com/fatih/color v1.18.0
 	github.com/go-logr/logr v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -22,10 +22,8 @@ github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
-github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
-github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
-github.com/Masterminds/semver/v3 v3.3.1 h1:QtNSWtVZ3nBfk8mAOu/B6v7FMJ+NHTIgUPi7rj+4nv4=
-github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1Xbatp0=
+github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
 github.com/Masterminds/squirrel v1.5.4 h1:uUcX/aBc8O7Fg9kaISIUsHXdKuqehiXAMQTYX8afzqM=

--- a/pkg/provider/catalogsources.go
+++ b/pkg/provider/catalogsources.go
@@ -4,7 +4,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	olmv1Alpha "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -3,7 +3,7 @@ package versions
 import (
 	"regexp"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 )
 
 var (

--- a/tests/observability/suite.go
+++ b/tests/observability/suite.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/common"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/identifiers"
 	pdbv1 "github.com/redhat-best-practices-for-k8s/certsuite/tests/observability/pdb"

--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -21,7 +21,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/common"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/identifiers"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/operator/access"


### PR DESCRIPTION
https://github.com/Masterminds/semver/releases/tag/v3.4.0

Removes the extra `v1.5.0` library that we were somehow including and causing confusion.  Standardizes on the `v3` version of semver.