### PR TITLE
fix(ci): Revert Docker-dependent workflows to ubuntu-24.04

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
   analysis:
     if: github.repository_owner == 'redhat-best-practices-for-k8s'
     name: Scorecard analysis
-    runs-on: ubuntu-slim
+    runs-on: ubuntu-24.04
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
## Summary
- Reverts `scorecard.yml` and `doc-publish.yml` from `ubuntu-slim` to `ubuntu-24.04`
- The ubuntu-slim runner does not have Docker available since it runs in a container rather than a full VM
- These workflows use Docker-based actions that require Docker:
  - `scorecard.yml`: `ossf/scorecard-action` pulls a container image
  - `doc-publish.yml`: uses `.github/actions/documentation` which is a Docker action

## Test plan
- [ ] Verify scorecard workflow passes after merge
- [ ] Verify doc-publish workflow passes after merge

🤖 Generated with [Claude Code](https://claude.ai/claude-code)