### PR TITLE
Multus annotation safeguards

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -548,6 +548,11 @@ func GetPodIPsPerNet(annotation string) (ips map[string]CniNetworkInterface, err
 	// The list of ips pr net is parsed from the content of the "k8s.v1.cni.cncf.io/networks-status" annotation.
 	ips = make(map[string]CniNetworkInterface)
 
+	// Sanity check: if the annotation is missing or empty, return empty result without error
+	if strings.TrimSpace(annotation) == "" {
+		return ips, nil
+	}
+
 	var cniInfo []CniNetworkInterface
 	err = json.Unmarshal([]byte(annotation), &cniInfo)
 	if err != nil {
@@ -564,6 +569,11 @@ func GetPodIPsPerNet(annotation string) (ips map[string]CniNetworkInterface, err
 }
 
 func GetPciPerPod(annotation string) (pciAddr []string, err error) {
+	// Sanity check: if the annotation is missing or empty, return empty result without error
+	if strings.TrimSpace(annotation) == "" {
+		return []string{}, nil
+	}
+
 	var cniInfo []CniNetworkInterface
 	err = json.Unmarshal([]byte(annotation), &cniInfo)
 	if err != nil {


### PR DESCRIPTION
In the autodiscover step, we were seeing logs like:

```
[ERROR] [Aug 11 13:59:35.951] [pods.go: 68] Could not get PCIs for Pod "networkingputa-55774dd985-6b5ks" (namespace "networking-tests-cybnlyllme"), err: could not unmarshal network-status annotation, err: unexpected end of JSON input
```

This was caused because we are specifically looking for `"k8s.v1.cni.cncf.io/network-status"` annotations on pods.  I'm adding some safeguards to make the process more readable and "safer" with an empty string check.

New logs look like:

```
[INFO] [Aug 11 14:49:14.821] [pods.go: 69] Pod "networkingputa-566559c666-n99kj" (namespace "networking-tests-exwmmpfwvk") missing or empty annotation "k8s.v1.cni.cncf.io/network-status". Present annotations: [openshift.io/scc k8s.ovn.org/pod-networks k8s.v1.cni.cncf.io/networks]
```

This is a non-functional change as I'm not changing the output, just making everything have proper checks.