### PR TITLE
Update Go to v1.26.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN \
 ENV \
 	GO_DL_URL=https://golang.org/dl \
 	GOPATH=/root/go
-ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.25.6.linux-amd64.tar.gz
-ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.25.6.linux-arm64.tar.gz
+ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.26.0.linux-amd64.tar.gz
+ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.26.0.linux-arm64.tar.gz
 
 # Determine the CPU architecture and download the appropriate Go binary
 # We only build our binaries on x86_64 and aarch64 platforms, so it is not necessary
@@ -32,11 +32,11 @@ RUN \
 	if [ "$(uname -m)" = x86_64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_x86_64} --quiet \
 		&& rm -rf /usr/local/go \
-		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.25.6.linux-amd64.tar.gz; \
+		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.26.0.linux-amd64.tar.gz; \
 	elif [ "$(uname -m)" = aarch64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_aarch64} --quiet \
 		&& rm -rf /usr/local/go \
-		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.25.6.linux-arm64.tar.gz; \
+		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.26.0.linux-arm64.tar.gz; \
 	else \
 		echo "CPU architecture is not supported." && exit 1; \
 	fi

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redhat-best-practices-for-k8s/certsuite
 
-go 1.25.6
+go 1.26.0
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
## Summary
- Update Go version from 1.25.6 to 1.26.0 in `go.mod` and `Dockerfile`
- [Go 1.26 Release Notes](https://go.dev/doc/go1.26) - brings Green Tea GC (10-40% less GC overhead), self-referential generics, faster cgo, `crypto/hpke`, and post-quantum TLS

## Jira
[CNFCERT-1344](https://issues.redhat.com/browse/CNFCERT-1344)

## Changes
- `go.mod`: `go 1.25.6` -> `go 1.26.0`
- `Dockerfile`: Updated Go download URLs from `go1.25.6` to `go1.26.0` (amd64 and arm64)

## Test plan
- [x] `go mod tidy` succeeds
- [x] `make build` succeeds
- [x] `make test` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Related PRs
- [certsuite#3455](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3455)
- [certsuite-operator#283](https://github.com/redhat-best-practices-for-k8s/certsuite-operator/pull/283)
- [oct#408](https://github.com/redhat-best-practices-for-k8s/oct/pull/408)
- [collector#654](https://github.com/redhat-best-practices-for-k8s/collector/pull/654)
- [certsuite-claim#162](https://github.com/redhat-best-practices-for-k8s/certsuite-claim/pull/162)
- [kpi-collection-tool#65](https://github.com/redhat-best-practices-for-k8s/kpi-collection-tool/pull/65)
- [privileged-daemonset#336](https://github.com/redhat-best-practices-for-k8s/privileged-daemonset/pull/336)
- [perfdive#48](https://github.com/redhat-best-practices-for-k8s/perfdive/pull/48)
- [cr-scale-operator#5](https://github.com/redhat-best-practices-for-k8s/cr-scale-operator/pull/5)
- [certsuite-overview#118](https://github.com/redhat-best-practices-for-k8s/certsuite-overview/pull/118)
- [certsuite-qe#1360](https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1360)
- [kpi-analyzer#9](https://github.com/redhat-best-practices-for-k8s/kpi-analyzer/pull/9)
- [operator-results-spreadsheet#42](https://github.com/redhat-best-practices-for-k8s/operator-results-spreadsheet/pull/42)
- [json-parser#1](https://github.com/redhat-best-practices-for-k8s/json-parser/pull/1)