### PR TITLE
Fix ES module import issue in nightlies dashboard workflow

### DIFF
--- a/.github/workflows/update-dashboard.yml
+++ b/.github/workflows/update-dashboard.yml
@@ -40,10 +40,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          cat > package.json << 'EOF'
+          {
+            "type": "module"
+          }
+          EOF
+          
           cat > generate-dashboard.js << 'EOF'
-          const { Octokit } = require('@octokit/rest');
-          const fs = require('fs');
-          const path = require('path');
+          import { Octokit } from '@octokit/rest';
+          import fs from 'fs';
+          import path from 'path';
+          import { fileURLToPath } from 'url';
+          
+          const __filename = fileURLToPath(import.meta.url);
+          const __dirname = path.dirname(__filename);
 
           const octokit = new Octokit({
             auth: process.env.GITHUB_TOKEN


### PR DESCRIPTION
## 🐛 **Fix**

The nightlies dashboard workflow was failing with ES module import errors:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module @octokit/rest not supported
```

## 🔧 **Changes**

- Convert from CommonJS `require()` to ES module `import` syntax
- Add `package.json` with `"type": "module"` for ES module support  
- Add `__dirname` setup for ES modules compatibility
- Update `@octokit/rest` import to use modern ES module syntax

## ✅ **Result**

- Fixes dashboard workflow execution
- Enables automatic nightlies dashboard updates
- Dashboard will be accessible at https://redhat-best-practices-for-k8s.github.io/certsuite/nightlies/

## 🔗 **Related**

- Fixes the dashboard deployment issue reported in the merged PR #3119
- Part of the nightlies dashboard implementation effort