### PR TITLE
Remove 'shell' from composite action

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -13,5 +13,4 @@ runs:
         haskell: true
         docker-images: true
         swap-storage: false
-      shell: bash
 


### PR DESCRIPTION
Follow up to https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3285

This shouldn't have the `shell: bash` since it is already using `uses`.