### PR TITLE
Use new QE test groupings for faster CI

### DIFF
--- a/.github/workflows/qe-hosted-arm.yml
+++ b/.github/workflows/qe-hosted-arm.yml
@@ -71,7 +71,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+        # Suites with -k8s suffix exclude OCP-required tests (run only K8S-compatible tests)
+        # OCP-required suites (affiliatedcertification, performance, platformalteration) run on qe-ocp-*.yaml workflows
+        suite: [accesscontrol1-k8s, accesscontrol2-k8s, accesscontrol3-k8s, accesscontrol4-k8s, accesscontrol5-k8s, accesscontrol6-k8s, accesscontrol7-k8s, accesscontrol8-k8s, accesscontrol9-k8s, accesscontrol10-k8s, accesscontrol11-k8s, accesscontrol12-k8s, accesscontrol13-k8s, manageability, networking1-k8s, networking2-k8s, networking3-k8s, lifecycle1-k8s, lifecycle2-k8s, lifecycle3-k8s, lifecycle4-k8s, lifecycle5-k8s, lifecycle6-k8s, lifecycle7-k8s, lifecycle8-k8s, lifecycle9-k8s, observability-k8s, operator-k8s]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -100,7 +100,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+        # Suites with -k8s suffix exclude OCP-required tests (run only K8S-compatible tests)
+        # OCP-required suites (affiliatedcertification, performance, platformalteration) run on qe-ocp-*.yaml workflows
+        suite: [accesscontrol1-k8s, accesscontrol2-k8s, accesscontrol3-k8s, accesscontrol4-k8s, accesscontrol5-k8s, accesscontrol6-k8s, accesscontrol7-k8s, accesscontrol8-k8s, accesscontrol9-k8s, accesscontrol10-k8s, accesscontrol11-k8s, accesscontrol12-k8s, accesscontrol13-k8s, manageability, networking1-k8s, networking2-k8s, networking3-k8s, lifecycle1-k8s, lifecycle2-k8s, lifecycle3-k8s, lifecycle4-k8s, lifecycle5-k8s, lifecycle6-k8s, lifecycle7-k8s, lifecycle8-k8s, lifecycle9-k8s, observability-k8s, operator-k8s]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/runner/.kube/config'

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -64,8 +64,10 @@ jobs:
     if: needs.build-and-store.result == 'success'
     strategy:
       fail-fast: false
-      matrix: 
-        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+      matrix:
+        # Suites with -ocp suffix run only OCP-required tests
+        # 100% OCP-required suites don't need suffix but use it for consistency
+        suite: [affiliatedcertification-ocp, performance-ocp, platformalteration1-ocp, platformalteration2-ocp, platformalteration3-ocp, platformalteration4-ocp]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/labuser2/.kube/config'

--- a/.github/workflows/qe-ocp-416.yaml
+++ b/.github/workflows/qe-ocp-416.yaml
@@ -64,8 +64,10 @@ jobs:
     if: needs.build-and-store.result == 'success'
     strategy:
       fail-fast: false
-      matrix: 
-        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+      matrix:
+        # Suites with -ocp suffix run only OCP-required tests
+        # 100% OCP-required suites don't need suffix but use it for consistency
+        suite: [affiliatedcertification-ocp, performance-ocp, platformalteration1-ocp, platformalteration2-ocp, platformalteration3-ocp, platformalteration4-ocp]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/labuser3/.kube/config'

--- a/.github/workflows/qe-ocp-417.yaml
+++ b/.github/workflows/qe-ocp-417.yaml
@@ -64,8 +64,10 @@ jobs:
     if: needs.build-and-store.result == 'success'
     strategy:
       fail-fast: false
-      matrix: 
-        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+      matrix:
+        # Suites with -ocp suffix run only OCP-required tests
+        # 100% OCP-required suites don't need suffix but use it for consistency
+        suite: [affiliatedcertification-ocp, performance-ocp, platformalteration1-ocp, platformalteration2-ocp, platformalteration3-ocp, platformalteration4-ocp]
     env:
       SHELL: /bin/bash
       KUBECONFIG: '/home/labuser4/.kube/config'

--- a/.github/workflows/qe-ocp-418.yaml
+++ b/.github/workflows/qe-ocp-418.yaml
@@ -65,8 +65,10 @@ jobs:
     if: needs.build-and-store.result == 'success'
     strategy:
       fail-fast: false
-      matrix: 
-        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+      matrix:
+        # Suites with -ocp suffix run only OCP-required tests
+        # 100% OCP-required suites don't need suffix but use it for consistency
+        suite: [affiliatedcertification-ocp, performance-ocp, platformalteration1-ocp, platformalteration2-ocp, platformalteration3-ocp, platformalteration4-ocp]
         # run-type: [binary, image]
         run-type: [binary]
     env:

--- a/.github/workflows/qe-ocp-419.yaml
+++ b/.github/workflows/qe-ocp-419.yaml
@@ -65,8 +65,10 @@ jobs:
     if: needs.build-and-store.result == 'success'
     strategy:
       fail-fast: false
-      matrix: 
-        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+      matrix:
+        # Suites with -ocp suffix run only OCP-required tests
+        # 100% OCP-required suites don't need suffix but use it for consistency
+        suite: [affiliatedcertification-ocp, performance-ocp, platformalteration1-ocp, platformalteration2-ocp, platformalteration3-ocp, platformalteration4-ocp]
         # run-type: [binary, image]
         run-type: [binary]
     env:

--- a/.github/workflows/qe-ocp-420.yaml
+++ b/.github/workflows/qe-ocp-420.yaml
@@ -65,8 +65,10 @@ jobs:
     if: needs.build-and-store.result == 'success'
     strategy:
       fail-fast: false
-      matrix: 
-        suite: [accesscontrol, affiliatedcertification, manageability, networking, lifecycle, performance, platformalteration, observability, operator]
+      matrix:
+        # Suites with -ocp suffix run only OCP-required tests
+        # 100% OCP-required suites don't need suffix but use it for consistency
+        suite: [affiliatedcertification-ocp, performance-ocp, platformalteration1-ocp, platformalteration2-ocp, platformalteration3-ocp, platformalteration4-ocp]
         # run-type: [binary, image]
         run-type: [binary]
     env:


### PR DESCRIPTION
## Summary
- Update workflow matrices to use new QE test groupings from certsuite-qe#1326
- Kind/Ubuntu workflows now use `-k8s` suffix to exclude OCP-required tests
- OCP workflows now use `-ocp` suffix to run only OCP-required tests
- Split large suites for parallel execution (accesscontrol: 13 groups, lifecycle: 9 groups, networking: 3 groups)

## Changes

### Kind/Ubuntu-hosted workflows (qe-hosted.yml, qe-hosted-arm.yml)
- Use `-k8s` suffix to filter to K8S-compatible tests only
- Remove 100% OCP-required suites (affiliatedcertification, performance, platformalteration)
- Total: 28 jobs (down from 9 full suites running all tests)

### OCP workflows (qe-ocp-*.yaml)
- Use `-ocp` suffix to run only OCP-required tests
- Keep only OCP-required suites: affiliatedcertification, performance, platformalteration1-4
- Total: 6 jobs (down from 9 full suites)

## Expected Impact
- **Kind workflow**: Runs only K8S-compatible tests (faster Kind setup ~2-3 min vs OCP ~15-20 min)
- **OCP workflow**: Reduced from 9 to 6 jobs (runs only tests that actually need OCP)
- **Networking**: Split into 3 parallel groups (~45 min each vs previous ~1h51m single job)

## Dependencies
- Depends-On: redhat-best-practices-for-k8s/certsuite-qe#1326 (merged)

## Test plan
- [ ] Verify qe-hosted.yml runs with new groupings
- [ ] Verify qe-ocp-*.yaml runs with new groupings
- [ ] Verify no tests are skipped (full coverage maintained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)