### PR TITLE
add TrimSpace to output string in GetSSHDaemonPort to prevent errors

### DIFF
--- a/tests/networking/netutil/netutil.go
+++ b/tests/networking/netutil/netutil.go
@@ -85,5 +85,5 @@ func GetSSHDaemonPort(cut *provider.Container) (string, error) {
 		return "", fmt.Errorf("failed to execute command %s on %s, err: %v", findSSHDaemonPort, cut, err)
 	}
 
-	return outStr, nil
+	return strings.TrimSpace(outStr), nil
 }


### PR DESCRIPTION
## Changes
- Add `strings.TrimSpace` before `outStr` is returned this will take care of
```
  - Spaces  
  - Tabs \t
  - Newlines \n
  - Carriage returns \r
```
- Fixes: #3159 