### PR TITLE
Update copyright headers to 2026

### DIFF
--- a/cmd/certsuite/check/image_cert_status/image_cert_status.go
+++ b/cmd/certsuite/check/image_cert_status/image_cert_status.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/cmd/certsuite/claim/show/csv/csv.go
+++ b/cmd/certsuite/claim/show/csv/csv.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package csv
 
 import (

--- a/cmd/certsuite/generate/catalog/catalog.go
+++ b/cmd/certsuite/generate/catalog/catalog.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/cmd/certsuite/generate/feedback/feedback.go
+++ b/cmd/certsuite/generate/feedback/feedback.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/cmd/certsuite/pkg/claim/claim_test.go
+++ b/cmd/certsuite/pkg/claim/claim_test.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package claim
 
 import (

--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
 package run
 
 import (

--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
 package resultsspreadsheet
 
 import (

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package cli
 
 import (

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/clientsholder/command.go
+++ b/internal/clientsholder/command.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package log
 
 import (

--- a/internal/results/archiver.go
+++ b/internal/results/archiver.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package results
 
 import (

--- a/internal/results/doc.go
+++ b/internal/results/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Red Hat, Inc.
+// Copyright (C) 2021-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/results/doc_test.go
+++ b/internal/results/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Red Hat, Inc.
+// Copyright (C) 2021-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/internal/results/rhconnect.go
+++ b/internal/results/rhconnect.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package results
 
 import (

--- a/internal/results/rhconnect_test.go
+++ b/internal/results/rhconnect_test.go
@@ -1,1 +1,2 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package results

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_clusteroperators.go
+++ b/pkg/autodiscover/autodiscover_clusteroperators.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package autodiscover
 
 import (

--- a/pkg/autodiscover/autodiscover_clusteroperators_test.go
+++ b/pkg/autodiscover/autodiscover_clusteroperators_test.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package autodiscover
 
 import (

--- a/pkg/autodiscover/autodiscover_events_test.go
+++ b/pkg/autodiscover/autodiscover_events_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_nads.go
+++ b/pkg/autodiscover/autodiscover_nads.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package autodiscover
 
 import (

--- a/pkg/autodiscover/autodiscover_nads_test.go
+++ b/pkg/autodiscover/autodiscover_nads_test.go
@@ -1,1 +1,2 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package autodiscover

--- a/pkg/autodiscover/autodiscover_networkpolicies_test.go
+++ b/pkg/autodiscover/autodiscover_networkpolicies_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_operators_test.go
+++ b/pkg/autodiscover/autodiscover_operators_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2023-2024 Red Hat, Inc.
+// Copyright (C) 2023-2026 Red Hat, Inc.
 
 package autodiscover
 

--- a/pkg/autodiscover/autodiscover_pdbs_test.go
+++ b/pkg/autodiscover/autodiscover_pdbs_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_pods.go
+++ b/pkg/autodiscover/autodiscover_pods.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_pods_test.go
+++ b/pkg/autodiscover/autodiscover_pods_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_resources_test.go
+++ b/pkg/autodiscover/autodiscover_resources_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_services.go
+++ b/pkg/autodiscover/autodiscover_services.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_services_test.go
+++ b/pkg/autodiscover/autodiscover_services_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/autodiscover_sriov.go
+++ b/pkg/autodiscover/autodiscover_sriov.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package autodiscover
 
 import (

--- a/pkg/autodiscover/autodiscover_sriov_test.go
+++ b/pkg/autodiscover/autodiscover_sriov_test.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package autodiscover
 
 import (

--- a/pkg/autodiscover/autodiscover_test.go
+++ b/pkg/autodiscover/autodiscover_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/autodiscover/constants.go
+++ b/pkg/autodiscover/constants.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/certsuite/certsuite.go
+++ b/pkg/certsuite/certsuite.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package certsuite
 
 import (

--- a/pkg/checksdb/checksdb.go
+++ b/pkg/checksdb/checksdb.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package checksdb
 
 import (

--- a/pkg/claimhelper/claimhelper.go
+++ b/pkg/claimhelper/claimhelper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/claimhelper/claimhelper_test.go
+++ b/pkg/claimhelper/claimhelper_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package collector
 
 import (

--- a/pkg/compatibility/compatibility.go
+++ b/pkg/compatibility/compatibility.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/compatibility/compatibility_test.go
+++ b/pkg/compatibility/compatibility_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Red Hat, Inc.
+// Copyright (C) 2021-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/diagnostics/diagnostics_test.go
+++ b/pkg/diagnostics/diagnostics_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Red Hat, Inc.
+// Copyright (C) 2021-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/podhelper/podhelper.go
+++ b/pkg/podhelper/podhelper.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
 package podhelper
 
 import (

--- a/pkg/podhelper/podhelper_test.go
+++ b/pkg/podhelper/podhelper_test.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
 package podhelper
 
 import (

--- a/pkg/postmortem/postmortem.go
+++ b/pkg/postmortem/postmortem.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/catalogsources.go
+++ b/pkg/provider/catalogsources.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
 package provider
 
 import (

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/containers_test.go
+++ b/pkg/provider/containers_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/deployments.go
+++ b/pkg/provider/deployments.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/deployments_test.go
+++ b/pkg/provider/deployments_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/filters.go
+++ b/pkg/provider/filters.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/filters_test.go
+++ b/pkg/provider/filters_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/isolation.go
+++ b/pkg/provider/isolation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/pods_test.go
+++ b/pkg/provider/pods_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/statefulsets.go
+++ b/pkg/provider/statefulsets.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/provider/statefulsets_test.go
+++ b/pkg/provider/statefulsets_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2023 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/stringhelper/stringhelper.go
+++ b/pkg/stringhelper/stringhelper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/stringhelper/stringhelper_test.go
+++ b/pkg/stringhelper/stringhelper_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/pkg/versions/versions.go
+++ b/pkg/versions/versions.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package versions
 
 import (

--- a/tests/accesscontrol/doc.go
+++ b/tests/accesscontrol/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/accesscontrol/doc_test.go
+++ b/tests/accesscontrol/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/accesscontrol/pidshelper_test.go
+++ b/tests/accesscontrol/pidshelper_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/accesscontrol/resources/resources.go
+++ b/tests/accesscontrol/resources/resources.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2022-2026 Red Hat, Inc.
 package resources
 
 import (

--- a/tests/accesscontrol/resources/resources_test.go
+++ b/tests/accesscontrol/resources/resources_test.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2022-2026 Red Hat, Inc.
 package resources
 
 import (

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/accesscontrol/suite_test.go
+++ b/tests/accesscontrol/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/certification/doc.go
+++ b/tests/certification/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/certification/doc_test.go
+++ b/tests/certification/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/certification/suite_test.go
+++ b/tests/certification/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/common/constant_test.go
+++ b/tests/common/constant_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/common/doc.go
+++ b/tests/common/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/common/doc_test.go
+++ b/tests/common/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/common/env.go
+++ b/tests/common/env.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/common/env_test.go
+++ b/tests/common/env_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/common/rbac/roles_test.go
+++ b/tests/common/rbac/roles_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/identifiers/doc.go
+++ b/tests/identifiers/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Red Hat, Inc.
+// Copyright (C) 2021-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/identifiers/doc_test.go
+++ b/tests/identifiers/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Red Hat, Inc.
+// Copyright (C) 2021-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package identifiers
 
 const (

--- a/tests/identifiers/exceptions.go
+++ b/tests/identifiers/exceptions.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/identifiers/exceptions_test.go
+++ b/tests/identifiers/exceptions_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Red Hat, Inc.
+// Copyright (C) 2021-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/identifiers/impact.go
+++ b/tests/identifiers/impact.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Red Hat, Inc.
+// Copyright (C) 2021-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/identifiers/remediation_test.go
+++ b/tests/identifiers/remediation_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/doc.go
+++ b/tests/lifecycle/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/doc_test.go
+++ b/tests/lifecycle/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/podrecreation/podrecreation.go
+++ b/tests/lifecycle/podrecreation/podrecreation.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/podrecreation/podrecreation_test.go
+++ b/tests/lifecycle/podrecreation/podrecreation_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/podsets/podsets_test.go
+++ b/tests/lifecycle/podsets/podsets_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/scaling/crd_scaling_test.go
+++ b/tests/lifecycle/scaling/crd_scaling_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/scaling/deployment_scaling_test.go
+++ b/tests/lifecycle/scaling/deployment_scaling_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/scaling/statefulset_scaling_test.go
+++ b/tests/lifecycle/scaling/statefulset_scaling_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/suite.go
+++ b/tests/lifecycle/suite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/suite_test.go
+++ b/tests/lifecycle/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/tolerations/tolerations.go
+++ b/tests/lifecycle/tolerations/tolerations.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/tolerations/tolerations_test.go
+++ b/tests/lifecycle/tolerations/tolerations_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/volumes/volumes.go
+++ b/tests/lifecycle/volumes/volumes.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/lifecycle/volumes/volumes_test.go
+++ b/tests/lifecycle/volumes/volumes_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/manageability/suite_test.go
+++ b/tests/manageability/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/networking/doc.go
+++ b/tests/networking/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/networking/doc_test.go
+++ b/tests/networking/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/networking/netcommons/netcommons_test.go
+++ b/tests/networking/netcommons/netcommons_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/networking/netutil/netutil.go
+++ b/tests/networking/netutil/netutil.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/networking/netutil/netutil_test.go
+++ b/tests/networking/netutil/netutil_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/networking/services/services.go
+++ b/tests/networking/services/services.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/networking/services/services_test.go
+++ b/tests/networking/services/services_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/networking/suite_test.go
+++ b/tests/networking/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/observability/doc.go
+++ b/tests/observability/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/observability/doc_test.go
+++ b/tests/observability/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/observability/suite.go
+++ b/tests/observability/suite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/observability/suite_test.go
+++ b/tests/observability/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/operator/access/access.go
+++ b/tests/operator/access/access.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package access
 
 import (

--- a/tests/operator/access/access_test.go
+++ b/tests/operator/access/access_test.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package access
 
 import (

--- a/tests/operator/helper.go
+++ b/tests/operator/helper.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/operator/helper_test.go
+++ b/tests/operator/helper_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/operator/openapi/openapi.go
+++ b/tests/operator/openapi/openapi.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package openapi
 
 import (

--- a/tests/operator/openapi/openapi_test.go
+++ b/tests/operator/openapi/openapi_test.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package openapi
 
 import (

--- a/tests/operator/phasecheck/phasecheck.go
+++ b/tests/operator/phasecheck/phasecheck.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/operator/phasecheck/phasecheck_test.go
+++ b/tests/operator/phasecheck/phasecheck_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/operator/suite_test.go
+++ b/tests/operator/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/performance/suite.go
+++ b/tests/performance/suite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/performance/suite_test.go
+++ b/tests/performance/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/bootparams/bootparams.go
+++ b/tests/platform/bootparams/bootparams.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/bootparams/bootparams_test.go
+++ b/tests/platform/bootparams/bootparams_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/clusteroperator/clusteroperator.go
+++ b/tests/platform/clusteroperator/clusteroperator.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package clusteroperator
 
 import (

--- a/tests/platform/clusteroperator/clusteroperator_test.go
+++ b/tests/platform/clusteroperator/clusteroperator_test.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2025-2026 Red Hat, Inc.
 package clusteroperator
 
 import (

--- a/tests/platform/cnffsdiff/fsdiff.go
+++ b/tests/platform/cnffsdiff/fsdiff.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/cnffsdiff/fsdiff_test.go
+++ b/tests/platform/cnffsdiff/fsdiff_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/doc.go
+++ b/tests/platform/doc.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/doc_test.go
+++ b/tests/platform/doc_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/hugepages/hugepages.go
+++ b/tests/platform/hugepages/hugepages.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2022-2026 Red Hat, Inc.
 package hugepages
 
 import (

--- a/tests/platform/hugepages/hugepages_test.go
+++ b/tests/platform/hugepages/hugepages_test.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2022-2026 Red Hat, Inc.
 package hugepages
 
 import (

--- a/tests/platform/isredhat/isredhat.go
+++ b/tests/platform/isredhat/isredhat.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/isredhat/isredhat_test.go
+++ b/tests/platform/isredhat/isredhat_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/nodetainted/nodetainted.go
+++ b/tests/platform/nodetainted/nodetainted.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Red Hat, Inc.
+// Copyright (C) 2021-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/nodetainted/nodetainted_test.go
+++ b/tests/platform/nodetainted/nodetainted_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2021-2024 Red Hat, Inc.
+// Copyright (C) 2021-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/operatingsystem/operatingsystem.go
+++ b/tests/platform/operatingsystem/operatingsystem.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/operatingsystem/operatingsystem_test.go
+++ b/tests/platform/operatingsystem/operatingsystem_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/suite_test.go
+++ b/tests/platform/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/sysctlconfig/sysctlconfig.go
+++ b/tests/platform/sysctlconfig/sysctlconfig.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/platform/sysctlconfig/sysctlconfig_test.go
+++ b/tests/platform/sysctlconfig/sysctlconfig_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2024 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/tests/preflight/suite_test.go
+++ b/tests/preflight/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2022-2024 Red Hat, Inc.
+// Copyright (C) 2022-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/webserver/webserver.go
+++ b/webserver/webserver.go
@@ -1,3 +1,4 @@
+// Copyright (C) 2023-2026 Red Hat, Inc.
 package webserver
 
 import (


### PR DESCRIPTION
Update copyright year to 2026 for all Go files modified in 2025/2026. Also adds missing copyright headers to 34 files that were lacking them.

NOTE: This change does not mass update all of the files, rather there are a number of files that should have been updated in the last calendar year that were not updated even though their contents were touched.  They now should show 2026 as their current last year touched.

## Related PRs
- certsuite-claim: https://github.com/redhat-best-practices-for-k8s/certsuite-claim/pull/157
- oct: https://github.com/redhat-best-practices-for-k8s/oct/pull/390

🤖 Generated with [Claude Code](https://claude.com/claude-code)