### PR TITLE
Fix markdownlint errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,6 @@ Please contact us in case the documentation is broken.
 
 * The catalog of all the available test cases can be found in the [test catalog](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md).
 
-
-
 ## Demo
 
 <!-- markdownlint-disable MD033 MD045 -->


### PR DESCRIPTION
```
$ make markdownlint 
markdownlint '**/*.md'
README.md:27 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
README.md:28 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 3]
make: *** [markdownlint] Error 1
```