### PR TITLE
Add 4.20 workflows to rekick script

### DIFF
--- a/script/rekick-failed-workflows.sh
+++ b/script/rekick-failed-workflows.sh
@@ -57,11 +57,13 @@ WORKFLOWS_TO_CHECK=(
 	"QE OCP 4.17 Testing"
 	"QE OCP 4.18 Testing"
 	"QE OCP 4.19 Testing"
+	"QE OCP 4.20 Testing"
 	"QE OCP 4.14 Intrusive Testing"
 	"QE OCP 4.16 Intrusive Testing"
 	"QE OCP 4.17 Intrusive Testing"
 	"QE OCP 4.18 Intrusive Testing"
 	"QE OCP 4.19 Intrusive Testing"
+	"QE OCP 4.20 Intrusive Testing"
 	"OCP ARM64 4.16 QE Testing"
 	"qe-ocp-hosted.yml"
 )


### PR DESCRIPTION
Follow up to #3326 

- Added `"QE OCP 4.20 Testing"` and `"QE OCP 4.20 Intrusive Testing"` to the `WORKFLOWS_TO_CHECK` array in `script/rekick-failed-workflows.sh` to support OCP 4.20 testing workflows.