### PR TITLE
Fix fakeClient deprecation

### DIFF
--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -152,8 +152,8 @@ func GetTestClientsHolder(k8sMockObjects []runtime.Object) *ClientsHolder {
 	}
 
 	// Add the objects to their corresponding API Clients
-	clientsHolder.K8sClient = k8sFakeClient.NewSimpleClientset(k8sClientObjects...)
-	clientsHolder.APIExtClient = apiextv1fake.NewSimpleClientset(k8sExtClientObjects...)
+	clientsHolder.K8sClient = k8sFakeClient.NewClientset(k8sClientObjects...)
+	clientsHolder.APIExtClient = apiextv1fake.NewClientset(k8sExtClientObjects...)
 	clientsHolder.CNCFNetworkingClient = cncfNetworkAttachmentFake.NewSimpleClientset(k8sPlumbingObjects...)
 
 	clientsHolder.ready = true

--- a/pkg/autodiscover/autodiscover_events_test.go
+++ b/pkg/autodiscover/autodiscover_events_test.go
@@ -51,7 +51,7 @@ func TestFindAbnormalEvents(t *testing.T) {
 		}
 
 		// Create fake client
-		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		client := k8sfake.NewClientset(runtimeObjects...)
 		abnormalEvents := findAbnormalEvents(client.CoreV1(), []string{"test-namespace"})
 		assert.Len(t, abnormalEvents, len(testCase.expectedEvents))
 

--- a/pkg/autodiscover/autodiscover_networkpolicies_test.go
+++ b/pkg/autodiscover/autodiscover_networkpolicies_test.go
@@ -49,7 +49,7 @@ func TestGetNetworkPolicies(t *testing.T) {
 		}
 
 		// Create fake client
-		client := k8sfake.NewSimpleClientset(runtimeObjects...)
+		client := k8sfake.NewClientset(runtimeObjects...)
 		networkPolicies, err := getNetworkPolicies(client.NetworkingV1())
 		assert.Nil(t, err)
 		assert.Len(t, networkPolicies, len(testCase.expectedNetworkPolicies))

--- a/pkg/autodiscover/autodiscover_operators_test.go
+++ b/pkg/autodiscover/autodiscover_operators_test.go
@@ -54,7 +54,7 @@ func TestGetAllNamespaces(t *testing.T) {
 			testRuntimeObjects = append(testRuntimeObjects, n)
 		}
 
-		clientSet := fake.NewSimpleClientset(testRuntimeObjects...)
+		clientSet := fake.NewClientset(testRuntimeObjects...)
 		namespaces, err := getAllNamespaces(clientSet.CoreV1())
 		assert.Nil(t, err)
 		assert.Equal(t, tc.expectedNamespaces, namespaces)
@@ -266,7 +266,7 @@ func TestIsIstioServiceMeshInstalled(t *testing.T) {
 
 	for _, tc := range testCases {
 		// Generate the deployment for the test
-		clientSet := fake.NewSimpleClientset(tc.testDeployment)
+		clientSet := fake.NewClientset(tc.testDeployment)
 		result := isIstioServiceMeshInstalled(clientSet.AppsV1(), []string{"istio-system"})
 		assert.Equal(t, tc.expectedResult, result)
 	}

--- a/pkg/provider/deployments_test.go
+++ b/pkg/provider/deployments_test.go
@@ -61,7 +61,7 @@ func TestGetUpdatedDeployment(t *testing.T) {
 			})
 		}
 
-		fakeClient := k8sfake.NewSimpleClientset(runtimeObjects...)
+		fakeClient := k8sfake.NewClientset(runtimeObjects...)
 
 		deployment, err := GetUpdatedDeployment(fakeClient.AppsV1(), "testNS", "test1")
 

--- a/tests/networking/services/services_test.go
+++ b/tests/networking/services/services_test.go
@@ -87,7 +87,7 @@ func TestGetServiceIPVersion(t *testing.T) {
 	}
 }
 
-func createService(ips []string, aFp corev1.IPFamilyPolicyType) (aService *corev1.Service) {
+func createService(ips []string, aFp corev1.IPFamilyPolicy) (aService *corev1.Service) {
 	aService = &corev1.Service{}
 	aService.Name = "test-service"
 	aService.Namespace = "tnf"


### PR DESCRIPTION
Looks like there was a deprecation in the latest versions of the `fake` client in the k8s libraries.

**Kubernetes fake client instantiation updates:**

* Replaced `NewSimpleClientset` with `NewClientset` for creating Kubernetes fake clients in `internal/clientsholder/clientsholder.go`, ensuring compatibility with the latest client-go API.
* Updated test setup in `pkg/autodiscover/autodiscover_events_test.go`, `pkg/autodiscover/autodiscover_networkpolicies_test.go`, `pkg/autodiscover/autodiscover_operators_test.go`, and `pkg/provider/deployments_test.go` to use `NewClientset` instead of `NewSimpleClientset` for fake client creation. [[1]](diffhunk://#diff-89c69e6276156690deab8f8bb3f7e03dbbc8e2a3161e70f09fc4b548176795b0L54-R54) [[2]](diffhunk://#diff-bff5481d0e99671933056f1b8d67d144a84226a764329deb8983927a9e4dfcfdL52-R52) [[3]](diffhunk://#diff-4c55a7894b672807b3c1826b4ad8535c688a2b789b1383c15466fb54245fe94aL57-R57) [[4]](diffhunk://#diff-4c55a7894b672807b3c1826b4ad8535c688a2b789b1383c15466fb54245fe94aL269-R269) [[5]](diffhunk://#diff-8f94f569f4acc91e91c0a806f052a4c1ea555aac0a0f29363949ad8c333c16eeL64-R64)

**Test helper type correction:**

* Changed the parameter type in the `createService` helper from `corev1.IPFamilyPolicyType` to `corev1.IPFamilyPolicy` in `tests/networking/services/services_test.go` to match the expected type.