### PR TITLE
Update Go to 1.25.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN \
 ENV \
 	GO_DL_URL=https://golang.org/dl \
 	GOPATH=/root/go
-ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.25.3.linux-amd64.tar.gz
-ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.25.3.linux-arm64.tar.gz
+ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.25.4.linux-amd64.tar.gz
+ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.25.4.linux-arm64.tar.gz
 
 # Determine the CPU architecture and download the appropriate Go binary
 # We only build our binaries on x86_64 and aarch64 platforms, so it is not necessary
@@ -32,11 +32,11 @@ RUN \
 	if [ "$(uname -m)" = x86_64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_x86_64} --quiet \
 		&& rm -rf /usr/local/go \
-		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.25.3.linux-amd64.tar.gz; \
+		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.25.4.linux-amd64.tar.gz; \
 	elif [ "$(uname -m)" = aarch64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_aarch64} --quiet \
 		&& rm -rf /usr/local/go \
-		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.25.3.linux-arm64.tar.gz; \
+		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.25.4.linux-arm64.tar.gz; \
 	else \
 		echo "CPU architecture is not supported." && exit 1; \
 	fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-best-practices-for-k8s/certsuite
 
-go 1.25.3
+go 1.25.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/tVVHm9gnwl8/m/-oTvYIjCAQAJ

Changes:
* Updated the Go download URLs in the `Dockerfile` to use version 1.25.4 for both x86_64 and aarch64 architectures, ensuring the correct binaries are fetched during image build.
* Modified the extraction commands in the `Dockerfile` to match the new Go binary filenames for version 1.25.4.
* Updated the `go.mod` file to specify Go version 1.25.4 for module compatibility.