### PR TITLE
Adjust hosted QE runs for efficiency

### DIFF
--- a/.github/workflows/qe-hosted-arm.yml
+++ b/.github/workflows/qe-hosted-arm.yml
@@ -101,17 +101,17 @@ jobs:
       # Download the image from the artifact and load it into the docker daemon.
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
-        
-      - name: Download image from artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: testimage
-          path: /tmp
 
       - name: Setup partner cluster
         uses: ./.github/actions/setup-partner-cluster
         with:
           make-command: 'install-for-qe'
+
+      - name: Download image from artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: testimage
+          path: /tmp
 
       - name: Load image into docker
         run: docker load --input /tmp/testimage.tar

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -79,10 +79,34 @@ jobs:
           name: testimage
           path: /tmp/testimage.tar
 
+  # Build the binary used for testing first, then pass it to the QE tests.
+  # This saves time by not building the binary in each QE suite.
+  build-binary-for-qe:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Set up Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          go-version-file: go.mod
+
+      - name: Build the binary
+        run: make build-certsuite-tool
+
+      - name: Store binary as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: certsuite-binary
+          path: ./certsuite
+
   qe-testing:
     runs-on: ubuntu-24.04
-    needs: build-image-for-qe
-    if: needs.build-image-for-qe.result == 'success' 
+    needs: [build-image-for-qe, build-binary-for-qe]
+    if: needs.build-image-for-qe.result == 'success' && needs.build-binary-for-qe.result == 'success' 
     strategy:
       fail-fast: false
       matrix:
@@ -121,6 +145,17 @@ jobs:
       - name: Load image into docker
         run: docker load --input /tmp/testimage.tar
 
+      - name: Download binary from artifact
+        if: github.event_name == 'schedule'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: certsuite-binary
+          path: .
+
+      - name: Make binary executable
+        if: github.event_name == 'schedule'
+        run: chmod +x ./certsuite
+
       - name: Clone the QE repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -141,10 +176,6 @@ jobs:
           command: cd ${GITHUB_WORKSPACE}/certsuite-qe; FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE} CERTSUITE_IMAGE=${{env.CERTSUITE_IMAGE_NAME}} CERTSUITE_IMAGE_TAG=${{env.TEST_CERTSUITE_IMAGE_TAG}} JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=true ENABLE_FLAKY_RETRY=true make test-features
 
       # Only run against the binary during a scheduled run
-      - name: Build the binary
-        if: github.event_name == 'schedule'
-        run: make build-certsuite-tool
-        
       - name: Run the tests (against binary)
         if: github.event_name == 'schedule'
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2


### PR DESCRIPTION
I noticed that the qe-hosted-arm.yml was failing over and over because the testimage.tar was not available.  That's because the `Setup partner cluster` step was modifying the docker install under the covers and the image was no longer available.

**Workflow optimization and artifact management:**

* Added a new `build-binary-for-qe` job in `.github/workflows/qe-hosted.yml` to build the `certsuite` binary once and upload it as an artifact, reducing redundant builds in each QE suite.
* Updated the `qe-testing` job to depend on both the image and binary build jobs, ensuring tests only run if both artifacts are available.
* Added steps in the `qe-testing` job to download the binary artifact and make it executable, but only during scheduled runs.
* Removed the redundant step that built the binary inside the `qe-testing` job during scheduled runs, since the binary is now built and shared via artifact.

**Job step reordering:**

* In `.github/workflows/qe-hosted-arm.yml`, reordered the `Setup partner cluster` step to occur before downloading the image artifact, ensuring the cluster is ready for subsequent steps.