### PR TITLE
Fix deprecated 'WithCredentialsFile' func

### DIFF
--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -75,12 +75,17 @@ func readCSV(fp string) ([][]string, error) {
 func CreateSheetsAndDriveServices(credentials string) (sheetService *sheets.Service, driveService *drive.Service, err error) {
 	ctx := context.TODO()
 
-	sheetSrv, err := sheets.NewService(ctx, option.WithCredentialsFile(credentials))
+	credentialsJSON, err := os.ReadFile(credentials)
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to read credentials file: %v", err)
+	}
+
+	sheetSrv, err := sheets.NewService(ctx, option.WithCredentialsJSON(credentialsJSON))
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to retrieve Sheets service: %v", err)
 	}
 
-	driveSrv, err := drive.NewService(ctx, option.WithCredentialsFile(credentials))
+	driveSrv, err := drive.NewService(ctx, option.WithCredentialsJSON(credentialsJSON))
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to retrieve Drive service: %v", err)
 	}


### PR DESCRIPTION
The linter was throwing an error about a deprecated function `WithCredentialsFile`.

Improvements to credential loading:

* Changed service initialization to read the credentials file into a byte slice and use `option.WithCredentialsJSON` instead of `option.WithCredentialsFile`, allowing for better error handling and flexibility.
* Added explicit error checking and reporting when reading the credentials file, making failures easier to diagnose.