### PR TITLE
Disable 'image' runs from nightlies

### DIFF
--- a/.github/workflows/qe-ocp-418-intrusive.yaml
+++ b/.github/workflows/qe-ocp-418-intrusive.yaml
@@ -63,7 +63,8 @@ jobs:
       matrix: 
         # Add more suites if more intrusive tests are added to the QE repo
         suite: [lifecycle]
-        run-type: [binary, image]
+        # run-type: [binary, image]
+        run-type: [binary]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.crc/machines/crc/kubeconfig'

--- a/.github/workflows/qe-ocp-418.yaml
+++ b/.github/workflows/qe-ocp-418.yaml
@@ -62,7 +62,8 @@ jobs:
       fail-fast: false
       matrix: 
         suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
-        run-type: [binary, image]
+        # run-type: [binary, image]
+        run-type: [binary]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.crc/machines/crc/kubeconfig'

--- a/.github/workflows/qe-ocp-419-intrusive.yaml
+++ b/.github/workflows/qe-ocp-419-intrusive.yaml
@@ -63,7 +63,8 @@ jobs:
       matrix: 
         # Add more suites if more intrusive tests are added to the QE repo
         suite: [lifecycle]
-        run-type: [binary, image]
+        # run-type: [binary, image]
+        run-type: [binary]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.crc/machines/crc/kubeconfig'

--- a/.github/workflows/qe-ocp-419.yaml
+++ b/.github/workflows/qe-ocp-419.yaml
@@ -62,7 +62,8 @@ jobs:
       fail-fast: false
       matrix: 
         suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
-        run-type: [binary, image]
+        # run-type: [binary, image]
+        run-type: [binary]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.crc/machines/crc/kubeconfig'


### PR DESCRIPTION
Temporarily commenting out the image runs due to memory constraints in the runner VMs.  Something seems to have changed upstream that's now giving us less memory to work with.