### PR TITLE
adding a new PodStates struct to env for ready/non-ready pod comparison

### DIFF
--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -59,8 +59,14 @@ const (
 	labelTemplate              = "%s/%s"
 )
 
+type PodStates struct {
+	BeforeExecution map[string]int
+	AfterExecution  map[string]int
+}
+
 type DiscoveredTestData struct {
 	Env                          configuration.TestParameters
+	PodStates                    PodStates
 	Pods                         []corev1.Pod
 	AllPods                      []corev1.Pod
 	ProbePods                    []corev1.Pod
@@ -130,7 +136,7 @@ var data = DiscoveredTestData{}
 const labelRegex = `(\S*)\s*:\s*(\S*)`
 const labelRegexMatches = 3
 
-func createLabels(labelStrings []string) (labelObjects []labelObject) {
+func CreateLabels(labelStrings []string) (labelObjects []labelObject) {
 	for _, label := range labelStrings {
 		r := regexp.MustCompile(labelRegex)
 
@@ -159,8 +165,8 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 		log.Fatal("Failed to retrieve storageClasses - err: %v", err)
 	}
 
-	podsUnderTestLabelsObjects := createLabels(config.PodsUnderTestLabels)
-	operatorsUnderTestLabelsObjects := createLabels(config.OperatorsUnderTestLabels)
+	podsUnderTestLabelsObjects := CreateLabels(config.PodsUnderTestLabels)
+	operatorsUnderTestLabelsObjects := CreateLabels(config.OperatorsUnderTestLabels)
 
 	log.Debug("Pods under test labels: %+v", podsUnderTestLabelsObjects)
 	log.Debug("Operators under test labels: %+v", operatorsUnderTestLabelsObjects)
@@ -181,11 +187,12 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	data.AllPackageManifests = getAllPackageManifests(oc.OlmPkgClient.PackageManifests(""))
 
 	data.Namespaces = namespacesListToStringList(config.TargetNameSpaces)
-	data.Pods, data.AllPods = findPodsByLabels(oc.K8sClient.CoreV1(), podsUnderTestLabelsObjects, data.Namespaces)
+	data.Pods, data.AllPods = FindPodsByLabels(oc.K8sClient.CoreV1(), podsUnderTestLabelsObjects, data.Namespaces)
+	data.PodStates.BeforeExecution = CountPodsByStatus(data.AllPods)
 	data.AbnormalEvents = findAbnormalEvents(oc.K8sClient.CoreV1(), data.Namespaces)
 	probeLabels := []labelObject{{LabelKey: probeHelperPodsLabelName, LabelValue: probeHelperPodsLabelValue}}
 	probeNS := []string{config.ProbeDaemonSetNamespace}
-	data.ProbePods, _ = findPodsByLabels(oc.K8sClient.CoreV1(), probeLabels, probeNS)
+	data.ProbePods, _ = FindPodsByLabels(oc.K8sClient.CoreV1(), probeLabels, probeNS)
 	data.ResourceQuotaItems, err = getResourceQuotas(oc.K8sClient.CoreV1())
 	if err != nil {
 		log.Fatal("Cannot get resource quotas, err: %v", err)
@@ -223,7 +230,7 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 	}
 
 	// Best effort mode autodiscovery for operand (running-only) pods.
-	pods, _ := findPodsByLabels(oc.K8sClient.CoreV1(), nil, data.Namespaces)
+	pods, _ := FindPodsByLabels(oc.K8sClient.CoreV1(), nil, data.Namespaces)
 	if err != nil {
 		log.Fatal("Failed to get running pods, err: %v", err)
 	}

--- a/pkg/autodiscover/autodiscover_pods.go
+++ b/pkg/autodiscover/autodiscover_pods.go
@@ -41,7 +41,7 @@ func findPodsMatchingAtLeastOneLabel(oc corev1client.CoreV1Interface, labels []l
 	return allPods
 }
 
-func findPodsByLabels(oc corev1client.CoreV1Interface, labels []labelObject, namespaces []string) (runningPods, allPods []corev1.Pod) {
+func FindPodsByLabels(oc corev1client.CoreV1Interface, labels []labelObject, namespaces []string) (runningPods, allPods []corev1.Pod) {
 	runningPods = []corev1.Pod{}
 	allPods = []corev1.Pod{}
 	// Iterate through namespaces
@@ -69,4 +69,21 @@ func findPodsByLabels(oc corev1client.CoreV1Interface, labels []labelObject, nam
 	}
 
 	return runningPods, allPods
+}
+
+func CountPodsByStatus(allPods []corev1.Pod) map[string]int {
+	podStates := map[string]int{
+		"ready":     0,
+		"non-ready": 0,
+	}
+
+	for i := range allPods {
+		if allPods[i].Status.Phase == corev1.PodRunning {
+			podStates["ready"]++
+		} else {
+			podStates["non-ready"]++
+		}
+	}
+
+	return podStates
 }

--- a/pkg/autodiscover/autodiscover_pods_test.go
+++ b/pkg/autodiscover/autodiscover_pods_test.go
@@ -91,7 +91,7 @@ func TestFindPodsUnderTest(t *testing.T) {
 		testRuntimeObjects = append(testRuntimeObjects, generatePod(tc.testPodName, tc.testPodNamespace, tc.queryLabel))
 		oc := clientsholder.GetTestClientsHolder(testRuntimeObjects)
 
-		podResult, _ := findPodsByLabels(oc.K8sClient.CoreV1(), testLabel, testNamespaces)
+		podResult, _ := FindPodsByLabels(oc.K8sClient.CoreV1(), testLabel, testNamespaces)
 		assert.Equal(t, tc.expectedResults, podResult)
 	}
 }

--- a/pkg/autodiscover/autodiscover_test.go
+++ b/pkg/autodiscover/autodiscover_test.go
@@ -50,8 +50,8 @@ func TestCreateLabels(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if gotLabelObjects := createLabels(tt.args.labelStrings); !reflect.DeepEqual(gotLabelObjects, tt.wantLabelObjects) {
-				t.Errorf("createLabels() = %v, want %v", gotLabelObjects, tt.wantLabelObjects)
+			if gotLabelObjects := CreateLabels(tt.args.labelStrings); !reflect.DeepEqual(gotLabelObjects, tt.wantLabelObjects) {
+				t.Errorf("CreateLabels() = %v, want %v", gotLabelObjects, tt.wantLabelObjects)
 			}
 		})
 	}

--- a/pkg/claimhelper/claimhelper_test.go
+++ b/pkg/claimhelper/claimhelper_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite-claim/pkg/claim"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -183,7 +184,7 @@ func TestToJUnitXML(t *testing.T) {
 		endTime, err := time.Parse(DateTimeFormatDirective, "2023-12-20 14:51:34 -0600 MST")
 		assert.Nil(t, err)
 
-		testClaimBuilder, err := NewClaimBuilder()
+		testClaimBuilder, err := NewClaimBuilder(&provider.TestEnvironment{})
 		assert.Nil(t, err)
 
 		testClaimBuilder.claimRoot.Claim.Results = make(map[string]claim.Result)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -81,6 +81,7 @@ type TestEnvironment struct { // rename this with testTarget
 	ProbePods       map[string]*corev1.Pod // map from nodename to probePod
 	AllPods         []*Pod                 `json:"AllPods"`
 	CSVToPodListMap map[string][]*Pod      `json:"CSVToPodListMap"`
+	PodStates       autodiscover.PodStates `json:"podStates"`
 
 	// Deployment Groupings
 	Deployments []*Deployment `json:"testDeployments"`
@@ -300,6 +301,8 @@ func buildTestEnvironment() { //nolint:funlen,gocyclo
 		nodeName := data.ProbePods[i].Spec.NodeName
 		env.ProbePods[nodeName] = &data.ProbePods[i]
 	}
+
+	env.PodStates = data.PodStates
 
 	csvPods := []*Pod{}
 	env.CSVToPodListMap = make(map[string][]*Pod)


### PR DESCRIPTION
## Implementation
- Created a new `PodStates` struct in the `env`, this is unstructured, but could be switched to exact `Phases` if we feel we want to keep track of all phases
   - I don't love the unstructured nature, but wasn't sure how granular we wanted to be. 
- Add logic to compare before/after `ready` states and log the diff
- Updated `NewClaimBuilder` to take in an `env` so that this can be modified, since `env` by nature is a singleton.
- Exported various methods that needed to be called outside of the `autodiscover` pkg.

# Testing

Below is the output of the `claim.json` with this. 
```json
❯ cat results/claim.json | jq .claim.configurations.podStates
{
  "AfterExecution": {
    "non-ready": 0,
    "ready": 2
  },
  "BeforeExecution": {
    "non-ready": 0,
    "ready": 3
  }
}
```

Below is the sample log file (though it seems to only log to the file and not the console, but that seem by design of the suite)
```log
[WARN] [Jul 28 11:36:24.356] [certsuite.go: 152] Some pods were not ready during entire test execution. See results/claim.json podStates section for more details
```

Below is an image from the results html parser
<img width="241" height="305" alt="Screenshot From 2025-07-29 06-54-04" src="https://github.com/user-attachments/assets/ee4c3e37-c683-41f5-b29d-254603fbab3b" />
