### PR TITLE
Add permissions for updating workflows

### DIFF
--- a/.github/workflows/probe-update.yaml
+++ b/.github/workflows/probe-update.yaml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: main
+          persist-credentials: false
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
@@ -107,11 +109,12 @@ jobs:
         if: steps.versions.outputs.should_update == 'true'
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
+          token: ${{ secrets.UPDATE_CERTIFIED_DB_TOKEN }}
           commit-message: "Update certsuite-probe to ${{ steps.versions.outputs.latest }}"
           title: "Update probe to ${{ steps.versions.outputs.latest }}"
           body: |
             - Bump certsuite-probe to `${{ steps.versions.outputs.latest }}`
-            - Updated `version.json`, `docs/runtime-env.md`, and `cmd/certsuite/run/run.go`
+            - Updated `version.json`, `docs/runtime-env.md`, `cmd/certsuite/run/run.go`, and `.github/workflows/pre-main.yaml`
           branch: update-probe-${{ steps.versions.outputs.latest }}
 
 


### PR DESCRIPTION
https://github.com/redhat-best-practices-for-k8s/certsuite/actions/runs/17469229193/job/49612992831#step:8:263

The latest run failed because we weren't using a GITHUB_TOKEN with permissions to update workflows.