### PR TITLE
Add --unique-probe-name boolean config variable

### DIFF
--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -52,6 +52,10 @@ func NewCommand() *cobra.Command {
 	runCmd.PersistentFlags().String("connect-api-base-url", "", "Base URL for Red Hat Connect API")
 	runCmd.PersistentFlags().String("connect-api-proxy-url", "", "Proxy URL for Red Hat Connect API")
 	runCmd.PersistentFlags().String("connect-api-proxy-port", "", "Proxy port for Red Hat Connect API")
+	// When enabled, certsuite will deploy a uniquely named probe daemonset per run
+	runCmd.PersistentFlags().Bool("unique-probe-name", false, "Deploy a uniquely named probe daemonset per run")
+	// Hide this development-only flag from help output
+	_ = runCmd.PersistentFlags().MarkHidden("unique-probe-name")
 
 	return runCmd
 }
@@ -86,6 +90,7 @@ func initTestParamsFromFlags(cmd *cobra.Command) error {
 	testParams.ConnectAPIBaseURL, _ = cmd.Flags().GetString("connect-api-base-url")
 	testParams.ConnectAPIProxyURL, _ = cmd.Flags().GetString("connect-api-proxy-url")
 	testParams.ConnectAPIProxyPort, _ = cmd.Flags().GetString("connect-api-proxy-port")
+	testParams.UniqueProbeName, _ = cmd.Flags().GetBool("unique-probe-name")
 	timeoutStr, _ := cmd.Flags().GetString("timeout")
 
 	// Check if the output directory exists and, if not, create it

--- a/docs/test-run.md
+++ b/docs/test-run.md
@@ -96,6 +96,12 @@ The following is a non-exhaustive list of the most common flags that the `certsu
 
     See the [OCT tool](https://github.com/redhat-best-practices-for-k8s/oct) for more information on how to create this DB.
 
+* `--unique-probe-name`: Deploy a uniquely named probe DaemonSet per run.
+
+!!! note
+
+    Development only: This flag is intended for development and troubleshooting to avoid sharing probe pods across concurrent runs. It should not be required in normal operation.
+
 ## Using the container image
 
 The only prerequisite for running the Test Suite in container mode is having Docker or Podman installed.

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -28,6 +28,7 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/performance"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/platform"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/preflight"
+	k8sPrivilegedDs "github.com/redhat-best-practices-for-k8s/privileged-daemonset"
 )
 
 func LoadInternalChecksDB() {
@@ -299,6 +300,14 @@ func Run(labelsFilter, outputFolder string) error {
 			if err != nil {
 				log.Fatal("Failed to remove web file %s: %v", file, err)
 			}
+		}
+	}
+
+	// If unique probe name is enabled, remove the probe daemonset
+	if configuration.GetTestParameters().UniqueProbeName {
+		err = k8sPrivilegedDs.DeleteDaemonSet(env.ProbeDaemonsetName, env.Config.ProbeDaemonSetNamespace)
+		if err != nil {
+			log.Fatal("Failed to remove unique probe daemonset: %v", err)
 		}
 	}
 

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -140,4 +140,6 @@ type TestParameters struct {
 	ConnectAPIProxyPort           string
 	// AllowNonRunning determines whether autodiscovery includes non-Running pods
 	AllowNonRunning bool
+	// UniqueProbeName when true, appends a random suffix to the probe DaemonSet name per run
+	UniqueProbeName bool
 }


### PR DESCRIPTION
Adds a new (development only) `--unique-probe-name` variable that QE can use when we are running the certsuite in parallel.

When enabled, the code will randomly add a suffix string to the certsuite-probe name so each run of the certsuite will have its own version of the probe.