### PR TITLE
Update Go to v1.25.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN \
 ENV \
 	GO_DL_URL=https://golang.org/dl \
 	GOPATH=/root/go
-ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.25.5.linux-amd64.tar.gz
-ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.25.5.linux-arm64.tar.gz
+ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.25.6.linux-amd64.tar.gz
+ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.25.6.linux-arm64.tar.gz
 
 # Determine the CPU architecture and download the appropriate Go binary
 # We only build our binaries on x86_64 and aarch64 platforms, so it is not necessary
@@ -32,11 +32,11 @@ RUN \
 	if [ "$(uname -m)" = x86_64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_x86_64} --quiet \
 		&& rm -rf /usr/local/go \
-		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.25.5.linux-amd64.tar.gz; \
+		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.25.6.linux-amd64.tar.gz; \
 	elif [ "$(uname -m)" = aarch64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_aarch64} --quiet \
 		&& rm -rf /usr/local/go \
-		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.25.5.linux-arm64.tar.gz; \
+		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.25.6.linux-arm64.tar.gz; \
 	else \
 		echo "CPU architecture is not supported." && exit 1; \
 	fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-best-practices-for-k8s/certsuite
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/Vd2tYVM8eUc/m/pQP7Bk0aCQAJ

## CVEs Addressed

- **CVE-2025-61728** (archive/zip): Super-linear file name indexing algorithm in ZIP archives can cause CPU exhaustion
- **CVE-2025-61726** (net/http): Request.ParseForm vulnerable to DoS with large number of key-value pairs
- **CVE-2025-61730** (crypto/tls): TLS 1.3 handshake information disclosure via message injection
- **CVE-2025-68119** (cmd/go): Arbitrary code execution via malicious VCS version strings
- **CVE-2025-68121** (crypto/tls): Config.Clone improperly copies session ticket keys allowing unauthorized session resumption
- **CVE-2025-61731** (net/url): URL parsing vulnerability