### PR TITLE
Add consolidated free-disk-space action

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,17 @@
+name: 'Free Disk Space'
+description: 'Frees up disk space on Ubuntu runners by removing unnecessary packages and files'
+runs:
+  using: "composite"
+  steps:
+    - name: Free Disk Space (Ubuntu)
+      uses: jlumbroso/free-disk-space@main
+      with:
+        tool-cache: false
+        large-packages: true
+        android: true
+        dotnet: true
+        haskell: true
+        docker-images: true
+        swap-storage: false
+      shell: bash
+

--- a/.github/actions/setup-docker-storage/action.yml
+++ b/.github/actions/setup-docker-storage/action.yml
@@ -1,0 +1,24 @@
+name: 'Setup Docker Storage'
+description: 'Configures Docker to use /mnt/docker-storage instead of /var/lib/docker'
+runs:
+  using: "composite"
+  steps:
+    - name: Create docker/daemon.json if it does not exist
+      shell: bash
+      run: |
+        if [ ! -f /etc/docker/daemon.json ]; then
+          echo '{}' | sudo tee /etc/docker/daemon.json
+        fi
+
+    - name: Make docker to use /mnt (sdb) for storage
+      shell: bash
+      run: |
+        df -h
+        lsblk
+        sudo mkdir /mnt/docker-storage
+        sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
+        sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
+        cat /etc/docker/daemon.json
+        sudo systemctl restart docker
+        sudo ls -la /mnt/docker-storage
+

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -435,22 +435,8 @@ jobs:
       # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
       # This step needs to be done right after the partner repo's bootstrap scripts, as they
       # overwrite the docker's daemon.json.
-      - name: Create docker/daemon.json if it does not exist
-        run: |
-          if [ ! -f /etc/docker/daemon.json ]; then
-            echo '{}' | sudo tee /etc/docker/daemon.json
-          fi
-
-      - name: Make docker to use /mnt (sdb) for storage
-        run: |
-          df -h
-          lsblk
-          sudo mkdir /mnt/docker-storage
-          sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
-          sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
-          cat /etc/docker/daemon.json
-          sudo systemctl restart docker
-          sudo ls -la /mnt/docker-storage
+      - name: Setup Docker Storage
+        uses: ./.github/actions/setup-docker-storage
 
       - name: Login to Quay.io
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
@@ -502,22 +488,8 @@ jobs:
       # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
       # This step needs to be done right after the partner repo's bootstrap scripts, as they
       # overwrite the docker's daemon.json.
-      - name: Create docker/daemon.json if it does not exist
-        run: |
-          if [ ! -f /etc/docker/daemon.json ]; then
-            echo '{}' | sudo tee /etc/docker/daemon.json
-          fi
-
-      - name: Make docker to use /mnt (sdb) for storage
-        run: |
-          df -h
-          lsblk
-          sudo mkdir /mnt/docker-storage
-          sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
-          sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
-          cat /etc/docker/daemon.json
-          sudo systemctl restart docker
-          sudo ls -la /mnt/docker-storage
+      - name: Setup Docker Storage
+        uses: ./.github/actions/setup-docker-storage
 
       - name: Login to Quay.io
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/.github/workflows/qe-hosted-arm.yml
+++ b/.github/workflows/qe-hosted-arm.yml
@@ -36,28 +36,18 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
       # This step needs to be done right after the partner repo's bootstrap scripts, as they
       # overwrite the docker's daemon.json.
-      - name: Create docker/daemon.json if it does not exist
-        run: |
-          if [ ! -f /etc/docker/daemon.json ]; then
-            echo '{}' | sudo tee /etc/docker/daemon.json
-          fi
-
-      - name: Make docker to use /mnt (sdb) for storage
-        run: |
-          df -h
-          lsblk
-          sudo mkdir /mnt/docker-storage
-          sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
-          sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
-          cat /etc/docker/daemon.json
-          sudo systemctl restart docker
-          sudo ls -la /mnt/docker-storage
+      - name: Setup Docker Storage
+        uses: ./.github/actions/setup-docker-storage
 
       - name: Build temporary image tag for this PR
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -41,28 +41,18 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 
       # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
       # This step needs to be done right after the partner repo's bootstrap scripts, as they
       # overwrite the docker's daemon.json.
-      - name: Create docker/daemon.json if it does not exist
-        run: |
-          if [ ! -f /etc/docker/daemon.json ]; then
-            echo '{}' | sudo tee /etc/docker/daemon.json
-          fi
-
-      - name: Make docker to use /mnt (sdb) for storage
-        run: |
-          df -h
-          lsblk
-          sudo mkdir /mnt/docker-storage
-          sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
-          sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
-          cat /etc/docker/daemon.json
-          sudo systemctl restart docker
-          sudo ls -la /mnt/docker-storage
+      - name: Setup Docker Storage
+        uses: ./.github/actions/setup-docker-storage
 
       - name: Build temporary image tag for this PR
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/qe-ocp-414-intrusive.yaml
+++ b/.github/workflows/qe-ocp-414-intrusive.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-415-intrusive.yaml
+++ b/.github/workflows/qe-ocp-415-intrusive.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-415.yaml
+++ b/.github/workflows/qe-ocp-415.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-416-intrusive.yaml
+++ b/.github/workflows/qe-ocp-416-intrusive.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-416.yaml
+++ b/.github/workflows/qe-ocp-416.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-417-intrusive.yaml
+++ b/.github/workflows/qe-ocp-417-intrusive.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-417.yaml
+++ b/.github/workflows/qe-ocp-417.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-418-intrusive.yaml
+++ b/.github/workflows/qe-ocp-418-intrusive.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-418.yaml
+++ b/.github/workflows/qe-ocp-418.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-419-intrusive.yaml
+++ b/.github/workflows/qe-ocp-419-intrusive.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/qe-ocp-419.yaml
+++ b/.github/workflows/qe-ocp-419.yaml
@@ -28,6 +28,10 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
+        continue-on-error: true
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
 

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -122,22 +122,8 @@ jobs:
       # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
       # This step needs to be done right after the partner repo's bootstrap scripts, as they
       # overwrite the docker's daemon.json.
-      - name: Create docker/daemon.json if it does not exist
-        run: |
-          if [ ! -f /etc/docker/daemon.json ]; then
-            echo '{}' | sudo tee /etc/docker/daemon.json
-          fi
-
-      - name: Make docker to use /mnt (sdb) for storage
-        run: |
-          df -h
-          lsblk
-          sudo mkdir /mnt/docker-storage
-          sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
-          sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
-          cat /etc/docker/daemon.json
-          sudo systemctl restart docker
-          sudo ls -la /mnt/docker-storage
+      - name: Setup Docker Storage
+        uses: ./.github/actions/setup-docker-storage
 
       # Push the new TNF image to Quay.io.
       - name: Authenticate against Quay.io
@@ -258,22 +244,8 @@ jobs:
       # Restart docker using /mnt/docker-storage (sdb) instead of /var/lib/docker (sda).
       # This step needs to be done right after the partner repo's bootstrap scripts, as they
       # overwrite the docker's daemon.json.
-      - name: Create docker/daemon.json if it does not exist
-        run: |
-          if [ ! -f /etc/docker/daemon.json ]; then
-            echo '{}' | sudo tee /etc/docker/daemon.json
-          fi
-
-      - name: Make docker to use /mnt (sdb) for storage
-        run: |
-          df -h
-          lsblk
-          sudo mkdir /mnt/docker-storage
-          sudo jq '.  +={"data-root" : "/mnt/docker-storage"}' < /etc/docker/daemon.json > /tmp/docker-daemon.json
-          sudo cp /tmp/docker-daemon.json /etc/docker/daemon.json
-          cat /etc/docker/daemon.json
-          sudo systemctl restart docker
-          sudo ls -la /mnt/docker-storage
+      - name: Setup Docker Storage
+        uses: ./.github/actions/setup-docker-storage
 
       # Push the new TNF image to Quay.io.
       - name: Authenticate against Quay.io


### PR DESCRIPTION
We have been seeing out of disk space errors in our build-and-store actions runs because they're running out of disk space.  Also I found some areas where consolidation would make things "cleaner" instead of a lot of copy pasting.

Just as a note, these are the "pre" runs that builds the image and binary, not the actual test runs which are already taking care of their disk space.