### PR TITLE
Add probe update workflow

### DIFF
--- a/.github/workflows/probe-update.yaml
+++ b/.github/workflows/probe-update.yaml
@@ -1,0 +1,114 @@
+name: Update certsuite-probe version references
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  update-probe:
+    if: github.repository_owner == 'redhat-best-practices-for-k8s'
+    name: Update probe image tag and open PR
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      SHELL: /bin/bash
+      PROBE_REPO: redhat-best-practices-for-k8s/certsuite-probe
+      PROBE_RELEASES_URL: https://api.github.com/repos/redhat-best-practices-for-k8s/certsuite-probe/releases/latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: main
+
+      - name: Set up Go
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
+        with:
+          go-version-file: go.mod
+
+      - name: Determine current and latest probe versions
+        id: versions
+        run: |
+          set -euo pipefail
+
+          CURRENT=$(jq -r '.debugTag' version.json)
+          echo "current=${CURRENT}" >> $GITHUB_OUTPUT
+
+          # Fetch latest release with retry and exponential backoff
+          AUTH_HEADER=""
+          if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+            AUTH_HEADER="Authorization: Bearer ${GITHUB_TOKEN}"
+          fi
+
+          LATEST=""
+          for attempt in {1..5}; do
+            STATUS=$(curl -sS -H "Accept: application/vnd.github+json" ${AUTH_HEADER:+-H "$AUTH_HEADER"} -o /tmp/probe_latest.json -w "%{http_code}" "${PROBE_RELEASES_URL}" || true)
+            if [[ "${STATUS}" == "200" ]]; then
+              LATEST=$(jq -r .tag_name /tmp/probe_latest.json)
+            fi
+
+            if [[ -n "${LATEST}" && "${LATEST}" != "null" ]]; then
+              break
+            fi
+
+            SLEEP=$((2 ** (attempt-1)))
+            echo "Attempt ${attempt} failed (status=${STATUS}). Retrying in ${SLEEP}s..."
+            sleep "${SLEEP}"
+          done
+
+          if [[ -z "${LATEST}" || "${LATEST}" == "null" ]]; then
+            echo "Failed to resolve latest probe tag after retries" >&2
+            exit 1
+          fi
+          echo "latest=${LATEST}" >> $GITHUB_OUTPUT
+
+          if [[ "${CURRENT}" == "${LATEST}" ]]; then
+            echo "Probe already at latest (${LATEST})."; echo "should_update=false" >> $GITHUB_OUTPUT
+          else
+            echo "should_update=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Stop if already up to date
+        if: steps.versions.outputs.should_update == 'false'
+        run: echo "No update needed"
+
+      - name: Update files to latest probe version
+        if: steps.versions.outputs.should_update == 'true'
+        run: |
+          set -euo pipefail
+          LATEST=${{ steps.versions.outputs.latest }}
+
+          # Update version.json (debugTag)
+          tmp=$(mktemp)
+          jq --arg tag "${LATEST}" '.debugTag = $tag' version.json > "$tmp" && mv "$tmp" version.json
+
+          # Update docs/runtime-env.md default image reference
+          sed -i "s|certsuite-probe:v[0-9]\+\.[0-9]\+\.[0-9]\+|certsuite-probe:${LATEST}|" docs/runtime-env.md
+
+          # Update default flag in cmd/certsuite/run/run.go
+          sed -i "s|quay.io/redhat-best-practices-for-k8s/certsuite-probe:v[0-9]\+\.[0-9]\+\.[0-9]\+|quay.io/redhat-best-practices-for-k8s/certsuite-probe:${LATEST}|" cmd/certsuite/run/run.go
+
+          echo "Updated files to ${LATEST}:"
+          git --no-pager diff -- . | cat
+
+      - name: Run unit tests
+        if: steps.versions.outputs.should_update == 'true'
+        run: make test
+
+      - name: Create PR
+        if: steps.versions.outputs.should_update == 'true'
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+        with:
+          commit-message: "Update certsuite-probe to ${{ steps.versions.outputs.latest }}"
+          title: "Update probe to ${{ steps.versions.outputs.latest }}"
+          body: |
+            - Bump certsuite-probe to `${{ steps.versions.outputs.latest }}`
+            - Updated `version.json`, `docs/runtime-env.md`, and `cmd/certsuite/run/run.go`
+          branch: update-probe-${{ steps.versions.outputs.latest }}
+
+


### PR DESCRIPTION
Similar to other workflows that look at releases that I use:
- https://github.com/palmsoftware/quick-k8s/blob/main/.github/workflows/calico-update.yml
- https://github.com/palmsoftware/quick-k8s/blob/main/.github/workflows/olm-update.yml

This will check for new probe versions and make the appropriate `sed` replaces.