### PR TITLE
Fix dashboard deployment to use gh-pages branch

### DIFF
--- a/.github/workflows/update-dashboard.yml
+++ b/.github/workflows/update-dashboard.yml
@@ -40,10 +40,20 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          cat > package.json << 'EOF'
+          {
+            "type": "module"
+          }
+          EOF
+          
           cat > generate-dashboard.js << 'EOF'
-          const { Octokit } = require('@octokit/rest');
-          const fs = require('fs');
-          const path = require('path');
+          import { Octokit } from '@octokit/rest';
+          import fs from 'fs';
+          import path from 'path';
+          import { fileURLToPath } from 'url';
+          
+          const __filename = fileURLToPath(import.meta.url);
+          const __dirname = path.dirname(__filename);
 
           const octokit = new Octokit({
             auth: process.env.GITHUB_TOKEN

--- a/.github/workflows/update-dashboard.yml
+++ b/.github/workflows/update-dashboard.yml
@@ -439,14 +439,10 @@ jobs:
 
             node generate-dashboard.js
 
-      - name: Commit updated dashboard
-        run: |
-          git config --local user.email "action@github.com"
-          git config --local user.name "GitHub Action"
-          git add docs/nightlies/index.html docs/nightlies/workflow-data.json
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "🔄 Update nightlies dashboard [automated]"
-            git push
-          fi
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/nightlies
+          destination_dir: nightlies
+          keep_files: false


### PR DESCRIPTION
## 🐛 **Fix Dashboard Deployment**

The nightlies dashboard workflow was failing at the commit step due to protected branch restrictions:

```
remote: error: GH006: Protected branch update failed
remote: - Changes must be made through a pull request
```

## 🔧 **Changes**

- Replace direct commit to `main` with `peaceiris/actions-gh-pages@v4`
- Deploy to `nightlies/` subdirectory to avoid overwriting existing docs
- Use standard GitHub Pages deployment approach
- Bypasses protected branch restrictions

## ✅ **Result**

- Dashboard will deploy to `gh-pages` branch properly
- Available at https://redhat-best-practices-for-k8s.github.io/certsuite/nightlies/
- Fixes the protected branch deployment issue from the previous run

## 🔗 **Related**

- Completes the fix started in PR #3121
- Enables automated nightlies dashboard updates