### PR TITLE
Simplify WaitGroup for Go 1.25

### DIFF
--- a/tests/lifecycle/podrecreation/podrecreation.go
+++ b/tests/lifecycle/podrecreation/podrecreation.go
@@ -130,13 +130,11 @@ func deletePod(pod *corev1.Pod, mode string, wg *sync.WaitGroup) error {
 	if mode == DeleteBackground {
 		return nil
 	}
-	wg.Add(1)
 	podName := pod.Name
 	namespace := pod.Namespace
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		waitPodDeleted(namespace, podName, gracePeriodSeconds, watcher)
-	}()
+	})
 	return nil
 }
 


### PR DESCRIPTION
In Go 1.25 (#3176) they introduced a simpler way to spawn goroutines instead of the usual `wg.Add(1)` line.  All you need is `wg.Go(func(){})`

https://tip.golang.org/doc/go1.25

