### PR TITLE
Remove 'limits' from requests-and-limits test

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -360,16 +360,16 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Non-Telco|Mandatory|
 |Telco|Mandatory|
 
-#### access-control-requests-and-limits
+#### access-control-requests
 
 |Property|Description|
 |---|---|
-|Unique ID|access-control-requests-and-limits|
-|Description|Check that containers have resource requests and limits specified in their spec. Set proper QoS class and resource requests/limits based on container use case.|
-|Suggested Remediation|Add requests and limits to your container spec. See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits|
+|Unique ID|access-control-requests|
+|Description|Check that containers have resource requests specified in their spec. Set proper resource requests based on container use case.|
+|Suggested Remediation|Add requests to your container spec. See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits|
 |Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requests-limits|
 |Exception Process|Exceptions possible for platform and infrastructure containers. Must identify which container needs access and document why with details.|
-|Impact Statement|Missing resource requests and limits can lead to resource contention, node instability, and unpredictable application performance.|
+|Impact Statement|Missing resource requests can lead to resource contention, node instability, and unpredictable application performance.|
 |Tags|telco,access-control|
 |**Scenario**|**Optional/Mandatory**|
 |Extended|Mandatory|

--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Please contact us in case the documentation is broken.
 
 * The catalog of all the available test cases can be found in the [test catalog](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md).
 
-
-
 ## Demo
 
 <!-- markdownlint-disable MD033 MD045 -->

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -18,7 +18,7 @@ testCases:
     - access-control-pod-host-pid
     - access-control-pod-role-bindings
     - access-control-pod-service-account
-    - access-control-requests-and-limits
+    - access-control-requests
     - access-control-security-context-non-root-user-id-check
     - access-control-security-context-privilege-escalation
     - access-control-security-context-read-only-file-system

--- a/tests/accesscontrol/resources/resources.go
+++ b/tests/accesscontrol/resources/resources.go
@@ -5,26 +5,11 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 )
 
-// HasRequestsAndLimitsSet checks if a container has both resource limits and resource requests set.
+// HasRequestsSet checks if a container has resource requests set.
 // Returns :
-//   - bool : true if both resource limits and resource requests are set for the container, otherwise return false.
-func HasRequestsAndLimitsSet(cut *provider.Container, logger *log.Logger) bool {
+//   - bool : true if resource requests are set for the container, otherwise return false.
+func HasRequestsSet(cut *provider.Container, logger *log.Logger) bool {
 	passed := true
-	// Parse the limits.
-	if len(cut.Resources.Limits) == 0 {
-		logger.Error("Container %q has been found missing resource limits", cut)
-		passed = false
-	} else {
-		if cut.Resources.Limits.Cpu().IsZero() {
-			logger.Error("Container %q has been found missing CPU limits", cut)
-			passed = false
-		}
-
-		if cut.Resources.Limits.Memory().IsZero() {
-			logger.Error("Container %q has been found missing memory limits", cut)
-			passed = false
-		}
-	}
 
 	// Parse the requests.
 	if len(cut.Resources.Requests) == 0 {

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -245,10 +245,10 @@ func LoadChecks() {
 			return nil
 		}))
 
-	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestPodRequestsAndLimitsIdentifier)).
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestPodRequestsIdentifier)).
 		WithSkipCheckFn(testhelper.GetNoPodsUnderTestSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
-			testPodRequestsAndLimits(c, &env)
+			testPodRequests(c, &env)
 			return nil
 		}))
 
@@ -955,21 +955,21 @@ func testNoSSHDaemonsAllowed(check *checksdb.Check, env *provider.TestEnvironmen
 	check.SetResult(compliantObjects, nonCompliantObjects)
 }
 
-// testPodRequestsAndLimits is a function that checks if each container has resource requests and limits.
+// testPodRequests is a function that checks if each container has resource requests.
 // It sets the result of a compliance check based on the analysis of lists of compliant and non-compliant objects.
-func testPodRequestsAndLimits(check *checksdb.Check, env *provider.TestEnvironment) {
+func testPodRequests(check *checksdb.Check, env *provider.TestEnvironment) {
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject
-	// Loop through the containers, looking for containers that are missing requests or limits.
+	// Loop through the containers, looking for containers that are missing requests.
 	// These need to be defined in order to pass.
 	for _, cut := range env.Containers {
 		check.LogInfo("Testing Container %q", cut)
-		if !resources.HasRequestsAndLimitsSet(cut, check.GetLogger()) {
-			check.LogError("Container %q is missing resource requests or limits", cut)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container is missing resource requests or limits", false))
+		if !resources.HasRequestsSet(cut, check.GetLogger()) {
+			check.LogError("Container %q is missing resource requests", cut)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container is missing resource requests", false))
 		} else {
-			check.LogInfo("Container %q has resource requests and limits", cut)
-			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container has resource requests and limits", true))
+			check.LogInfo("Container %q has resource requests", cut)
+			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container has resource requests", true))
 		}
 	}
 

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -48,7 +48,7 @@ const (
 	TestOneProcessPerContainerIdentifierDocLink              = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-one-process-per-container"
 	TestSYSNiceRealtimeCapabilityIdentifierDocLink           = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-sys_nice"
 	TestSysPtraceCapabilityIdentifierDocLink                 = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-sys_ptrace"
-	TestPodRequestsAndLimitsIdentifierDocLink                = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requests-limits"
+	TestPodRequestsIdentifierDocLink                         = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requests-limits"
 	TestNamespaceResourceQuotaIdentifierDocLink              = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-memory-allocation"
 	TestNoSSHDaemonsAllowedIdentifierDocLink                 = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-pod-interaction-and-configuration"
 

--- a/tests/identifiers/exceptions.go
+++ b/tests/identifiers/exceptions.go
@@ -52,6 +52,6 @@ const (
 
 	OperatorSkipRangeExceptionProcess = `If there is not a version of the operator that needs to be skipped, then an exception will be granted.`
 
-	// Exceptions for requests and limits test
-	RequestsAndLimitsExceptionProcess = `Exceptions possible for platform and infrastructure containers. Must identify which container needs access and document why with details.`
+	// Exceptions for requests test
+	RequestsExceptionProcess = `Exceptions possible for platform and infrastructure containers. Must identify which container needs access and document why with details.`
 )

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -166,7 +166,7 @@ var (
 	TestOneProcessPerContainerIdentifier                             claim.Identifier
 	TestSYSNiceRealtimeCapabilityIdentifier                          claim.Identifier
 	TestSysPtraceCapabilityIdentifier                                claim.Identifier
-	TestPodRequestsAndLimitsIdentifier                               claim.Identifier
+	TestPodRequestsIdentifier                                        claim.Identifier
 	TestNamespaceResourceQuotaIdentifier                             claim.Identifier
 	TestPodDisruptionBudgetIdentifier                                claim.Identifier
 	TestAPICompatibilityWithNextOCPReleaseIdentifier                 claim.Identifier
@@ -1613,13 +1613,13 @@ that Node's kernel may not have the same hacks.'`,
 		},
 		TagTelco)
 
-	TestPodRequestsAndLimitsIdentifier = AddCatalogEntry(
-		"requests-and-limits",
+	TestPodRequestsIdentifier = AddCatalogEntry(
+		"requests",
 		common.AccessControlTestKey,
-		`Check that containers have resource requests and limits specified in their spec. Set proper QoS class and resource requests/limits based on container use case.`,
-		RequestsAndLimitsRemediation,
-		RequestsAndLimitsExceptionProcess,
-		TestPodRequestsAndLimitsIdentifierDocLink,
+		`Check that containers have resource requests specified in their spec. Set proper resource requests based on container use case.`,
+		RequestsRemediation,
+		RequestsExceptionProcess,
+		TestPodRequestsIdentifierDocLink,
 		true,
 		map[string]string{
 			FarEdge:  Mandatory,

--- a/tests/identifiers/impact.go
+++ b/tests/identifiers/impact.go
@@ -62,7 +62,7 @@ const (
 	TestOneProcessPerContainerIdentifierImpact              = `Multiple processes per container complicate monitoring, debugging, and security assessment, and can lead to zombie processes and resource leaks.`
 	TestSYSNiceRealtimeCapabilityIdentifierImpact           = `Missing SYS_NICE capability on real-time nodes prevents applications from setting appropriate scheduling priorities, causing performance degradation.`
 	TestSysPtraceCapabilityIdentifierImpact                 = `Missing SYS_PTRACE capability when using shared process namespaces prevents inter-container process communication, breaking application functionality.`
-	TestPodRequestsAndLimitsIdentifierImpact                = `Missing resource requests and limits can lead to resource contention, node instability, and unpredictable application performance.`
+	TestPodRequestsIdentifierImpact                         = `Missing resource requests can lead to resource contention, node instability, and unpredictable application performance.`
 	TestNamespaceResourceQuotaIdentifierImpact              = `Without resource quotas, workloads can consume excessive cluster resources, causing performance issues and potential denial of service for other applications.`
 	TestSecConReadOnlyFilesystemImpact                      = `Writable root filesystems increase the attack surface and can be exploited to modify container behavior or persist malware.`
 	TestNoSSHDaemonsAllowedIdentifierImpact                 = `SSH daemons in containers create additional attack surfaces, violate immutable infrastructure principles, and can be exploited for unauthorized access.`
@@ -203,7 +203,7 @@ var ImpactMap = map[string]string{
 	"access-control-one-process-per-container":               TestOneProcessPerContainerIdentifierImpact,
 	"access-control-sys-nice-realtime-capability":            TestSYSNiceRealtimeCapabilityIdentifierImpact,
 	"access-control-sys-ptrace-capability":                   TestSysPtraceCapabilityIdentifierImpact,
-	"access-control-requests-and-limits":                     TestPodRequestsAndLimitsIdentifierImpact,
+	"access-control-requests":                                TestPodRequestsIdentifierImpact,
 	"access-control-namespace-resource-quota":                TestNamespaceResourceQuotaIdentifierImpact,
 	"access-control-security-context-read-only-file-system":  TestSecConReadOnlyFilesystemImpact,
 	"access-control-ssh-daemons":                             TestNoSSHDaemonsAllowedIdentifierImpact,

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -157,7 +157,7 @@ const (
 
 	OCPReservedPortsUsageRemediation = `Ensure that workload's apps do not listen on ports that are reserved by OpenShift. The following ports are reserved by OpenShift and must NOT be used by any application: 22623, 22624.`
 
-	RequestsAndLimitsRemediation = `Add requests and limits to your container spec. See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits`
+	RequestsRemediation = `Add requests to your container spec. See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits`
 
 	NamespaceResourceQuotaRemediation = `Apply a ResourceQuota to the namespace your workload is running in. The workload's namespace should have resource quota defined.`
 


### PR DESCRIPTION
Removes the `limits` from the original `requests-and-limits` test as we are no longer going to be enforcing the check for limits.  This has been a controversial check and will be "smoother" with it removed.