### PR TITLE
Take advantage of QE memory limit flag

### DIFF
--- a/.github/workflows/qe-ocp-414-intrusive.yaml
+++ b/.github/workflows/qe-ocp-414-intrusive.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   pull-unstable-image:

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   pull-unstable-image:

--- a/.github/workflows/qe-ocp-415-intrusive.yaml
+++ b/.github/workflows/qe-ocp-415-intrusive.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   pull-unstable-image:

--- a/.github/workflows/qe-ocp-415.yaml
+++ b/.github/workflows/qe-ocp-415.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   pull-unstable-image:

--- a/.github/workflows/qe-ocp-416-intrusive.yaml
+++ b/.github/workflows/qe-ocp-416-intrusive.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   pull-unstable-image:

--- a/.github/workflows/qe-ocp-416.yaml
+++ b/.github/workflows/qe-ocp-416.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   pull-unstable-image:

--- a/.github/workflows/qe-ocp-417-intrusive.yaml
+++ b/.github/workflows/qe-ocp-417-intrusive.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   pull-unstable-image:

--- a/.github/workflows/qe-ocp-417.yaml
+++ b/.github/workflows/qe-ocp-417.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   pull-unstable-image:

--- a/.github/workflows/qe-ocp-418-intrusive.yaml
+++ b/.github/workflows/qe-ocp-418-intrusive.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   build-and-store:
@@ -98,7 +99,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.16
+        uses: palmsoftware/quick-ocp@v0.0.17
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-418.yaml
+++ b/.github/workflows/qe-ocp-418.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   build-and-store:
@@ -97,7 +98,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.16
+        uses: palmsoftware/quick-ocp@v0.0.17
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-419-intrusive.yaml
+++ b/.github/workflows/qe-ocp-419-intrusive.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   build-and-store:
@@ -98,7 +99,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.16
+        uses: palmsoftware/quick-ocp@v0.0.17
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-419.yaml
+++ b/.github/workflows/qe-ocp-419.yaml
@@ -13,6 +13,7 @@ permissions:
 
 env:
   QE_REPO: redhat-best-practices-for-k8s/certsuite-qe
+  ENABLE_CERTSUITE_MEMORY_LIMIT: true
 
 jobs:
   build-and-store:
@@ -97,7 +98,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.16
+        uses: palmsoftware/quick-ocp@v0.0.17
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true


### PR DESCRIPTION
Enable the `GOMEMLIMIT` support in QE from: https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1191

`quick-ocp` also now supports swap instead of disabling it.  Hopefully alleviating some of the memory pressure.