### PR TITLE
Modify precheck images job

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -19,7 +19,6 @@ env:
   OCT_IMAGE_NAME: redhat-best-practices-for-k8s/oct
   OCT_IMAGE_TAG: latest
   PROBE_IMAGE_NAME: redhat-best-practices-for-k8s/certsuite-probe
-  PROBE_IMAGE_TAG: v0.0.25
   CERTSUITE_CONFIG_DIR: /tmp/certsuite/config
   CERTSUITE_OUTPUT_DIR: /tmp/certsuite/output
   SMOKE_TESTS_LOG_LEVEL: debug
@@ -171,10 +170,17 @@ jobs:
     env:
       SHELL: /bin/bash
     steps:
+      - name: Check out code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          ref: ${{ github.sha }}
+
       - name: Pull the images to verify they exist
         run: |
           docker pull ${REGISTRY}/${OCT_IMAGE_NAME}:${OCT_IMAGE_TAG}
-          docker pull ${REGISTRY}/${PROBE_IMAGE_NAME}:${PROBE_IMAGE_TAG}
+          PROBE_TAG=$(jq -r '.debugTag' version.json)
+          echo "Using probe tag: ${PROBE_TAG}"
+          docker pull ${REGISTRY}/${PROBE_IMAGE_NAME}:${PROBE_TAG}
 
   smoke-tests-local:
     name: Run Local Smoke Tests

--- a/.github/workflows/probe-update.yaml
+++ b/.github/workflows/probe-update.yaml
@@ -93,9 +93,6 @@ jobs:
           # Update default flag in cmd/certsuite/run/run.go
           sed -i "s|quay.io/redhat-best-practices-for-k8s/certsuite-probe:v[0-9]\+\.[0-9]\+\.[0-9]\+|quay.io/redhat-best-practices-for-k8s/certsuite-probe:${LATEST}|" cmd/certsuite/run/run.go
 
-          # Update PROBE_IMAGE_TAG in CI workflow pre-main.yaml
-          sed -i "s|PROBE_IMAGE_TAG: v[0-9]\+\.[0-9]\+\.[0-9]\+|PROBE_IMAGE_TAG: ${LATEST}|" .github/workflows/pre-main.yaml
-
           echo "Updated files to ${LATEST}:"
           git --no-pager diff -- . | cat
 


### PR DESCRIPTION
Because of permissions problems, I modified the `pre-main.yml` to just grab the debugTag variable from version.json instead so the update job doesn't have to modify another workflow.