### PR TITLE
Update labels to pass preflight

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -461,6 +461,10 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          labels: |
+            name=cnf-certification-test
+            vendor=certsuite
+            maintainer=certsuite maintainers
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.CERTSUITE_IMAGE_NAME_LEGACY }}:${{ env.CERTSUITE_IMAGE_TAG }}
@@ -524,6 +528,10 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          labels: |
+            name=certsuite
+            vendor=certsuite
+            maintainer=certsuite maintainers
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{ env.CERTSUITE_IMAGE_NAME }}:${{ env.CERTSUITE_IMAGE_TAG }}

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -155,6 +155,10 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          labels: |
+            name=certsuite
+            vendor=certsuite
+            maintainer=certsuite maintainers
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{env.CERTSUITE_IMAGE_NAME}}:${{ env.CERTSUITE_VERSION }}
@@ -287,6 +291,10 @@ jobs:
           context: .
           file: Dockerfile
           platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
+          labels: |
+            name=cnf-certification-test
+            vendor=certsuite
+            maintainer=certsuite maintainers
           push: true
           tags: |
             ${{ env.REGISTRY }}/${{env.CERTSUITE_IMAGE_NAME_LEGACY}}:${{ env.CERTSUITE_VERSION }}


### PR DESCRIPTION
Similar to: https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/pull/588

This should allow us to pass the new Preflight tests: https://github.com/redhat-best-practices-for-k8s/certsuite/actions/runs/17437313990