### PR TITLE
Fix /tmp permissions for self-hosted

### DIFF
--- a/.github/workflows/qe-ocp-414-intrusive.yaml
+++ b/.github/workflows/qe-ocp-414-intrusive.yaml
@@ -37,7 +37,7 @@ jobs:
           context: .
           file: ./Dockerfile
           tags: quay.io/redhat-best-practices-for-k8s/certsuite:localtest-414
-          outputs: type=docker,dest=/tmp/testimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/testimage-414.tar
 
       - name: Build the binary
         run: make build-certsuite-tool
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: testimage
-          path: /tmp/testimage.tar
+          path: ${{ runner.temp }}/testimage-414.tar
 
       - name: Store binary as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -109,10 +109,10 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: testimage
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Load image into docker
-        run: docker load --input /tmp/testimage.tar
+        run: docker load --input ${{ runner.temp }}/testimage-414.tar
 
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -37,7 +37,7 @@ jobs:
           context: .
           file: ./Dockerfile
           tags: quay.io/redhat-best-practices-for-k8s/certsuite:localtest-414
-          outputs: type=docker,dest=/tmp/testimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/testimage-414.tar
 
       - name: Build the binary
         run: make build-certsuite-tool
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: testimage
-          path: /tmp/testimage.tar
+          path: ${{ runner.temp }}/testimage-414.tar
 
       - name: Store binary as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -108,10 +108,10 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: testimage
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Load image into docker
-        run: docker load --input /tmp/testimage.tar
+        run: docker load --input ${{ runner.temp }}/testimage-414.tar
 
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2

--- a/.github/workflows/qe-ocp-415-intrusive.yaml
+++ b/.github/workflows/qe-ocp-415-intrusive.yaml
@@ -37,7 +37,7 @@ jobs:
           context: .
           file: ./Dockerfile
           tags: quay.io/redhat-best-practices-for-k8s/certsuite:localtest-415
-          outputs: type=docker,dest=/tmp/testimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/testimage-415.tar
 
       - name: Build the binary
         run: make build-certsuite-tool
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: testimage
-          path: /tmp/testimage.tar
+          path: ${{ runner.temp }}/testimage-415.tar
 
       - name: Store binary as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -109,10 +109,10 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: testimage
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Load image into docker
-        run: docker load --input /tmp/testimage.tar
+        run: docker load --input ${{ runner.temp }}/testimage-415.tar
 
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2

--- a/.github/workflows/qe-ocp-415.yaml
+++ b/.github/workflows/qe-ocp-415.yaml
@@ -37,7 +37,7 @@ jobs:
           context: .
           file: ./Dockerfile
           tags: quay.io/redhat-best-practices-for-k8s/certsuite:localtest-415
-          outputs: type=docker,dest=/tmp/testimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/testimage-415.tar
 
       - name: Build the binary
         run: make build-certsuite-tool
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: testimage
-          path: /tmp/testimage.tar
+          path: ${{ runner.temp }}/testimage-415.tar
 
       - name: Store binary as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -108,10 +108,10 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: testimage
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Load image into docker
-        run: docker load --input /tmp/testimage.tar
+        run: docker load --input ${{ runner.temp }}/testimage-415.tar
 
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2

--- a/.github/workflows/qe-ocp-416-intrusive.yaml
+++ b/.github/workflows/qe-ocp-416-intrusive.yaml
@@ -37,7 +37,7 @@ jobs:
           context: .
           file: ./Dockerfile
           tags: quay.io/redhat-best-practices-for-k8s/certsuite:localtest-416
-          outputs: type=docker,dest=/tmp/testimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/testimage-416.tar
 
       - name: Build the binary
         run: make build-certsuite-tool
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: testimage
-          path: /tmp/testimage.tar
+          path: ${{ runner.temp }}/testimage-416.tar
 
       - name: Store binary as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -109,10 +109,10 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: testimage
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Load image into docker
-        run: docker load --input /tmp/testimage.tar
+        run: docker load --input ${{ runner.temp }}/testimage-416.tar
 
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2

--- a/.github/workflows/qe-ocp-416.yaml
+++ b/.github/workflows/qe-ocp-416.yaml
@@ -37,7 +37,7 @@ jobs:
           context: .
           file: ./Dockerfile
           tags: quay.io/redhat-best-practices-for-k8s/certsuite:localtest-416
-          outputs: type=docker,dest=/tmp/testimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/testimage-416.tar
 
       - name: Build the binary
         run: make build-certsuite-tool
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: testimage
-          path: /tmp/testimage.tar
+          path: ${{ runner.temp }}/testimage-416.tar
 
       - name: Store binary as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -108,10 +108,10 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: testimage
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Load image into docker
-        run: docker load --input /tmp/testimage.tar
+        run: docker load --input ${{ runner.temp }}/testimage-416.tar
 
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2

--- a/.github/workflows/qe-ocp-417-intrusive.yaml
+++ b/.github/workflows/qe-ocp-417-intrusive.yaml
@@ -37,7 +37,7 @@ jobs:
           context: .
           file: ./Dockerfile
           tags: quay.io/redhat-best-practices-for-k8s/certsuite:localtest-417
-          outputs: type=docker,dest=/tmp/testimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/testimage-417.tar
 
       - name: Build the binary
         run: make build-certsuite-tool
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: testimage
-          path: /tmp/testimage.tar
+          path: ${{ runner.temp }}/testimage-417.tar
 
       - name: Store binary as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -109,10 +109,10 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: testimage
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Load image into docker
-        run: docker load --input /tmp/testimage.tar
+        run: docker load --input ${{ runner.temp }}/testimage-417.tar
 
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2

--- a/.github/workflows/qe-ocp-417.yaml
+++ b/.github/workflows/qe-ocp-417.yaml
@@ -37,7 +37,7 @@ jobs:
           context: .
           file: ./Dockerfile
           tags: quay.io/redhat-best-practices-for-k8s/certsuite:localtest-417
-          outputs: type=docker,dest=/tmp/testimage.tar
+          outputs: type=docker,dest=${{ runner.temp }}/testimage-417.tar
 
       - name: Build the binary
         run: make build-certsuite-tool
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: testimage
-          path: /tmp/testimage.tar
+          path: ${{ runner.temp }}/testimage-417.tar
 
       - name: Store binary as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
@@ -108,10 +108,10 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: testimage
-          path: /tmp
+          path: ${{ runner.temp }}
 
       - name: Load image into docker
-        run: docker load --input /tmp/testimage.tar
+        run: docker load --input ${{ runner.temp }}/testimage-417.tar
 
       - name: Run the tests (against image)
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for OCP 414, 415, 416, and 417 (both intrusive and non-intrusive variants) to use the `${{ runner.temp }}` directory for storing and loading Docker image artifacts instead of the fixed `/tmp` path. This change improves portability and reliability across different runner environments.

**Workflow improvements:**

* Changed the Docker build output destination from `/tmp/testimage.tar` to `${{ runner.temp }}/testimage-<version>.tar` in all relevant workflow files, ensuring the use of the runner's temporary directory. [[1]](diffhunk://#diff-7c7a796d8d04f13a7219994504949f30901f04632757c1850c40ef4d76fd6354L40-R40) [[2]](diffhunk://#diff-9499a4a976b22ea2752cd9cf3932bbe0db259aa38974b1eccb7e3cbf614d8c89L40-R40) [[3]](diffhunk://#diff-09d856183725abb03c0eb0b643ca6f82d8a5f2b92e011cb5c4317dea48198b95L40-R40) [[4]](diffhunk://#diff-0b57db0ff12befba052eeb4771e35e128ff43a54d970d2772bd8b6eb164ad491L40-R40) [[5]](diffhunk://#diff-df8a761db8187a6bd39f75c8692d21deb08b40a39d7de0608e8fa68d899281aeL40-R40) [[6]](diffhunk://#diff-5fd78ee70cb32c3b445965f5985e0ab527e6012b5cf4276d358aaf0de629b946L40-R40) [[7]](diffhunk://#diff-34ce979f0f602d580184f58b9cfe10ffde2442bfbd4da5897fb8595303b61982L40-R40) [[8]](diffhunk://#diff-2f8ecbe302d75aba6f002660cdc6bf76db927602c783b6dd875bbaedd863320aL40-R40)
* Updated the artifact upload and download steps to use `${{ runner.temp }}/testimage-<version>.tar` instead of `/tmp/testimage.tar` for both storing and retrieving Docker image artifacts. [[1]](diffhunk://#diff-7c7a796d8d04f13a7219994504949f30901f04632757c1850c40ef4d76fd6354L49-R49) [[2]](diffhunk://#diff-9499a4a976b22ea2752cd9cf3932bbe0db259aa38974b1eccb7e3cbf614d8c89L49-R49) [[3]](diffhunk://#diff-09d856183725abb03c0eb0b643ca6f82d8a5f2b92e011cb5c4317dea48198b95L49-R49) [[4]](diffhunk://#diff-0b57db0ff12befba052eeb4771e35e128ff43a54d970d2772bd8b6eb164ad491L49-R49) [[5]](diffhunk://#diff-df8a761db8187a6bd39f75c8692d21deb08b40a39d7de0608e8fa68d899281aeL49-R49) [[6]](diffhunk://#diff-5fd78ee70cb32c3b445965f5985e0ab527e6012b5cf4276d358aaf0de629b946L49-R49) [[7]](diffhunk://#diff-34ce979f0f602d580184f58b9cfe10ffde2442bfbd4da5897fb8595303b61982L49-R49) [[8]](diffhunk://#diff-2f8ecbe302d75aba6f002660cdc6bf76db927602c783b6dd875bbaedd863320aL49-R49)
* Adjusted the path for downloading artifacts and for the `docker load` command to match the new location in `${{ runner.temp }}` for all affected workflows. [[1]](diffhunk://#diff-7c7a796d8d04f13a7219994504949f30901f04632757c1850c40ef4d76fd6354L112-R115) [[2]](diffhunk://#diff-9499a4a976b22ea2752cd9cf3932bbe0db259aa38974b1eccb7e3cbf614d8c89L111-R114) [[3]](diffhunk://#diff-09d856183725abb03c0eb0b643ca6f82d8a5f2b92e011cb5c4317dea48198b95L112-R115) [[4]](diffhunk://#diff-0b57db0ff12befba052eeb4771e35e128ff43a54d970d2772bd8b6eb164ad491L111-R114) [[5]](diffhunk://#diff-df8a761db8187a6bd39f75c8692d21deb08b40a39d7de0608e8fa68d899281aeL112-R115) [[6]](diffhunk://#diff-5fd78ee70cb32c3b445965f5985e0ab527e6012b5cf4276d358aaf0de629b946L111-R114) [[7]](diffhunk://#diff-34ce979f0f602d580184f58b9cfe10ffde2442bfbd4da5897fb8595303b61982L112-R115) [[8]](diffhunk://#diff-2f8ecbe302d75aba6f002660cdc6bf76db927602c783b6dd875bbaedd863320aL111-R114)