### PR TITLE
Fix string parsing for 4.20

### DIFF
--- a/.github/workflows/qe-ocp-418-intrusive.yaml
+++ b/.github/workflows/qe-ocp-418-intrusive.yaml
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.21
+        uses: palmsoftware/quick-ocp@v0.0.22
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-418.yaml
+++ b/.github/workflows/qe-ocp-418.yaml
@@ -102,7 +102,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.21
+        uses: palmsoftware/quick-ocp@v0.0.22
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-419-intrusive.yaml
+++ b/.github/workflows/qe-ocp-419-intrusive.yaml
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.21
+        uses: palmsoftware/quick-ocp@v0.0.22
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-419.yaml
+++ b/.github/workflows/qe-ocp-419.yaml
@@ -102,7 +102,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.21
+        uses: palmsoftware/quick-ocp@v0.0.22
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-420-intrusive.yaml
+++ b/.github/workflows/qe-ocp-420-intrusive.yaml
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.21
+        uses: palmsoftware/quick-ocp@v0.0.22
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-420.yaml
+++ b/.github/workflows/qe-ocp-420.yaml
@@ -102,7 +102,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.21
+        uses: palmsoftware/quick-ocp@v0.0.22
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true


### PR DESCRIPTION
https://github.com/palmsoftware/quick-ocp/pull/36 fixes the string parsing when it comes to a user specifying 4.20 which used to evaluate as 4.2.