### PR TITLE
Dockerfile: add --nobest for dnf update.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV \
 # hadolint ignore=DL3041
 RUN \
 	mkdir ${CERTSUITE_DIR} \
-	&& dnf update --assumeyes --disableplugin=subscription-manager \
+	&& dnf update --assumeyes --disableplugin=subscription-manager --nobest \
 	&& dnf install --assumeyes --disableplugin=subscription-manager \
 		gcc \
 		git \


### PR DESCRIPTION
We're getting this error from time to time due to transient dependency mistmatches in official repositories:
```
$ docker run
registry.access.redhat.com/ubi9/ubi:9.6@sha256:8f1496d50a66e41433031bf5bdedd4635520e692ccd76ffcb649cf9d30d669af dnf update --assumeyes --disableplugin=subscription-manager 
Red Hat Universal Base Image 9 (RPMs) - BaseOS  1.1 MB/s | 588 kB 00:00
Red Hat Universal Base Image 9 (RPMs) - AppStre 4.3 MB/s | 2.4 MB 00:00
Red Hat Universal Base Image 9 (RPMs) - CodeRea 555 kB/s | 287 kB 00:00
Error:
 Problem: The operation would result in removing the following protected
packages: systemd
(try to add '--allowerasing' to command line to replace conflicting packages or '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```
This is making our tnf-image.yaml workflows to fail, see here: https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/actions/runs/17755359417/job/50457323515#step:5:73

The --nobest makes it work during those transient repo states.