### PR TITLE
Adjust quick-ocp memory to 12000

### DIFF
--- a/.github/workflows/qe-ocp-418-intrusive.yaml
+++ b/.github/workflows/qe-ocp-418-intrusive.yaml
@@ -102,6 +102,7 @@ jobs:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
           desiredOCPVersion: 4.18
+          crcMemory: 12000
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
       

--- a/.github/workflows/qe-ocp-418.yaml
+++ b/.github/workflows/qe-ocp-418.yaml
@@ -101,6 +101,7 @@ jobs:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
           desiredOCPVersion: 4.18
+          crcMemory: 12000
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
       

--- a/.github/workflows/qe-ocp-419-intrusive.yaml
+++ b/.github/workflows/qe-ocp-419-intrusive.yaml
@@ -102,6 +102,7 @@ jobs:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
           desiredOCPVersion: 4.19
+          crcMemory: 12000
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
       

--- a/.github/workflows/qe-ocp-419.yaml
+++ b/.github/workflows/qe-ocp-419.yaml
@@ -101,6 +101,7 @@ jobs:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
           desiredOCPVersion: 4.19
+          crcMemory: 12000
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
       

--- a/.github/workflows/qe-ocp-hosted.yml
+++ b/.github/workflows/qe-ocp-hosted.yml
@@ -89,6 +89,7 @@ jobs:
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
+          crcMemory: 12000
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
       


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1159

We're realizing that we need some extra memory headroom for the CRC cluster.