### PR TITLE
Add OCP-version-aware TLS minimum version compliance test

### DIFF
--- a/.github/actions/test-scenarios/networking/README.md
+++ b/.github/actions/test-scenarios/networking/README.md
@@ -1,0 +1,34 @@
+# Networking Test Scenarios
+
+Self-contained scenario tests for the networking test suite. Each scenario deploys a single workload with a known configuration, runs the certsuite against it, and validates the expected result.
+
+## Scenarios
+
+### tls-minimum-version
+
+Validates that the `networking-tls-minimum-version` test correctly checks services against the cluster's TLS security profile. On non-OpenShift clusters (including CI), the default Intermediate profile is used (min TLS 1.2). Each workload is tested in isolation.
+
+| Scenario | Manifest | TLS Config | Expected Test Result |
+|---|---|---|---|
+| TLS 1.3 Only (compliant) | `tls13-only.yaml` | TLS 1.3 only | `passed` |
+| TLS 1.2 Allowed (compliant) | `tls12-allowed.yaml` | TLS 1.2 + 1.3, Intermediate ciphers | `passed` |
+| Plain HTTP (compliant) | `plain-http.yaml` | No TLS | `passed` |
+
+## Adding a new scenario
+
+1. Create a directory under the appropriate test suite (e.g., `networking/<test-name>/`).
+2. Add a `deploy.sh` that accepts a manifest filename as `$1`, creates the namespace, applies shared resources, and deploys the single workload.
+3. Add a `cleanup.sh` to tear down resources.
+4. Place Kubernetes manifests and certsuite config in a `manifests/` subdirectory. Each manifest should define a single workload (Deployment + Service).
+5. Add one entry per workload to `../scenarios.json`:
+   ```json
+   {
+     "name": "Human-readable name",
+     "label_filter": "test-case-label",
+     "path": "networking/<test-name>",
+     "manifest": "<workload>.yaml",
+     "expected_result": "passed|failed",
+     "output_dir": "<workload>-results"
+   }
+   ```
+   The runner script (`../run-scenarios.sh`) picks up all entries automatically. Validation is data-driven: the runner checks that the test state in `claim.json` matches `expected_result`.

--- a/.github/actions/test-scenarios/networking/tls-minimum-version/cleanup.sh
+++ b/.github/actions/test-scenarios/networking/tls-minimum-version/cleanup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Clean up TLS scenario test resources.
+
+NAMESPACE="tls-test-ns"
+RESULTS_DIR="${1:-tls-test-results}"
+
+kubectl delete namespace "$NAMESPACE" --ignore-not-found
+rm -rf "$RESULTS_DIR"
+
+echo "TLS test resources cleaned up."

--- a/.github/actions/test-scenarios/networking/tls-minimum-version/deploy.sh
+++ b/.github/actions/test-scenarios/networking/tls-minimum-version/deploy.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy a single TLS test workload into tls-test-ns.
+# Usage: deploy.sh <manifest-file>
+#
+# The manifest file is looked up under manifests/ and must define a Deployment
+# whose name matches the filename without the .yaml extension.
+
+MANIFEST_FILE="${1:?Usage: deploy.sh <manifest-file>}"
+DEPLOY_NAME="${MANIFEST_FILE%.yaml}"
+
+NAMESPACE="tls-test-ns"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFESTS_DIR="${SCRIPT_DIR}/manifests"
+
+kubectl create namespace "$NAMESPACE"
+
+# Generate self-signed TLS certificate
+openssl req -x509 -nodes -days 1 -newkey rsa:2048 \
+  -keyout /tmp/tls.key -out /tmp/tls.crt \
+  -subj "/CN=tls-test.${NAMESPACE}.svc"
+
+kubectl create secret tls tls-test-cert \
+  --cert=/tmp/tls.crt --key=/tmp/tls.key \
+  -n "$NAMESPACE"
+
+# nginx config: TLS 1.3 only
+kubectl create configmap nginx-tls13-only -n "$NAMESPACE" --from-literal=default.conf='
+server {
+    listen 8443 ssl;
+    ssl_certificate /etc/tls/tls.crt;
+    ssl_certificate_key /etc/tls/tls.key;
+    ssl_protocols TLSv1.3;
+    location / { return 200 "tls13-only"; }
+}'
+
+# nginx config: TLS 1.2 only (no TLS 1.3) — non-compliant with Intermediate
+kubectl create configmap nginx-tls12-only -n "$NAMESPACE" --from-literal=default.conf='
+server {
+    listen 8443 ssl;
+    ssl_certificate /etc/tls/tls.crt;
+    ssl_certificate_key /etc/tls/tls.key;
+    ssl_protocols TLSv1.2;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    location / { return 200 "tls12-only"; }
+}'
+
+# nginx config: TLS 1.2+1.3 with Intermediate-profile ciphers only
+kubectl create configmap nginx-tls12-allowed -n "$NAMESPACE" --from-literal=default.conf='
+server {
+    listen 8443 ssl;
+    ssl_certificate /etc/tls/tls.crt;
+    ssl_certificate_key /etc/tls/tls.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384;
+    ssl_prefer_server_ciphers off;
+    location / { return 200 "tls12-allowed"; }
+}'
+
+# Deploy the single workload
+kubectl apply -n "$NAMESPACE" -f "${MANIFESTS_DIR}/${MANIFEST_FILE}"
+kubectl wait deployment -n "$NAMESPACE" "$DEPLOY_NAME" --for=condition=Available --timeout=120s
+
+echo "Workload '${DEPLOY_NAME}' deployed successfully."

--- a/.github/actions/test-scenarios/networking/tls-minimum-version/manifests/certsuite-config.yaml
+++ b/.github/actions/test-scenarios/networking/tls-minimum-version/manifests/certsuite-config.yaml
@@ -1,0 +1,6 @@
+---
+targetNameSpaces:
+  - name: tls-test-ns
+podsUnderTestLabels:
+  - "tls-test: target"
+operatorsUnderTestLabels: []

--- a/.github/actions/test-scenarios/networking/tls-minimum-version/manifests/plain-http.yaml
+++ b/.github/actions/test-scenarios/networking/tls-minimum-version/manifests/plain-http.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: plain-http
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: plain-http
+      tls-test: target
+  template:
+    metadata:
+      labels:
+        app: plain-http
+        tls-test: target
+    spec:
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: plain-http-svc
+spec:
+  selector:
+    app: plain-http
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/.github/actions/test-scenarios/networking/tls-minimum-version/manifests/tls12-allowed.yaml
+++ b/.github/actions/test-scenarios/networking/tls-minimum-version/manifests/tls12-allowed.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tls12-allowed
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tls12-allowed
+      tls-test: target
+  template:
+    metadata:
+      labels:
+        app: tls12-allowed
+        tls-test: target
+    spec:
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8443
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls
+              readOnly: true
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+      volumes:
+        - name: tls
+          secret:
+            secretName: tls-test-cert
+        - name: conf
+          configMap:
+            name: nginx-tls12-allowed
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls12-allowed-svc
+spec:
+  selector:
+    app: tls12-allowed
+  ports:
+    - port: 443
+      targetPort: 8443

--- a/.github/actions/test-scenarios/networking/tls-minimum-version/manifests/tls12-only.yaml
+++ b/.github/actions/test-scenarios/networking/tls-minimum-version/manifests/tls12-only.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tls12-only
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tls12-only
+      tls-test: target
+  template:
+    metadata:
+      labels:
+        app: tls12-only
+        tls-test: target
+    spec:
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8443
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls
+              readOnly: true
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+      volumes:
+        - name: tls
+          secret:
+            secretName: tls-test-cert
+        - name: conf
+          configMap:
+            name: nginx-tls12-only
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls12-only-svc
+spec:
+  selector:
+    app: tls12-only
+  ports:
+    - port: 443
+      targetPort: 8443

--- a/.github/actions/test-scenarios/networking/tls-minimum-version/manifests/tls13-only.yaml
+++ b/.github/actions/test-scenarios/networking/tls-minimum-version/manifests/tls13-only.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tls13-only
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tls13-only
+      tls-test: target
+  template:
+    metadata:
+      labels:
+        app: tls13-only
+        tls-test: target
+    spec:
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8443
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls
+              readOnly: true
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+      volumes:
+        - name: tls
+          secret:
+            secretName: tls-test-cert
+        - name: conf
+          configMap:
+            name: nginx-tls13-only
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls13-only-svc
+spec:
+  selector:
+    app: tls13-only
+  ports:
+    - port: 443
+      targetPort: 8443

--- a/.github/actions/test-scenarios/run-scenarios.sh
+++ b/.github/actions/test-scenarios/run-scenarios.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run all test scenarios defined in scenarios.json.
+# Each scenario deploys a single workload, runs certsuite, validates the
+# result against the expected state, and cleans up.
+#
+# Usage: run-scenarios.sh [--log-level LEVEL]
+#
+# Requires: jq, kubectl, ./certsuite binary
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCENARIOS_FILE="${SCRIPT_DIR}/scenarios.json"
+LOG_LEVEL="${SMOKE_TESTS_LOG_LEVEL:-info}"
+OVERALL_RC=0
+
+scenario_count=$(jq 'length' "$SCENARIOS_FILE")
+echo "=== Running ${scenario_count} test scenario(s) ==="
+
+for i in $(seq 0 $((scenario_count - 1))); do
+  NAME=$(jq -r ".[$i].name" "$SCENARIOS_FILE")
+  LABEL_FILTER=$(jq -r ".[$i].label_filter" "$SCENARIOS_FILE")
+  SCENARIO_PATH=$(jq -r ".[$i].path" "$SCENARIOS_FILE")
+  MANIFEST=$(jq -r ".[$i].manifest" "$SCENARIOS_FILE")
+  OUTPUT_DIR=$(jq -r ".[$i].output_dir" "$SCENARIOS_FILE")
+  EXPECTED_RESULT=$(jq -r ".[$i].expected_result" "$SCENARIOS_FILE")
+
+  SCENARIO_DIR="${SCRIPT_DIR}/${SCENARIO_PATH}"
+  CONFIG_FILE="${SCENARIO_DIR}/manifests/certsuite-config.yaml"
+
+  echo ""
+  echo "========================================"
+  echo "Scenario: ${NAME}"
+  echo "  Label filter:    ${LABEL_FILTER}"
+  echo "  Manifest:        ${MANIFEST}"
+  echo "  Expected result: ${EXPECTED_RESULT}"
+  echo "========================================"
+
+  RC=0
+
+  # Deploy
+  echo "--- Deploy ---"
+  if ! "${SCENARIO_DIR}/deploy.sh" "${MANIFEST}"; then
+    echo "FAIL: deploy failed for scenario '${NAME}'"
+    RC=1
+  fi
+
+  # Run certsuite (allow failure since some scenarios expect it)
+  if [[ $RC -eq 0 ]]; then
+    echo "--- Run certsuite ---"
+    ./certsuite run \
+      --label-filter="${LABEL_FILTER}" \
+      --config-file="${CONFIG_FILE}" \
+      --output-dir="${OUTPUT_DIR}" \
+      --log-level="${LOG_LEVEL}" || true
+  fi
+
+  # Validate
+  if [[ $RC -eq 0 ]]; then
+    echo "--- Validate ---"
+    CLAIM_FILE="${OUTPUT_DIR}/claim.json"
+    if [[ ! -f "$CLAIM_FILE" ]]; then
+      echo "FAIL: claim.json not found at ${CLAIM_FILE}"
+      RC=1
+    else
+      ACTUAL_STATE=$(jq -r --arg id "$LABEL_FILTER" '.claim.results[$id].state // empty' "$CLAIM_FILE")
+      if [[ -z "$ACTUAL_STATE" ]]; then
+        echo "FAIL: test ${LABEL_FILTER} not found in claim.json"
+        RC=1
+      elif [[ "$ACTUAL_STATE" != "$EXPECTED_RESULT" ]]; then
+        echo "FAIL: expected '${EXPECTED_RESULT}', got '${ACTUAL_STATE}'"
+        RC=1
+      else
+        echo "PASS: test state '${ACTUAL_STATE}' matches expected '${EXPECTED_RESULT}'"
+      fi
+    fi
+  fi
+
+  # Print debug log on failure
+  if [[ $RC -ne 0 ]]; then
+    echo "--- Scenario certsuite.log (debug) ---"
+    if [[ -f "certsuite.log" ]]; then
+      grep -i "tls\|tlsversion\|Probing\|exec.*fallback\|probe.*pod\|probePods\|DaemonSet\|daemonset\|cnf-suite" certsuite.log || echo "(no matching log lines)"
+    else
+      echo "(certsuite.log not found)"
+    fi
+  fi
+
+  # Cleanup (always runs)
+  echo "--- Cleanup ---"
+  "${SCENARIO_DIR}/cleanup.sh" "${OUTPUT_DIR}" || true
+
+  if [[ $RC -ne 0 ]]; then
+    OVERALL_RC=1
+  else
+    echo "Scenario '${NAME}' passed."
+  fi
+done
+
+echo ""
+if [[ $OVERALL_RC -ne 0 ]]; then
+  echo "=== One or more scenarios FAILED ==="
+  exit 1
+fi
+echo "=== All scenarios passed ==="

--- a/.github/actions/test-scenarios/scenarios.json
+++ b/.github/actions/test-scenarios/scenarios.json
@@ -1,0 +1,38 @@
+[
+  {
+    "name": "TLS 1.3 Only (non-compliant with Intermediate)",
+    "description": "Deploys an nginx server configured to accept only TLS 1.3 connections. Under the Intermediate profile (the default on non-OCP clusters), the server must accept all versions from TLS 1.2 upward. A TLS 1.3-only server rejects TLS 1.2 and is therefore non-compliant. This scenario verifies that overly restrictive servers are correctly flagged.",
+    "label_filter": "networking-tls-minimum-version",
+    "path": "networking/tls-minimum-version",
+    "manifest": "tls13-only.yaml",
+    "expected_result": "failed",
+    "output_dir": "tls13-only-results"
+  },
+  {
+    "name": "TLS 1.2 Only (non-compliant with Intermediate)",
+    "description": "Deploys an nginx server configured to accept only TLS 1.2 connections with Intermediate-profile ciphers. Under the Intermediate profile, the server must accept all versions from TLS 1.2 through TLS 1.3. A TLS 1.2-only server rejects TLS 1.3 and is therefore non-compliant. This scenario exercises the above-minimum version check (Step 3).",
+    "label_filter": "networking-tls-minimum-version",
+    "path": "networking/tls-minimum-version",
+    "manifest": "tls12-only.yaml",
+    "expected_result": "failed",
+    "output_dir": "tls12-only-results"
+  },
+  {
+    "name": "TLS 1.2 Allowed (compliant with Intermediate profile)",
+    "description": "Deploys an nginx server configured to accept both TLS 1.2 and TLS 1.3 connections, restricted to only the cipher suites allowed by the Intermediate TLS security profile. On non-OpenShift clusters (including CI), the test defaults to the Intermediate profile (min TLS 1.2). Since this server meets both the minimum version and cipher requirements, it is compliant. Note: this same server would be non-compliant under a Modern profile (which requires TLS 1.3), but that is covered by unit tests rather than CI scenarios.",
+    "label_filter": "networking-tls-minimum-version",
+    "path": "networking/tls-minimum-version",
+    "manifest": "tls12-allowed.yaml",
+    "expected_result": "passed",
+    "output_dir": "tls12-allowed-results"
+  },
+  {
+    "name": "Plain HTTP (compliant)",
+    "description": "Deploys a plain HTTP server with no TLS configured. Non-TLS services are reported as informational only and are not considered a compliance failure. The test verifies that the certsuite does not penalize services that do not use TLS at all, since they are outside the scope of TLS version enforcement.",
+    "label_filter": "networking-tls-minimum-version",
+    "path": "networking/tls-minimum-version",
+    "manifest": "plain-http.yaml",
+    "expected_result": "passed",
+    "output_dir": "plain-http-results"
+  }
+]

--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -287,6 +287,9 @@ jobs:
       - name: Print the certsuite.log
         run: cat certsuite-out/certsuite.log
 
+      - name: Run test scenarios
+        run: .github/actions/test-scenarios/run-scenarios.sh
+
       - name: 'Test: Run preflight specific test suite'
         run: ./certsuite run --label-filter=preflight --log-level="${SMOKE_TESTS_LOG_LEVEL}"
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 ## Test cases summary
 
-### Total test cases: 122
+### Total test cases: 123
 
 ### Total suites: 10
 
@@ -17,18 +17,18 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |affiliated-certification|4|[affiliated-certification](#affiliated-certification)|
 |lifecycle|19|[lifecycle](#lifecycle)|
 |manageability|2|[manageability](#manageability)|
-|networking|11|[networking](#networking)|
+|networking|12|[networking](#networking)|
 |observability|5|[observability](#observability)|
 |operator|12|[operator](#operator)|
 |performance|7|[performance](#performance)|
 |platform-alteration|14|[platform-alteration](#platform-alteration)|
 |preflight|17|[preflight](#preflight)|
 
-### Extended specific tests only: 13
+### Extended specific tests only: 14
 
 |Mandatory|Optional|
 |---|---|---|
-|10|3|
+|10|4|
 
 ### Far-Edge specific tests only: 9
 
@@ -1181,6 +1181,23 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |**Scenario**|**Optional/Mandatory**|
 |Extended|Mandatory|
 |Far-Edge|Mandatory|
+|Non-Telco|Optional|
+|Telco|Optional|
+
+#### networking-tls-minimum-version
+
+|Property|Description|
+|---|---|
+|Unique ID|networking-tls-minimum-version|
+|Description|Checks that TLS-enabled services in target namespaces honor the cluster's TLS security profile. On OpenShift, the profile is read from the APIServer CR (default: Intermediate, min TLS 1.2). On non-OpenShift clusters, Intermediate is used as default. Validates both minimum TLS version and cipher suite compliance. Non-TLS ports are reported as informational only. Note: this test is skipped on OpenShift clusters running versions below 4.22.|
+|Suggested Remediation|Configure workload services to honor the cluster's TLS security profile. On OpenShift, the minimum TLS version and allowed ciphers are determined by the APIServer CR's TLSSecurityProfile (default: Intermediate, min TLS 1.2). Ensure server TLS settings enforce at least the profile's minimum version and only accept ciphers from the profile's allowed list.|
+|Best Practice Reference|No Doc Link - Extended|
+|Exception Process|No exception needed for optional/extended tests.|
+|Impact Statement|Services accepting TLS versions below 1.3 are vulnerable to known protocol attacks (BEAST, POODLE, Lucky13) and may fail security compliance audits required for telco/CNF deployments.|
+|Tags|extended,networking|
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Optional|
+|Far-Edge|Optional|
 |Non-Telco|Optional|
 |Telco|Optional|
 

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 ## Test cases summary
 
-### Total test cases: 124
+### Total test cases: 125
 
 ### Total suites: 10
 
@@ -17,18 +17,18 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |affiliated-certification|4|[affiliated-certification](#affiliated-certification)|
 |lifecycle|19|[lifecycle](#lifecycle)|
 |manageability|2|[manageability](#manageability)|
-|networking|11|[networking](#networking)|
+|networking|12|[networking](#networking)|
 |observability|5|[observability](#observability)|
 |operator|12|[operator](#operator)|
 |performance|7|[performance](#performance)|
 |platform-alteration|14|[platform-alteration](#platform-alteration)|
 |preflight|19|[preflight](#preflight)|
 
-### Extended specific tests only: 13
+### Extended specific tests only: 14
 
 |Mandatory|Optional|
 |---|---|---|
-|10|3|
+|10|4|
 
 ### Far-Edge specific tests only: 9
 
@@ -1184,6 +1184,23 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Non-Telco|Optional|
 |Telco|Optional|
 
+#### networking-tls-minimum-version
+
+|Property|Description|
+|---|---|
+|Unique ID|networking-tls-minimum-version|
+|Description|Checks that TLS-enabled services in target namespaces honor the cluster's TLS security profile. On OpenShift, the profile is read from the APIServer CR (default: Intermediate, min TLS 1.2). On non-OpenShift clusters, Intermediate is used as default. Validates both minimum TLS version and cipher suite compliance. Non-TLS ports are reported as informational only. Note: this test is skipped on OpenShift clusters running versions below 4.22.|
+|Suggested Remediation|Configure workload services to honor the cluster's TLS security profile. On OpenShift, the minimum TLS version and allowed ciphers are determined by the APIServer CR's TLSSecurityProfile (default: Intermediate, min TLS 1.2). Ensure server TLS settings enforce at least the profile's minimum version and only accept ciphers from the profile's allowed list.|
+|Best Practice Reference|No Doc Link - Extended|
+|Exception Process|No exception needed for optional/extended tests.|
+|Impact Statement|Services accepting TLS versions below 1.3 are vulnerable to known protocol attacks (BEAST, POODLE, Lucky13) and may fail security compliance audits required for telco/CNF deployments.|
+|Tags|extended,networking|
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Optional|
+|Far-Edge|Optional|
+|Non-Telco|Optional|
+|Telco|Optional|
+
 #### networking-undeclared-container-ports-usage
 
 |Property|Description|
@@ -1879,7 +1896,7 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Property|Description|
 |---|---|
 |Unique ID|preflight-BasedOnUbi|
-|Description|Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)|
+|Description|Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI) or Red Hat Hardened Images (RHHI)|
 |Suggested Remediation|Change the FROM directive in your Dockerfile or Containerfile, for the latest list of images and details refer to: https://catalog.redhat.com/software/base-images|
 |Best Practice Reference|No Doc Link|
 |Exception Process|There is no documented exception process for this.|

--- a/_typos.toml
+++ b/_typos.toml
@@ -4,5 +4,8 @@ ITMS = "ITMS"
 odf = "odf"
 ono = "ono"
 
+[default.extend-identifiers]
+ITMS = "ITMS"
+
 [files]
 extend-exclude = ["depends-on.json", "go.mod", "results.html", "cmd/certsuite/claim/compare/testdata", "docs/assets/images/*.svg", "*.js"]

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -54,6 +54,7 @@ testCases:
     - networking-network-policy-deny-all
     - networking-ocp-reserved-ports-usage
     - networking-reserved-partner-ports
+    - networking-tls-minimum-version
     - networking-undeclared-container-ports-usage
     - observability-container-logging
     - observability-crd-status

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"reflect"
 
+	goversion "github.com/hashicorp/go-version"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 )
 
@@ -174,6 +175,10 @@ const (
 	// Listening ports
 	PortNumber   = "Port Number"
 	PortProtocol = "Port Protocol"
+
+	// TLS
+	TLSVersion = "TLS Version"
+	TLSCipher  = "TLS Cipher"
 
 	// OLM
 	SubscriptionName = "Subscription Name"
@@ -426,6 +431,36 @@ func GetNonOCPClusterSkipFn() func() (bool, string) {
 		if !provider.IsOCPCluster() {
 			return true, "non-OCP cluster detected"
 		}
+		return false, ""
+	}
+}
+
+func GetOCPVersionBelowSkipFn(env *provider.TestEnvironment, minVersion string) func() (bool, string) {
+	// Parse minVersion once at closure creation since it is constant.
+	minimum, minErr := goversion.NewVersion(minVersion)
+
+	return func() (bool, string) {
+		if !provider.IsOCPCluster() {
+			return false, ""
+		}
+
+		if minErr != nil {
+			return true, fmt.Sprintf("failed to parse minimum version %q: %v", minVersion, minErr)
+		}
+
+		if env.OpenshiftVersion == "" {
+			return true, "OCP version is empty"
+		}
+
+		current, err := goversion.NewVersion(env.OpenshiftVersion)
+		if err != nil {
+			return true, fmt.Sprintf("failed to parse OCP version %q: %v", env.OpenshiftVersion, err)
+		}
+
+		if current.LessThan(minimum) {
+			return true, fmt.Sprintf("OCP version %q is below %s", env.OpenshiftVersion, minVersion)
+		}
+
 		return false, ""
 	}
 }

--- a/pkg/testhelper/testhelper_test.go
+++ b/pkg/testhelper/testhelper_test.go
@@ -1284,6 +1284,68 @@ func TestFailureReasonOutEqual(t *testing.T) {
 	}
 }
 
+func TestGetOCPVersionBelowSkipFn(t *testing.T) {
+	// In the default test environment, IsOCPCluster() returns true because
+	// the global env's OpenshiftVersion defaults to "" (which != "0.0.0").
+	// These tests exercise the version comparison logic in the OCP path.
+	testCases := []struct {
+		name           string
+		ocpVersion     string
+		minVersion     string
+		expectedResult bool
+	}{
+		{
+			name:           "empty OCP version skips",
+			ocpVersion:     "",
+			minVersion:     "4.22",
+			expectedResult: true,
+		},
+		{
+			name:           "OCP version below minimum skips",
+			ocpVersion:     "4.21",
+			minVersion:     "4.22",
+			expectedResult: true,
+		},
+		{
+			name:           "OCP version at minimum does not skip",
+			ocpVersion:     "4.22",
+			minVersion:     "4.22",
+			expectedResult: false,
+		},
+		{
+			name:           "OCP version above minimum does not skip",
+			ocpVersion:     "4.23",
+			minVersion:     "4.22",
+			expectedResult: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := &provider.TestEnvironment{OpenshiftVersion: tc.ocpVersion}
+			testFunc := GetOCPVersionBelowSkipFn(env, tc.minVersion)
+			result, _ := testFunc()
+			assert.Equal(t, tc.expectedResult, result)
+		})
+	}
+}
+
+func TestGetOCPVersionBelowSkipFn_InvalidMinVersion(t *testing.T) {
+	env := &provider.TestEnvironment{OpenshiftVersion: "4.22"}
+	testFunc := GetOCPVersionBelowSkipFn(env, "not-a-version")
+	result, msg := testFunc()
+	assert.True(t, result, "invalid minVersion should trigger skip")
+	assert.Contains(t, msg, "failed to parse minimum version")
+}
+
+func TestGetOCPVersionBelowSkipFn_InvalidOCPVersion(t *testing.T) {
+	env := &provider.TestEnvironment{OpenshiftVersion: "invalid-version"}
+	testFunc := GetOCPVersionBelowSkipFn(env, "4.22")
+	result, msg := testFunc()
+	assert.True(t, result, "invalid OCP version should trigger skip")
+	assert.Contains(t, msg, "failed to parse OCP version")
+}
+
 func TestGetNoCatalogSourcesSkipFn(t *testing.T) {
 	testCases := []struct {
 		testEnv        *provider.TestEnvironment

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -21,6 +21,7 @@ const (
 	TestServiceDualStackIdentifierDocLink               = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-ipv4-&-ipv6"
 	TestUndeclaredContainerPortsUsageDocLink            = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requirements-cnf-reqs"
 	TestOCPReservedPortsUsageDocLink                    = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-ports-reserved-by-openshift"
+	TestTLSMinimumVersionIdentifierDocLink              = NoDocLinkExtended
 
 	// Access Control Suite
 	Test1337UIDIdentifierDocLink                             = NoDocLinkExtended

--- a/tests/identifiers/impact.go
+++ b/tests/identifiers/impact.go
@@ -37,6 +37,7 @@ const (
 	TestServiceDualStackIdentifierImpact               = `Single-stack IPv4 services limit network architecture flexibility and prevent migration to modern dual-stack infrastructures.`
 	TestUndeclaredContainerPortsUsageImpact            = `Undeclared ports can be blocked by security policies, causing unexpected connectivity issues and making troubleshooting difficult.`
 	TestOCPReservedPortsUsageImpact                    = `Using OpenShift-reserved ports can cause critical platform services to fail, potentially destabilizing the entire cluster.`
+	TestTLSMinimumVersionIdentifierImpact              = `Services accepting TLS versions below 1.3 are vulnerable to known protocol attacks (BEAST, POODLE, Lucky13) and may fail security compliance audits required for telco/CNF deployments.`
 
 	// Access Control Suite Impact Statements
 	Test1337UIDIdentifierImpact                             = `UID 1337 is reserved for use by Istio service mesh components; using it for applications can cause conflicts with Istio sidecars and break service mesh functionality.`
@@ -183,6 +184,7 @@ var ImpactMap = map[string]string{
 	"networking-dual-stack-service":                      TestServiceDualStackIdentifierImpact,
 	"networking-undeclared-container-ports-usage":        TestUndeclaredContainerPortsUsageImpact,
 	"networking-ocp-reserved-ports-usage":                TestOCPReservedPortsUsageImpact,
+	"networking-tls-minimum-version":                     TestTLSMinimumVersionIdentifierImpact,
 
 	// Access Control Suite
 	"access-control-no-1337-uid":                                 Test1337UIDIdentifierImpact,

--- a/tests/identifiers/impact.go
+++ b/tests/identifiers/impact.go
@@ -37,6 +37,7 @@ const (
 	TestServiceDualStackIdentifierImpact               = `Single-stack IPv4 services limit network architecture flexibility and prevent migration to modern dual-stack infrastructures.`
 	TestUndeclaredContainerPortsUsageImpact            = `Undeclared ports can be blocked by security policies, causing unexpected connectivity issues and making troubleshooting difficult.`
 	TestOCPReservedPortsUsageImpact                    = `Using OpenShift-reserved ports can cause critical platform services to fail, potentially destabilizing the entire cluster.`
+	TestTLSMinimumVersionIdentifierImpact              = `Services accepting TLS versions below 1.3 are vulnerable to known protocol attacks (BEAST, POODLE, Lucky13) and may fail security compliance audits required for telco/CNF deployments.`
 
 	// Access Control Suite Impact Statements
 	Test1337UIDIdentifierImpact                             = `UID 1337 is reserved for use by Istio service mesh components; using it for applications can cause conflicts with Istio sidecars and break service mesh functionality.`
@@ -181,6 +182,7 @@ var ImpactMap = map[string]string{
 	"networking-dual-stack-service":                      TestServiceDualStackIdentifierImpact,
 	"networking-undeclared-container-ports-usage":        TestUndeclaredContainerPortsUsageImpact,
 	"networking-ocp-reserved-ports-usage":                TestOCPReservedPortsUsageImpact,
+	"networking-tls-minimum-version":                     TestTLSMinimumVersionIdentifierImpact,
 
 	// Access Control Suite
 	"access-control-no-1337-uid":                                 Test1337UIDIdentifierImpact,

--- a/tests/identifiers/networking.go
+++ b/tests/identifiers/networking.go
@@ -32,6 +32,7 @@ var (
 	TestReservedExtendedPartnerPorts             claim.Identifier
 	TestRestartOnRebootLabelOnPodsUsingSRIOV     claim.Identifier
 	TestServiceDualStackIdentifier               claim.Identifier
+	TestTLSMinimumVersionIdentifier              claim.Identifier
 	TestUndeclaredContainerPortsUsage            claim.Identifier
 )
 
@@ -193,6 +194,27 @@ func init() {
 			Telco:    Optional,
 			NonTelco: Optional,
 			Extended: Mandatory,
+		},
+		TagExtended)
+
+	TestTLSMinimumVersionIdentifier = AddCatalogEntry(
+		"tls-minimum-version",
+		common.NetworkingTestKey,
+		`Checks that TLS-enabled services in target namespaces honor the cluster's TLS security profile. `+
+			`On OpenShift, the profile is read from the APIServer CR (default: Intermediate, min TLS 1.2). `+
+			`On non-OpenShift clusters, Intermediate is used as default. `+
+			`Validates both minimum TLS version and cipher suite compliance. `+
+			`Non-TLS ports are reported as informational only. `+
+			`Note: this test is skipped on OpenShift clusters running versions below 4.22.`,
+		TLSMinimumVersionRemediation,
+		NoExceptionProcessForExtendedTests,
+		TestTLSMinimumVersionIdentifierDocLink,
+		true,
+		map[string]string{
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
+			Extended: Optional,
 		},
 		TagExtended)
 

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -229,4 +229,6 @@ const (
 	ContainerPostStartIdentifierRemediation = `Identify which pod is not conforming to the process and submit information as to why it cannot use a postStart startup specification.`
 
 	ContainerPrestopIdentifierRemediation = `Identify which pod is not conforming to the process and submit information as to why it cannot use a preStop shutdown specification.`
+
+	TLSMinimumVersionRemediation = `Configure workload services to honor the cluster's TLS security profile. On OpenShift, the minimum TLS version and allowed ciphers are determined by the APIServer CR's TLSSecurityProfile (default: Intermediate, min TLS 1.2). Ensure server TLS settings enforce at least the profile's minimum version and only accept ciphers from the profile's allowed list.`
 )

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
@@ -31,6 +32,7 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/netutil"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/policies"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/services"
+	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/tlsversion"
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
@@ -155,6 +157,18 @@ func LoadChecks() {
 				return fmt.Errorf("failure getting pods using SRIOV: %w", err)
 			}
 			testNetworkAttachmentDefinitionSRIOVUsingMTU(c, sriovPods)
+			return nil
+		}))
+
+	// TLS minimum version test case
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestTLSMinimumVersionIdentifier)).
+		WithSkipCheckFn(
+			testhelper.GetNoServicesUnderTestSkipFn(&env),
+			testhelper.GetDaemonSetFailedToSpawnSkipFn(&env),
+			testhelper.GetOCPVersionBelowSkipFn(&env, tlsversion.OCPTLSProfileEnforcementVersion),
+		).
+		WithCheckFn(func(c *checksdb.Check) error {
+			testTLSMinimumVersion(c, &env)
 			return nil
 		}))
 }
@@ -490,4 +504,12 @@ func testNetworkAttachmentDefinitionSRIOVUsingMTU(check *checksdb.Check, sriovPo
 	}
 
 	check.SetResult(compliantObjects, nonCompliantObjects)
+}
+
+func testTLSMinimumVersion(check *checksdb.Check, env *provider.TestEnvironment) {
+	oc := clientsholder.GetClientsHolder()
+	policy := tlsversion.GetClusterTLSPolicy(oc.OcpClient, provider.IsOCPCluster())
+	check.LogInfo("Using TLS profile %q (min version: %s)", policy.ProfileType, tlsversion.TLSVersionString(policy.MinTLSVersion))
+	compliant, nonCompliant := tlsversion.CheckServiceTLSCompliance(check, env, policy)
+	check.SetResult(compliant, nonCompliant)
 }

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
@@ -31,6 +32,7 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/netutil"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/policies"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/services"
+	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/tlsversion"
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
@@ -148,6 +150,18 @@ func LoadChecks() {
 				return fmt.Errorf("failure getting pods using SRIOV: %w", err)
 			}
 			testNetworkAttachmentDefinitionSRIOVUsingMTU(c, sriovPods)
+			return nil
+		}))
+
+	// TLS minimum version test case
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestTLSMinimumVersionIdentifier)).
+		WithSkipCheckFn(
+			testhelper.GetNoServicesUnderTestSkipFn(&env),
+			testhelper.GetDaemonSetFailedToSpawnSkipFn(&env),
+			testhelper.GetOCPVersionBelowSkipFn(&env, tlsversion.OCPTLSProfileEnforcementVersion),
+		).
+		WithCheckFn(func(c *checksdb.Check) error {
+			testTLSMinimumVersion(c, &env)
 			return nil
 		}))
 }
@@ -483,4 +497,12 @@ func testNetworkAttachmentDefinitionSRIOVUsingMTU(check *checksdb.Check, sriovPo
 	}
 
 	check.SetResult(compliantObjects, nonCompliantObjects)
+}
+
+func testTLSMinimumVersion(check *checksdb.Check, env *provider.TestEnvironment) {
+	oc := clientsholder.GetClientsHolder()
+	policy := tlsversion.GetClusterTLSPolicy(oc.OcpClient, provider.IsOCPCluster())
+	check.LogInfo("Using TLS profile %q (min version: %s)", policy.ProfileType, tlsversion.TLSVersionString(policy.MinTLSVersion))
+	compliant, nonCompliant := tlsversion.CheckServiceTLSCompliance(check, env, policy)
+	check.SetResult(compliant, nonCompliant)
 }

--- a/tests/networking/tlsversion/tlsversion.go
+++ b/tests/networking/tlsversion/tlsversion.go
@@ -1,0 +1,779 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package tlsversion
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	configv1 "github.com/openshift/api/config/v1"
+	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	opensslFlagTLS10 = "-tls1"
+	opensslFlagTLS11 = "-tls1_1"
+	opensslFlagTLS12 = "-tls1_2"
+	opensslFlagTLS13 = "-tls1_3"
+
+	opensslProtoNameTLS10 = "TLSv1"
+	opensslProtoNameTLS11 = "TLSv1.1"
+	opensslProtoNameTLS12 = "TLSv1.2"
+	opensslProtoNameTLS13 = "TLSv1.3"
+
+	truncateLen = 200
+
+	// openssl output patterns used to classify TLS probe results.
+	opensslCipherNone       = "Cipher is (NONE)"
+	opensslAlertProtoVer    = "alert protocol version"
+	opensslAlertHandshake   = "alert handshake failure"
+	opensslHandshakeFailure = "handshake failure"
+	opensslNoCiphers        = "no ciphers available"
+	opensslConnected        = "CONNECTED"
+	opensslConnErrno        = "errno"
+
+	// OCPTLSProfileEnforcementVersion is the minimum OCP version at which the
+	// APIServer CR's TLS security profile is reliably enforced. On older versions,
+	// we ignore the CR and fall back to the Intermediate profile (min TLS 1.2).
+	OCPTLSProfileEnforcementVersion = "4.22"
+
+	TLSVersionNameTLS10 = "TLS 1.0"
+	TLSVersionNameTLS11 = "TLS 1.1"
+	TLSVersionNameTLS12 = "TLS 1.2"
+	TLSVersionNameTLS13 = "TLS 1.3"
+
+	cipherECDHERSAAES128GCMSHA256 = "ECDHE-RSA-AES128-GCM-SHA256"
+	reasonPortUnreachable         = "port unreachable"
+	reasonUnknown                 = "unknown"
+)
+
+// TLSPolicy holds the resolved effective TLS policy for the cluster.
+type TLSPolicy struct {
+	ProfileType        string
+	MinTLSVersion      uint16   // Go crypto/tls constant (e.g. tls.VersionTLS12)
+	AllowedCipherIDs   []uint16 // Go cipher suite IDs allowed for TLS 1.2
+	AllowedCipherNames []string // OpenSSL cipher names allowed for TLS 1.2
+}
+
+// TLSProbeResult holds the outcome of a TLS probe against a single service port.
+type TLSProbeResult struct {
+	Compliant     bool
+	IsTLS         bool
+	Reachable     bool
+	NegotiatedVer string
+	Reason        string
+}
+
+// opensslToGoCipher maps OpenSSL cipher suite names to Go crypto/tls cipher suite IDs.
+//
+// The OpenSSL names come from the OpenShift TLS security profiles defined in:
+//
+//	https://github.com/openshift/api/blob/master/config/v1/types_tlssecurityprofile.go
+//
+// which follow Mozilla's Server Side TLS recommendations:
+//
+//	https://wiki.mozilla.org/Security/Server_Side_TLS
+//
+// The Go cipher suite constants are documented at:
+//
+//	https://pkg.go.dev/crypto/tls#pkg-constants
+//
+// DHE ciphers (e.g. DHE-RSA-AES128-GCM-SHA256) have no Go equivalent and are omitted;
+// they are tested via the openssl exec probe path.
+var opensslToGoCipher = map[string]uint16{
+	"ECDHE-ECDSA-AES128-GCM-SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+	cipherECDHERSAAES128GCMSHA256:   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	"ECDHE-ECDSA-AES256-GCM-SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-RSA-AES256-GCM-SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	"ECDHE-ECDSA-CHACHA20-POLY1305": tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+	"ECDHE-RSA-CHACHA20-POLY1305":   tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,
+	"AES128-GCM-SHA256":             tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
+	"AES256-GCM-SHA384":             tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+	"AES128-SHA256":                 tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
+	"AES128-SHA":                    tls.TLS_RSA_WITH_AES_128_CBC_SHA,
+	"AES256-SHA":                    tls.TLS_RSA_WITH_AES_256_CBC_SHA,
+	"ECDHE-ECDSA-AES128-SHA256":     tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
+	"ECDHE-RSA-AES128-SHA256":       tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+	"ECDHE-ECDSA-AES128-SHA":        tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+	"ECDHE-RSA-AES128-SHA":          tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,
+	"ECDHE-ECDSA-AES256-SHA384":     tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA, // closest Go mapping
+	"ECDHE-RSA-AES256-SHA384":       tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,   // closest Go mapping
+	"ECDHE-ECDSA-AES256-SHA":        tls.TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,
+	"ECDHE-RSA-AES256-SHA":          tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	"DES-CBC3-SHA":                  tls.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+}
+
+// tls13CipherNames lists TLS 1.3 cipher names from OpenShift profiles.
+// TLS 1.3 ciphers are not configurable in Go (always enabled when TLS 1.3 is used)
+// so we skip them when building allowed/disallowed sets.
+var tls13CipherNames = map[string]bool{
+	"TLS_AES_128_GCM_SHA256":       true,
+	"TLS_AES_256_GCM_SHA384":       true,
+	"TLS_CHACHA20_POLY1305_SHA256": true,
+}
+
+// probeFunc is the function used to probe a service port via an exec pod.
+// It is a package-level variable so tests can inject a stub.
+var probeFunc = probeServicePortViaExecPod
+
+// ---------------------------------------------------------------------------
+// Public functions
+// ---------------------------------------------------------------------------
+
+// DefaultTLSPolicy returns the Intermediate profile (OpenShift default).
+func DefaultTLSPolicy() TLSPolicy {
+	return ResolveTLSProfile(nil)
+}
+
+// GetClusterTLSPolicy reads the cluster's TLS security profile from the APIServer CR
+// on OpenShift, or falls back to the Intermediate default on non-OCP clusters.
+// The caller's skip function guarantees the OCP version is at or above
+// OCPTLSProfileEnforcementVersion before this function is reached.
+// See https://docs.openshift.com/container-platform/latest/security/tls-security-profiles.html
+func GetClusterTLSPolicy(ocpClient clientconfigv1.ConfigV1Interface, isOCP bool) TLSPolicy {
+	if !isOCP {
+		return DefaultTLSPolicy()
+	}
+
+	apiServer, err := ocpClient.APIServers().Get(context.TODO(), "cluster", metav1.GetOptions{})
+	if err != nil {
+		return DefaultTLSPolicy()
+	}
+
+	return ResolveTLSProfile(apiServer.Spec.TLSSecurityProfile)
+}
+
+// ResolveTLSProfile converts an OpenShift TLSSecurityProfile into a TLSPolicy.
+// A nil profile resolves to the Intermediate profile (the OpenShift default).
+func ResolveTLSProfile(profile *configv1.TLSSecurityProfile) TLSPolicy {
+	if profile == nil {
+		return resolveTLSProfileSpec(string(configv1.TLSProfileIntermediateType),
+			configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
+	}
+
+	switch profile.Type {
+	// Old: most permissive profile. Min TLS 1.0, allows 28 ciphers including
+	// legacy suites (DES-CBC3-SHA, RC4, SHA-1 based). Intended for backward
+	// compatibility with very old clients.
+	case configv1.TLSProfileOldType:
+		return resolveTLSProfileSpec(string(configv1.TLSProfileOldType),
+			configv1.TLSProfiles[configv1.TLSProfileOldType])
+
+	// Modern: most restrictive profile. Min TLS 1.3, no TLS 1.2 ciphers
+	// (only the 3 mandatory TLS 1.3 suites). Provides the strongest security
+	// but drops support for all TLS 1.2 clients.
+	case configv1.TLSProfileModernType:
+		return resolveTLSProfileSpec(string(configv1.TLSProfileModernType),
+			configv1.TLSProfiles[configv1.TLSProfileModernType])
+
+	// Custom: user-defined profile with explicit min TLS version and cipher
+	// list. Falls back to Intermediate if the Custom spec is nil.
+	case configv1.TLSProfileCustomType:
+		if profile.Custom != nil {
+			spec := &profile.Custom.TLSProfileSpec
+			return resolveTLSProfileSpec(string(configv1.TLSProfileCustomType), spec)
+		}
+		return resolveTLSProfileSpec(string(configv1.TLSProfileIntermediateType),
+			configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
+
+	// Intermediate (default): balanced profile. Min TLS 1.2, allows 8 strong
+	// TLS 1.2 ciphers (ECDHE/DHE with GCM or ChaCha20-Poly1305) plus the
+	// 3 TLS 1.3 suites. This is the OpenShift default and the fallback for
+	// unrecognized profile types.
+	default:
+		return resolveTLSProfileSpec(string(configv1.TLSProfileIntermediateType),
+			configv1.TLSProfiles[configv1.TLSProfileIntermediateType])
+	}
+}
+
+// ProbeServicePortViaExec runs openssl s_client inside a probe pod to test
+// TLS compliance against the given policy.
+//
+// The probe follows a four-step flow:
+//  1. Connect at the policy's minimum TLS version to confirm the server accepts it.
+//  2. Connect one version below the minimum to confirm the server rejects it
+//     (skipped when minimum is TLS 1.0 since there is nothing lower).
+//  3. Connect at each version above the minimum up to TLS 1.3 to confirm the server
+//     accepts all versions in the profile's supported range (e.g. Intermediate must
+//     accept both TLS 1.2 and TLS 1.3).
+//  4. Attempt a TLS 1.2 handshake using only disallowed cipher suites to confirm the
+//     server rejects them (skipped when minimum is TLS 1.3).
+func ProbeServicePortViaExec(ch clientsholder.Command, ctx clientsholder.Context, address string, port int32, policy TLSPolicy) TLSProbeResult {
+	endpoint := net.JoinHostPort(address, strconv.Itoa(int(port)))
+
+	// Step 1: Confirm the server accepts the policy's minimum TLS version.
+	if result := probeExecMinVersion(ch, ctx, endpoint, policy); result != nil {
+		return *result
+	}
+
+	// Step 2: Confirm the server rejects versions below the minimum.
+	belowVer := versionBelow(policy.MinTLSVersion)
+	if belowVer > 0 {
+		if result := probeExecVersion(ch, ctx, endpoint, belowVer, false, policy); !result.Compliant {
+			return result
+		}
+	}
+
+	// Step 3: Confirm the server accepts all versions above the minimum up to TLS 1.3.
+	for _, aboveVer := range versionsAbove(policy.MinTLSVersion) {
+		if result := probeExecVersion(ch, ctx, endpoint, aboveVer, true, policy); !result.Compliant {
+			return result
+		}
+	}
+
+	// Step 4: Confirm the server rejects disallowed cipher suites.
+	if result := probeExecCipherCompliance(ch, ctx, endpoint, policy); result != nil {
+		return *result
+	}
+
+	return TLSProbeResult{
+		Compliant:     true,
+		IsTLS:         true,
+		Reachable:     true,
+		NegotiatedVer: TLSVersionString(policy.MinTLSVersion),
+		Reason:        fmt.Sprintf("server honors %s profile (via exec probe)", policy.ProfileType),
+	}
+}
+
+// CheckServiceTLSCompliance iterates env.Services and all their TCP ports,
+// probes each for TLS compliance against the given policy via a probe pod,
+// and returns report objects.
+func CheckServiceTLSCompliance(check *checksdb.Check, env *provider.TestEnvironment, policy TLSPolicy) (
+	compliant, nonCompliant []*testhelper.ReportObject) {
+	for _, svc := range env.Services {
+		// Skip headless services
+		if svc.Spec.ClusterIP == "" || svc.Spec.ClusterIP == corev1.ClusterIPNone {
+			check.LogInfo("Skipping headless service %q in namespace %q (no ClusterIP)", svc.Name, svc.Namespace)
+			continue
+		}
+
+		for _, port := range svc.Spec.Ports {
+			// Skip non-TCP ports
+			if port.Protocol != corev1.ProtocolTCP {
+				check.LogInfo("Skipping non-TCP port %d/%s on service %q", port.Port, port.Protocol, svc.Name)
+				continue
+			}
+
+			check.LogInfo("Probing service %q port %d in namespace %q (profile: %s, min: %s)",
+				svc.Name, port.Port, svc.Namespace, policy.ProfileType, TLSVersionString(policy.MinTLSVersion))
+
+			result := probeFunc(check, env, svc.Spec.ClusterIP, port.Port, policy)
+
+			// If no probe pods are available, treat as compliant (informational).
+			if result == nil {
+				check.LogInfo("No probe pods available to test service %q port %d, treating as compliant (informational)",
+					svc.Name, port.Port)
+				ro := buildReportObject(svc, port.Port, TLSProbeResult{
+					Compliant: true,
+					Reason:    "no probe pods available to test TLS compliance",
+				})
+				compliant = append(compliant, ro)
+				continue
+			}
+
+			check.LogInfo("Exec probe result for %s:%d: compliant=%v, isTLS=%v, reachable=%v, reason=%q",
+				svc.Spec.ClusterIP, port.Port, result.Compliant, result.IsTLS, result.Reachable, result.Reason)
+
+			// If the probe could not reach the service, treat it as compliant
+			// (informational) — the port isn't listening or is unreachable,
+			// so there's no TLS to validate.
+			if !result.Reachable {
+				check.LogInfo("Service %q port %d unreachable (%s), treating as compliant (informational)",
+					svc.Name, port.Port, result.Reason)
+				result.Compliant = true
+			}
+
+			ro := buildReportObject(svc, port.Port, *result)
+			if result.Compliant {
+				compliant = append(compliant, ro)
+			} else {
+				nonCompliant = append(nonCompliant, ro)
+			}
+		}
+	}
+
+	return compliant, nonCompliant
+}
+
+// IsPortTLS probes a single TCP port via openssl to determine whether it speaks TLS.
+// It does not validate TLS version or cipher compliance — only whether TLS is present.
+func IsPortTLS(ch clientsholder.Command, ctx clientsholder.Context, address string, port int32) (isTLS, reachable bool, reason string) {
+	endpoint := net.JoinHostPort(address, strconv.Itoa(int(port)))
+	cmd := fmt.Sprintf("echo | timeout 5 openssl s_client -connect %s 2>&1", endpoint)
+	stdout, _, err := ch.ExecCommandContainer(ctx, cmd)
+
+	if err != nil && !hasOpensslOutput(stdout) {
+		return false, false, fmt.Sprintf("exec probe failed: %v", err)
+	}
+
+	if strings.Contains(stdout, "connect:errno=") || strings.Contains(stdout, "Connection refused") {
+		return false, false, reasonPortUnreachable
+	}
+
+	if !hasOpensslOutput(stdout) {
+		return false, false, "no recognizable openssl output"
+	}
+
+	// TLS alerts indicate a genuine TLS server (even if it rejected our params)
+	if strings.Contains(stdout, opensslAlertProtoVer) ||
+		strings.Contains(stdout, opensslAlertHandshake) ||
+		strings.Contains(stdout, opensslHandshakeFailure) {
+		return true, true, "TLS server detected (handshake alert)"
+	}
+
+	// Successful TLS handshake: cipher is not NONE
+	if !strings.Contains(stdout, opensslCipherNone) {
+		if strings.Contains(stdout, "Cipher    :") || strings.Contains(stdout, "Cipher:") {
+			cipher := extractOpenSSLCipher(stdout)
+			if cipher != "" && cipher != "0000" && cipher != "(NONE)" {
+				return true, true, fmt.Sprintf("TLS negotiated (cipher: %s)", cipher)
+			}
+		}
+	}
+
+	// Connected but no TLS indicators — plaintext service
+	return false, true, "plaintext service (no TLS)"
+}
+
+// ---------------------------------------------------------------------------
+// Private functions
+// ---------------------------------------------------------------------------
+
+// ocpVersionToGoVersion converts OpenShift TLSProtocolVersion strings to Go tls constants.
+func ocpVersionToGoVersion(v configv1.TLSProtocolVersion) uint16 {
+	switch v {
+	case configv1.VersionTLS10:
+		return tls.VersionTLS10
+	case configv1.VersionTLS11:
+		return tls.VersionTLS11
+	case configv1.VersionTLS12:
+		return tls.VersionTLS12
+	case configv1.VersionTLS13:
+		return tls.VersionTLS13
+	default:
+		return tls.VersionTLS12 // safe default
+	}
+}
+
+// resolveTLSProfileSpec converts an OpenShift TLSProfileSpec (profile type name +
+// min version + cipher list) into our internal TLSPolicy. It maps each OpenSSL cipher
+// name to its Go constant, skipping TLS 1.3 ciphers (not configurable in Go) and DHE
+// ciphers (no Go equivalent).
+func resolveTLSProfileSpec(profileType string, spec *configv1.TLSProfileSpec) TLSPolicy {
+	policy := TLSPolicy{
+		ProfileType:   profileType,
+		MinTLSVersion: ocpVersionToGoVersion(spec.MinTLSVersion),
+	}
+
+	for _, cipherName := range spec.Ciphers {
+		if tls13CipherNames[cipherName] {
+			continue // TLS 1.3 ciphers are handled by the protocol, not configurable
+		}
+		policy.AllowedCipherNames = append(policy.AllowedCipherNames, cipherName)
+		if id, ok := opensslToGoCipher[cipherName]; ok {
+			policy.AllowedCipherIDs = append(policy.AllowedCipherIDs, id)
+		}
+	}
+
+	return policy
+}
+
+// versionBelow returns the TLS version one step below the given version,
+// or 0 if there is no lower version to test.
+func versionBelow(ver uint16) uint16 {
+	switch ver {
+	case tls.VersionTLS13:
+		return tls.VersionTLS12
+	case tls.VersionTLS12:
+		return tls.VersionTLS11
+	case tls.VersionTLS11:
+		return tls.VersionTLS10
+	default:
+		return 0
+	}
+}
+
+// versionsAbove returns all TLS versions strictly above minVer up to TLS 1.3.
+func versionsAbove(minVer uint16) []uint16 {
+	allVersions := []uint16{tls.VersionTLS10, tls.VersionTLS11, tls.VersionTLS12, tls.VersionTLS13}
+	var above []uint16
+	for _, v := range allVersions {
+		if v > minVer {
+			above = append(above, v)
+		}
+	}
+	return above
+}
+
+// hasOpensslOutput returns true if stdout contains any recognizable openssl markers,
+// indicating the command ran and produced parseable output even if the handshake failed.
+func hasOpensslOutput(stdout string) bool {
+	return strings.Contains(stdout, opensslConnected) ||
+		strings.Contains(stdout, opensslConnErrno) ||
+		strings.Contains(stdout, "SSL") ||
+		strings.Contains(stdout, "Cipher")
+}
+
+// opensslVersionNegotiated returns true if the openssl output indicates that the
+// given TLS version was successfully negotiated. It checks both spacing variants
+// that different openssl versions produce ("Protocol  : " and "Protocol: ").
+func opensslVersionNegotiated(stdout string, ver uint16) bool {
+	verName := opensslVersionName(ver)
+	return strings.Contains(stdout, "Protocol  : "+verName) ||
+		strings.Contains(stdout, "Protocol: "+verName)
+}
+
+// opensslHandshakeRejected returns true if the openssl output indicates
+// a rejected TLS handshake (cipher none, protocol version alert, or failure).
+func opensslHandshakeRejected(output string) bool {
+	return strings.Contains(output, opensslCipherNone) ||
+		strings.Contains(output, opensslAlertProtoVer) ||
+		strings.Contains(output, opensslHandshakeFailure)
+}
+
+// probeExecMinVersion connects at the policy's minimum TLS version and checks
+// whether the server accepts it. Returns nil on success (server accepted the
+// minimum version), or a TLSProbeResult describing the failure.
+func probeExecMinVersion(ch clientsholder.Command, ctx clientsholder.Context, endpoint string, policy TLSPolicy) *TLSProbeResult {
+	flag := opensslVersionFlag(policy.MinTLSVersion)
+	cmd := fmt.Sprintf("echo | timeout 5 openssl s_client -connect %s %s 2>&1", endpoint, flag)
+	stdout, _, err := ch.ExecCommandContainer(ctx, cmd)
+
+	// openssl exits non-zero on handshake failure, but stdout still contains
+	// parseable output. Only treat as unreachable if both the error is set AND
+	// stdout has no recognizable openssl markers.
+	if err != nil && !hasOpensslOutput(stdout) {
+		return &TLSProbeResult{
+			Compliant: true,
+			IsTLS:     false,
+			Reachable: false,
+			Reason:    fmt.Sprintf("exec probe failed: %v (stdout=%s)", err, truncate(stdout, truncateLen)),
+		}
+	}
+
+	// Check for rejection BEFORE parsing Protocol lines — openssl prints the
+	// *attempted* version even when the handshake fails.
+	if opensslHandshakeRejected(stdout) {
+		r := classifyExecNoMinVersion(stdout, policy)
+		return &r
+	}
+
+	if opensslVersionNegotiated(stdout, policy.MinTLSVersion) {
+		return nil
+	}
+	// Server may negotiate higher than the minimum (e.g. TLS 1.3 when min is 1.2).
+	if policy.MinTLSVersion < tls.VersionTLS13 && opensslVersionNegotiated(stdout, tls.VersionTLS13) {
+		return nil
+	}
+
+	r := classifyExecNoMinVersion(stdout, policy)
+	return &r
+}
+
+// classifyExecNoMinVersion categorizes an openssl exec probe result when the server
+// did not negotiate the policy's minimum version successfully.
+//
+// This function distinguishes between:
+//   - Port unreachable (connection refused, no route)
+//   - TLS server that rejected our version (has TLS alert in output)
+//   - Non-TLS service (openssl connected but got no TLS response)
+//   - Unrecognizable output (openssl not installed, timeout, etc.)
+//
+// IMPORTANT: Do NOT use Protocol lines or "SSL handshake" as TLS indicators.
+// openssl always prints "Protocol  : TLSv1.2" (the *attempted* version) and
+// "SSL handshake has read N bytes" in its output regardless of whether the
+// server actually speaks TLS. The only reliable TLS indicator is the presence
+// of a TLS alert message (e.g. "alert protocol version", "handshake failure").
+func classifyExecNoMinVersion(stdout string, policy TLSPolicy) TLSProbeResult {
+	// Connection refused or unreachable
+	if strings.Contains(stdout, "connect:errno=") || strings.Contains(stdout, "Connection refused") {
+		return TLSProbeResult{
+			Compliant: true,
+			IsTLS:     false,
+			Reachable: false,
+			Reason:    "port unreachable via exec probe",
+		}
+	}
+
+	// TLS alert indicators are conclusive evidence of a genuine TLS server
+	// that rejected our protocol version. Plain HTTP/gRPC services never
+	// generate TLS alerts — they produce errors like "packet length too long"
+	// or "record layer failure" instead.
+	if strings.Contains(stdout, opensslAlertProtoVer) ||
+		strings.Contains(stdout, opensslAlertHandshake) ||
+		strings.Contains(stdout, opensslHandshakeFailure) {
+		return TLSProbeResult{
+			Compliant:     false,
+			IsTLS:         true,
+			Reachable:     true,
+			NegotiatedVer: fmt.Sprintf("< %s", TLSVersionString(policy.MinTLSVersion)),
+			Reason:        fmt.Sprintf("server does not support %s via exec probe", TLSVersionString(policy.MinTLSVersion)),
+		}
+	}
+
+	// If stdout is empty or doesn't contain any recognizable openssl output,
+	// this likely means openssl is not installed or the command failed to run.
+	if !hasOpensslOutput(stdout) {
+		return TLSProbeResult{
+			Compliant: true,
+			IsTLS:     false,
+			Reachable: false,
+			Reason:    fmt.Sprintf("exec probe produced no recognizable output (stdout=%s)", truncate(stdout, truncateLen)),
+		}
+	}
+
+	// Connected but no TLS alerts — non-TLS service (plain HTTP, gRPC, etc.)
+	// The output may contain "Cipher is (NONE)", "packet length too long",
+	// "record layer failure", "write:errno=", or "SSL handshake has read N bytes",
+	// but none of these indicate TLS — they're artifacts of openssl trying to
+	// parse non-TLS responses.
+	return TLSProbeResult{
+		Compliant: true,
+		IsTLS:     false,
+		Reachable: true,
+		Reason:    "non-TLS service (informational, via exec probe)",
+	}
+}
+
+// probeExecVersion runs openssl s_client at a specific TLS version and checks whether
+// the server accepted or rejected it. When expectAccept is true (above-minimum check),
+// rejection means non-compliant. When expectAccept is false (below-minimum check),
+// acceptance means non-compliant.
+func probeExecVersion(ch clientsholder.Command, ctx clientsholder.Context, endpoint string, ver uint16, expectAccept bool, policy TLSPolicy) TLSProbeResult {
+	flag := opensslVersionFlag(ver)
+	cmd := fmt.Sprintf("echo | timeout 5 openssl s_client -connect %s %s 2>&1", endpoint, flag)
+	stdout, _, _ := ch.ExecCommandContainer(ctx, cmd)
+
+	rejected := opensslHandshakeRejected(stdout)
+	accepted := !rejected && opensslVersionNegotiated(stdout, ver)
+
+	if expectAccept && rejected {
+		return TLSProbeResult{
+			Compliant:     false,
+			IsTLS:         true,
+			Reachable:     true,
+			NegotiatedVer: TLSVersionString(ver),
+			Reason:        fmt.Sprintf("server rejected %s but %s profile requires support for versions %s through TLS 1.3 (via exec probe)", TLSVersionString(ver), policy.ProfileType, TLSVersionString(policy.MinTLSVersion)),
+		}
+	}
+
+	if !expectAccept && accepted {
+		return TLSProbeResult{
+			Compliant:     false,
+			IsTLS:         true,
+			Reachable:     true,
+			NegotiatedVer: TLSVersionString(ver),
+			Reason:        fmt.Sprintf("server accepts %s (%s minimum required, via exec probe)", TLSVersionString(ver), TLSVersionString(policy.MinTLSVersion)),
+		}
+	}
+
+	return TLSProbeResult{
+		Compliant:     true,
+		IsTLS:         true,
+		Reachable:     true,
+		NegotiatedVer: TLSVersionString(ver),
+		Reason:        fmt.Sprintf("server correctly handles %s (via exec probe)", TLSVersionString(ver)),
+	}
+}
+
+// probeExecCipherCompliance verifies that the server does not accept cipher suites
+// outside the policy's allowed list. It works by building the set of disallowed
+// ciphers for the profile, then attempting a TLS 1.2 handshake offering ONLY those
+// disallowed ciphers. A compliant server will reject the handshake; a non-compliant
+// server will negotiate one of the disallowed ciphers.
+//
+// This check is skipped entirely when the policy minimum is TLS 1.3, because TLS 1.3
+// cipher suites are fixed by the protocol and not configurable.
+//
+// Returns nil if the server is compliant (rejected all disallowed ciphers),
+// or a non-compliant TLSProbeResult identifying the accepted cipher.
+func probeExecCipherCompliance(ch clientsholder.Command, ctx clientsholder.Context, endpoint string, policy TLSPolicy) *TLSProbeResult {
+	// TLS 1.3 ciphers are mandatory and not configurable — nothing to check.
+	if policy.MinTLSVersion > tls.VersionTLS12 {
+		return nil
+	}
+
+	// Build the list of cipher suites that the profile does NOT allow.
+	disallowedNames := computeDisallowedOpenSSLCiphers(policy)
+	if len(disallowedNames) == 0 {
+		return nil
+	}
+
+	// Attempt a TLS 1.2 handshake offering only the disallowed ciphers.
+	// If the server is compliant, it will reject the handshake because none
+	// of the offered ciphers are in its allowed set.
+	cipherStr := strings.Join(disallowedNames, ":")
+	cmd := fmt.Sprintf("echo | timeout 5 openssl s_client -connect %s -cipher %s %s 2>&1", endpoint, cipherStr, opensslFlagTLS12)
+	stdout, _, _ := ch.ExecCommandContainer(ctx, cmd)
+
+	// Server rejected the disallowed ciphers — this is the expected (compliant) outcome.
+	rejected := opensslHandshakeRejected(stdout) ||
+		strings.Contains(stdout, opensslNoCiphers) ||
+		strings.Contains(stdout, opensslAlertHandshake)
+
+	if rejected {
+		return nil
+	}
+
+	// Server negotiated a cipher from the disallowed set — non-compliant.
+	if strings.Contains(stdout, "Cipher    :") || strings.Contains(stdout, "Cipher:") {
+		cipherName := extractOpenSSLCipher(stdout)
+		result := TLSProbeResult{
+			Compliant:     false,
+			IsTLS:         true,
+			Reachable:     true,
+			NegotiatedVer: TLSVersionNameTLS12,
+			Reason:        fmt.Sprintf("server accepted disallowed cipher %s (not in %s profile, via exec probe)", cipherName, policy.ProfileType),
+		}
+		return &result
+	}
+
+	return nil
+}
+
+// computeDisallowedOpenSSLCiphers returns OpenSSL cipher names that are NOT in the policy's allowed list.
+func computeDisallowedOpenSSLCiphers(policy TLSPolicy) []string {
+	allowedSet := make(map[string]bool, len(policy.AllowedCipherNames))
+	for _, name := range policy.AllowedCipherNames {
+		allowedSet[name] = true
+	}
+
+	var disallowed []string
+	for name := range opensslToGoCipher {
+		if !allowedSet[name] {
+			disallowed = append(disallowed, name)
+		}
+	}
+	return disallowed
+}
+
+// extractOpenSSLCipher parses the "Cipher    :" or "Cipher:" line from openssl
+// s_client output and returns the negotiated cipher name.
+func extractOpenSSLCipher(stdout string) string {
+	for line := range strings.SplitSeq(stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(trimmed, "Cipher    :"); ok {
+			return strings.TrimSpace(after)
+		}
+		if after, ok := strings.CutPrefix(trimmed, "Cipher:"); ok {
+			return strings.TrimSpace(after)
+		}
+	}
+	return reasonUnknown
+}
+
+// opensslVersionFlag converts a Go TLS version constant to the corresponding
+// openssl s_client command-line flag (e.g. tls.VersionTLS12 -> "-tls1_2").
+func opensslVersionFlag(ver uint16) string {
+	switch ver {
+	case tls.VersionTLS10:
+		return opensslFlagTLS10
+	case tls.VersionTLS11:
+		return opensslFlagTLS11
+	case tls.VersionTLS12:
+		return opensslFlagTLS12
+	case tls.VersionTLS13:
+		return opensslFlagTLS13
+	default:
+		return opensslFlagTLS12
+	}
+}
+
+// opensslVersionName converts a Go TLS version constant to the protocol name
+// as it appears in openssl s_client output (e.g. tls.VersionTLS12 -> "TLSv1.2").
+func opensslVersionName(ver uint16) string {
+	switch ver {
+	case tls.VersionTLS10:
+		return opensslProtoNameTLS10
+	case tls.VersionTLS11:
+		return opensslProtoNameTLS11
+	case tls.VersionTLS12:
+		return opensslProtoNameTLS12
+	case tls.VersionTLS13:
+		return opensslProtoNameTLS13
+	default:
+		return opensslProtoNameTLS12
+	}
+}
+
+// probeServicePortViaExecPod probes a service port from inside a probe pod using
+// openssl s_client. It finds the first available probe pod and runs
+// ProbeServicePortViaExec through it. Returns nil if no probe pods are available.
+func probeServicePortViaExecPod(check *checksdb.Check, env *provider.TestEnvironment, address string, port int32, policy TLSPolicy) *TLSProbeResult {
+	for nodeName, probePod := range env.ProbePods {
+		if probePod == nil || len(probePod.Spec.Containers) == 0 {
+			continue
+		}
+		check.LogInfo("Using probe pod on node %q for exec probe to %s:%d", nodeName, address, port)
+		result := ProbeServicePortViaExec(
+			clientsholder.GetClientsHolder(),
+			clientsholder.NewContext(probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name),
+			address, port, policy,
+		)
+		return &result
+	}
+	return nil
+}
+
+// buildReportObject constructs a ReportObject from a TLS probe result, populating
+// it with the service metadata (namespace, name, port) and negotiated TLS version.
+func buildReportObject(svc *corev1.Service, port int32, result TLSProbeResult) *testhelper.ReportObject {
+	ro := testhelper.NewReportObject(result.Reason, testhelper.ServiceType, result.Compliant)
+	ro.AddField(testhelper.Namespace, svc.Namespace)
+	ro.AddField(testhelper.ServiceName, svc.Name)
+	ro.AddField(testhelper.PortNumber, strconv.Itoa(int(port)))
+	ro.AddField(testhelper.PortProtocol, "TCP")
+	if result.NegotiatedVer != "" {
+		ro.AddField(testhelper.TLSVersion, result.NegotiatedVer)
+	}
+	return ro
+}
+
+// TLSVersionString converts a Go TLS version constant to a human-readable string
+// (e.g. tls.VersionTLS12 -> "TLS 1.2").
+func TLSVersionString(ver uint16) string {
+	switch ver {
+	case tls.VersionTLS10:
+		return TLSVersionNameTLS10
+	case tls.VersionTLS11:
+		return TLSVersionNameTLS11
+	case tls.VersionTLS12:
+		return TLSVersionNameTLS12
+	case tls.VersionTLS13:
+		return TLSVersionNameTLS13
+	default:
+		return fmt.Sprintf("unknown (0x%04x)", ver)
+	}
+}
+
+// truncate returns the first n bytes of s, appending "..." if truncated.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/tests/networking/tlsversion/tlsversion_test.go
+++ b/tests/networking/tlsversion/tlsversion_test.go
@@ -1,0 +1,1326 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package tlsversion
+
+import (
+	"crypto/tls"
+	"fmt"
+	"strings"
+	"testing"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// modernPolicy is the Modern profile (TLS 1.3 only).
+func modernPolicy() TLSPolicy {
+	return ResolveTLSProfile(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType})
+}
+
+// intermediatePolicy is the Intermediate profile (TLS 1.2 minimum).
+func intermediatePolicy() TLSPolicy {
+	return ResolveTLSProfile(nil) // nil = Intermediate (default)
+}
+
+type mockPattern struct {
+	key    string
+	stdout string
+	stderr string
+	err    error
+}
+
+func newMockCommand(patterns ...mockPattern) *clientsholder.MockCommand {
+	return &clientsholder.MockCommand{
+		ExecFunc: func(_ clientsholder.Context, command string) (string, string, error) {
+			for _, p := range patterns {
+				if strings.Contains(command, p.key) {
+					return p.stdout, p.stderr, p.err
+				}
+			}
+			return "", "", fmt.Errorf("unexpected command: %s", command)
+		},
+	}
+}
+
+func TestProbeServicePortViaExec_TLS13Enforced_ModernProfile(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_3",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		},
+		mockPattern{key: "-tls1_2",
+			stdout: "CONNECTED(00000003)\n---\nssl handshake failure\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.0.0.1", 443, modernPolicy())
+	assert.True(t, result.Compliant, "expected compliant, got: %s", result.Reason)
+	assert.Equal(t, "TLS 1.3", result.NegotiatedVer)
+}
+
+func TestProbeServicePortViaExec_AcceptsTLS12_ModernProfile(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_3",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		},
+		mockPattern{key: "-tls1_2",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\nCipher    : ECDHE-RSA-AES128-GCM-SHA256\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.0.0.1", 443, modernPolicy())
+	assert.False(t, result.Compliant, "expected non-compliant with Modern profile")
+	assert.Equal(t, "TLS 1.2", result.NegotiatedVer)
+}
+
+func TestProbeServicePortViaExec_AcceptsTLS12_IntermediateProfile(t *testing.T) {
+	// "-cipher" must be checked before "-tls1_2" since the cipher check command also contains "-tls1_2"
+	mock := newMockCommand(
+		mockPattern{key: "-cipher",
+			stdout: "CONNECTED(00000003)\n---\nssl handshake failure\n---",
+		},
+		mockPattern{key: "-tls1_3",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		},
+		mockPattern{key: "-tls1_2",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\nCipher    : ECDHE-RSA-AES128-GCM-SHA256\n---",
+		},
+		mockPattern{key: "-tls1_1",
+			stdout: "CONNECTED(00000003)\n---\nssl handshake failure\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.0.0.1", 443, intermediatePolicy())
+	assert.True(t, result.Compliant, "expected compliant with Intermediate profile, got: %s", result.Reason)
+}
+
+func TestProbeServicePortViaExec_TLS13OnlyRejectsTLS12_ModernProfile(t *testing.T) {
+	// Reproduces real openssl output when a TLS 1.3-only server rejects TLS 1.2.
+	// openssl exits non-zero on handshake failure, so ExecCommandContainer returns an error.
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_3",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		},
+		mockPattern{key: "-tls1_2",
+			stdout: `Connecting to 10.217.4.83
+error:0A00042E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version:ssl/record/rec_layer_s3.c:916:SSL alert number 70
+CONNECTED(00000003)
+---
+no peer certificate available
+---
+No client certificate CA names sent
+---
+SSL handshake has read 7 bytes and written 191 bytes
+Verification: OK
+---
+New, (NONE), Cipher is (NONE)
+Protocol: TLSv1.2
+Secure Renegotiation IS NOT supported
+Compression: NONE
+Expansion: NONE
+No ALPN negotiated
+SSL-Session:
+    Protocol  : TLSv1.2
+    Cipher    : 0000
+    Session-ID:
+    Session-ID-ctx:
+    Master-Key:
+    PSK identity: None
+    PSK identity hint: None
+    SRP username: None
+    Start Time: 1770929565
+    Timeout   : 7200 (sec)
+    Verify return code: 0 (ok)
+    Extended master secret: no
+---`,
+			err: fmt.Errorf("command terminated with exit code 1"),
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.217.4.83", 443, modernPolicy())
+	assert.True(t, result.Compliant, "expected compliant (TLS 1.2 rejected), got: %s", result.Reason)
+	assert.Equal(t, "TLS 1.3", result.NegotiatedVer)
+}
+
+func TestProbeServicePortViaExec_TLS13OnlyRejectsTLS12_IntermediateProfile(t *testing.T) {
+	// Reproduces the CI smoke test failure: a TLS 1.3-only server is probed via exec
+	// with Intermediate profile (min TLS 1.2). The openssl output for TLS 1.2 contains
+	// "Protocol  : TLSv1.2" (the *attempted* version) but "Cipher is (NONE)" indicates
+	// the handshake was rejected. The test must detect this as non-compliant.
+	// openssl exits non-zero on handshake failure, so ExecCommandContainer returns an error.
+	mock := newMockCommand(
+		mockPattern{key: "-cipher",
+			stdout: "CONNECTED(00000003)\n---\nssl handshake failure\n---",
+			err:    fmt.Errorf("command terminated with exit code 1"),
+		},
+		mockPattern{key: "-tls1_2",
+			err: fmt.Errorf("command terminated with exit code 1"),
+			stdout: `Connecting to 10.217.4.83
+error:0A00042E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version:ssl/record/rec_layer_s3.c:916:SSL alert number 70
+CONNECTED(00000003)
+---
+no peer certificate available
+---
+No client certificate CA names sent
+---
+SSL handshake has read 7 bytes and written 191 bytes
+Verification: OK
+---
+New, (NONE), Cipher is (NONE)
+Protocol: TLSv1.2
+Secure Renegotiation IS NOT supported
+Compression: NONE
+Expansion: NONE
+No ALPN negotiated
+SSL-Session:
+    Protocol  : TLSv1.2
+    Cipher    : 0000
+    Session-ID:
+    Session-ID-ctx:
+    Master-Key:
+    PSK identity: None
+    PSK identity hint: None
+    SRP username: None
+    Start Time: 1770929565
+    Timeout   : 7200 (sec)
+    Verify return code: 0 (ok)
+    Extended master secret: no
+---`,
+		},
+		mockPattern{key: "-tls1_1",
+			stdout: "CONNECTED(00000003)\n---\nssl handshake failure\n---",
+			err:    fmt.Errorf("command terminated with exit code 1"),
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.217.4.83", 443, intermediatePolicy())
+	assert.False(t, result.Compliant, "expected non-compliant: TLS 1.3-only server does not support TLS 1.2 required by Intermediate")
+	assert.True(t, result.IsTLS, "expected IsTLS=true")
+}
+
+func TestProbeServicePortViaExec_ExecErrorWithOutput_IntermediateProfile(t *testing.T) {
+	// Reproduces the actual CI behavior: when openssl fails a handshake, it exits
+	// non-zero, and ExecCommandContainer returns a non-nil error. But stdout still
+	// contains the openssl output that we need to parse. The code must NOT bail out
+	// early on error; it must examine stdout to classify the result.
+	rejectedOutput := `Connecting to 10.217.4.83
+error:0A00042E:SSL routines:ssl3_read_bytes:tlsv1 alert protocol version:ssl/record/rec_layer_s3.c:916:SSL alert number 70
+CONNECTED(00000003)
+---
+no peer certificate available
+---
+No client certificate CA names sent
+---
+SSL handshake has read 7 bytes and written 191 bytes
+Verification: OK
+---
+New, (NONE), Cipher is (NONE)
+Protocol: TLSv1.2
+Secure Renegotiation IS NOT supported
+Compression: NONE
+Expansion: NONE
+No ALPN negotiated
+SSL-Session:
+    Protocol  : TLSv1.2
+    Cipher    : 0000
+    Session-ID:
+    Session-ID-ctx:
+    Master-Key:
+    PSK identity: None
+    PSK identity hint: None
+    SRP username: None
+    Start Time: 1770929565
+    Timeout   : 7200 (sec)
+    Verify return code: 0 (ok)
+    Extended master secret: no
+---`
+	mock := newMockCommand(
+		mockPattern{key: "-cipher",
+			stdout: "CONNECTED(00000003)\n---\nssl handshake failure\n---",
+			err:    fmt.Errorf("command terminated with exit code 1"),
+		},
+		mockPattern{key: "-tls1_2",
+			stdout: rejectedOutput,
+			err:    fmt.Errorf("command terminated with exit code 1"),
+		},
+		mockPattern{key: "-tls1_1",
+			stdout: "CONNECTED(00000003)\n---\nssl handshake failure\n---",
+			err:    fmt.Errorf("command terminated with exit code 1"),
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.217.4.83", 443, intermediatePolicy())
+	assert.False(t, result.Compliant, "expected non-compliant: TLS 1.3-only server does not support TLS 1.2 required by Intermediate")
+	assert.True(t, result.IsTLS, "expected IsTLS=true")
+}
+
+func TestProbeServicePortViaExec_ExecErrorNoOutput(t *testing.T) {
+	// When exec returns an error with no useful output (e.g., openssl not installed),
+	// the result should be unreachable.
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_2",
+			stdout: "",
+			err:    fmt.Errorf("command not found: openssl"),
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.0.0.1", 443, intermediatePolicy())
+	assert.True(t, result.Compliant, "expected compliant (unreachable), got: %s", result.Reason)
+	assert.False(t, result.Reachable, "expected Reachable=false")
+}
+
+func TestProbeServicePortViaExec_ConnectionRefused(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_2",
+			stdout: "connect:errno=111\nConnection refused",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.0.0.1", 443, intermediatePolicy())
+	assert.True(t, result.Compliant, "expected compliant (unreachable), got: %s", result.Reason)
+	assert.False(t, result.Reachable, "expected Reachable=false")
+}
+
+func TestProbeServicePortViaExec_NonTLS(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_2",
+			stdout: "CONNECTED(00000003)\nwrite:errno=104\n",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.0.0.1", 8080, intermediatePolicy())
+	assert.True(t, result.Compliant, "expected compliant (non-TLS informational), got: %s", result.Reason)
+	assert.False(t, result.IsTLS, "expected IsTLS=false for non-TLS service")
+}
+
+func TestProbeServicePortViaExec_NonTLS_RealisticOpenSSLOutput(t *testing.T) {
+	// Reproduces the CI failure where openssl connecting to a plain HTTP service
+	// (e.g. test-service-dualstack:8080) produces output containing
+	// "Cipher is (NONE)" and "Protocol  : TLSv1.2" even though the service is
+	// NOT TLS. The key insight is that openssl always reports the *attempted*
+	// protocol version and "SSL handshake has read N bytes" even for non-TLS
+	// connections. The only reliable TLS indicator is a TLS alert message
+	// (e.g. "alert protocol version"). Non-TLS services produce errors like
+	// "packet length too long" or "record layer failure" instead.
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_2",
+			stdout: `Connecting to 10.96.200.200
+A0EB58ABFFFF0000:error:0A0000C6:SSL routines:tls_get_more_records:packet length too long:ssl/record/methods/tls_common.c:662:
+A0EB58ABFFFF0000:error:0A000139:SSL routines::record layer failure:ssl/record/rec_layer_s3.c:696:
+CONNECTED(00000003)
+---
+no peer certificate available
+---
+No client certificate CA names sent
+---
+SSL handshake has read 5 bytes and written 198 bytes
+Verification: OK
+---
+New, (NONE), Cipher is (NONE)
+Protocol: TLSv1.2
+Secure Renegotiation IS NOT supported
+Compression: NONE
+Expansion: NONE
+No ALPN negotiated
+SSL-Session:
+    Protocol  : TLSv1.2
+    Cipher    : 0000
+    Session-ID:
+    Session-ID-ctx:
+    Master-Key:
+    PSK identity: None
+    PSK identity hint: None
+    SRP username: None
+    Start Time: 1770930000
+    Timeout   : 7200 (sec)
+    Verify return code: 0 (ok)
+    Extended master secret: no
+---`,
+			err: fmt.Errorf("command terminated with exit code 1"),
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.96.200.200", 8080, intermediatePolicy())
+	assert.True(t, result.Compliant, "expected compliant (non-TLS service), got: %s", result.Reason)
+	assert.False(t, result.IsTLS, "expected IsTLS=false for plain HTTP service")
+	assert.True(t, result.Reachable, "expected Reachable=true (connection established)")
+}
+
+func TestResolveTLSProfile_Nil(t *testing.T) {
+	policy := ResolveTLSProfile(nil)
+	assert.Equal(t, "Intermediate", policy.ProfileType)
+	assert.Equal(t, uint16(tls.VersionTLS12), policy.MinTLSVersion)
+	assert.NotEmpty(t, policy.AllowedCipherIDs, "expected non-empty allowed cipher list for Intermediate")
+}
+
+func TestResolveTLSProfile_Old(t *testing.T) {
+	policy := ResolveTLSProfile(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType})
+	assert.Equal(t, "Old", policy.ProfileType)
+	assert.Equal(t, uint16(tls.VersionTLS10), policy.MinTLSVersion)
+	// Old profile should have more allowed ciphers than Intermediate
+	intermediate := ResolveTLSProfile(nil)
+	assert.Greater(t, len(policy.AllowedCipherIDs), len(intermediate.AllowedCipherIDs),
+		"expected Old to have more ciphers than Intermediate")
+}
+
+func TestResolveTLSProfile_Modern(t *testing.T) {
+	policy := ResolveTLSProfile(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType})
+	assert.Equal(t, "Modern", policy.ProfileType)
+	assert.Equal(t, uint16(tls.VersionTLS13), policy.MinTLSVersion)
+	assert.Empty(t, policy.AllowedCipherIDs, "expected no TLS 1.2 allowed ciphers for Modern")
+}
+
+func TestResolveTLSProfile_Custom(t *testing.T) {
+	policy := ResolveTLSProfile(&configv1.TLSSecurityProfile{
+		Type: configv1.TLSProfileCustomType,
+		Custom: &configv1.CustomTLSProfile{
+			TLSProfileSpec: configv1.TLSProfileSpec{
+				MinTLSVersion: configv1.VersionTLS12,
+				Ciphers: []string{
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+				},
+			},
+		},
+	})
+	assert.Equal(t, "Custom", policy.ProfileType)
+	assert.Equal(t, uint16(tls.VersionTLS12), policy.MinTLSVersion)
+	assert.Len(t, policy.AllowedCipherIDs, 2)
+}
+
+func TestVersionBelow(t *testing.T) {
+	tests := []struct {
+		ver      uint16
+		expected uint16
+	}{
+		{tls.VersionTLS13, tls.VersionTLS12},
+		{tls.VersionTLS12, tls.VersionTLS11},
+		{tls.VersionTLS11, tls.VersionTLS10},
+		{tls.VersionTLS10, 0},
+	}
+
+	for _, tc := range tests {
+		assert.Equal(t, tc.expected, versionBelow(tc.ver), "versionBelow(0x%04x)", tc.ver)
+	}
+}
+
+func TestTLSVersionString(t *testing.T) {
+	tests := []struct {
+		ver      uint16
+		expected string
+	}{
+		{tls.VersionTLS10, "TLS 1.0"},
+		{tls.VersionTLS11, "TLS 1.1"},
+		{tls.VersionTLS12, "TLS 1.2"},
+		{tls.VersionTLS13, "TLS 1.3"},
+		{0x0000, "unknown (0x0000)"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.expected, func(t *testing.T) {
+			assert.Equal(t, tc.expected, TLSVersionString(tc.ver))
+		})
+	}
+}
+
+func TestOpensslVersionFlag(t *testing.T) {
+	tests := []struct {
+		ver      uint16
+		expected string
+	}{
+		{tls.VersionTLS10, "-tls1"},
+		{tls.VersionTLS11, "-tls1_1"},
+		{tls.VersionTLS12, "-tls1_2"},
+		{tls.VersionTLS13, "-tls1_3"},
+	}
+	for _, tc := range tests {
+		assert.Equal(t, tc.expected, opensslVersionFlag(tc.ver), "opensslVersionFlag(0x%04x)", tc.ver)
+	}
+}
+
+func TestDefaultTLSPolicy(t *testing.T) {
+	policy := DefaultTLSPolicy()
+	assert.Equal(t, "Intermediate", policy.ProfileType)
+	assert.Equal(t, uint16(tls.VersionTLS12), policy.MinTLSVersion)
+}
+
+func TestGetClusterTLSPolicy_NonOCP(t *testing.T) {
+	policy := GetClusterTLSPolicy(nil, false)
+	assert.Equal(t, "Intermediate", policy.ProfileType)
+	assert.Equal(t, uint16(tls.VersionTLS12), policy.MinTLSVersion)
+}
+
+func TestIsPortTLS_TLSServer(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.True(t, isTLS, "expected TLS, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS negotiated")
+}
+
+func TestIsPortTLS_PlaintextService(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nCipher is (NONE)\npacket length too long\n---",
+			err:    fmt.Errorf("exit status 1"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 8080)
+	assert.False(t, isTLS, "expected plaintext, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "plaintext")
+}
+
+func TestIsPortTLS_ConnectionRefused(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "connect:errno=111\nConnection refused",
+			err:    fmt.Errorf("exit status 1"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 9999)
+	assert.False(t, isTLS)
+	assert.False(t, reachable)
+	assert.Contains(t, reason, "unreachable")
+}
+
+func TestIsPortTLS_TLSHandshakeAlert(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nalert handshake failure\nCipher is (NONE)\n---",
+			err:    fmt.Errorf("exit status 1"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.True(t, isTLS, "TLS alert means genuine TLS server, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS server detected")
+}
+
+func TestIsPortTLS_ExecFailed(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "",
+			err:    fmt.Errorf("command not found"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, _ := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.False(t, isTLS)
+	assert.False(t, reachable)
+}
+
+func TestVersionsAbove(t *testing.T) {
+	tests := []struct {
+		name     string
+		minVer   uint16
+		expected []uint16
+	}{
+		{"TLS 1.0 returns 1.1, 1.2, 1.3", tls.VersionTLS10, []uint16{tls.VersionTLS11, tls.VersionTLS12, tls.VersionTLS13}},
+		{"TLS 1.1 returns 1.2, 1.3", tls.VersionTLS11, []uint16{tls.VersionTLS12, tls.VersionTLS13}},
+		{"TLS 1.2 returns 1.3", tls.VersionTLS12, []uint16{tls.VersionTLS13}},
+		{"TLS 1.3 returns empty", tls.VersionTLS13, nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := versionsAbove(tc.minVer)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestOpensslVersionNegotiated(t *testing.T) {
+	tests := []struct {
+		name     string
+		stdout   string
+		ver      uint16
+		expected bool
+	}{
+		{"TLS 1.2 with spaces", "Protocol  : TLSv1.2\nCipher    : AES", tls.VersionTLS12, true},
+		{"TLS 1.2 without spaces", "Protocol: TLSv1.2\nCipher: AES", tls.VersionTLS12, true},
+		{"TLS 1.3 negotiated", "Protocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384", tls.VersionTLS13, true},
+		{"wrong version", "Protocol  : TLSv1.2\nCipher    : AES", tls.VersionTLS13, false},
+		{"empty output", "", tls.VersionTLS12, false},
+		{"cipher none still matches protocol", "Cipher is (NONE)\nProtocol  : TLSv1.2", tls.VersionTLS12, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := opensslVersionNegotiated(tc.stdout, tc.ver)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestProbeServicePortViaExec_IntermediateRejectsTLS13Only(t *testing.T) {
+	// Server only supports TLS 1.2, rejects TLS 1.3. Intermediate profile requires
+	// both TLS 1.2 and TLS 1.3, so this should be non-compliant.
+	mock := newMockCommand(
+		mockPattern{key: "-cipher",
+			stdout: "CONNECTED(00000003)\n---\nssl handshake failure\n---",
+		},
+		mockPattern{key: "-tls1_3",
+			stdout: "CONNECTED(00000003)\n---\nalert protocol version\nCipher is (NONE)\n---",
+		},
+		mockPattern{key: "-tls1_2",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\nCipher    : ECDHE-RSA-AES128-GCM-SHA256\n---",
+		},
+		mockPattern{key: "-tls1_1",
+			stdout: "CONNECTED(00000003)\n---\nssl handshake failure\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.0.0.1", 443, intermediatePolicy())
+	assert.False(t, result.Compliant, "expected non-compliant: TLS 1.2-only server doesn't support TLS 1.3 required by Intermediate")
+	assert.True(t, result.IsTLS)
+	assert.Contains(t, result.Reason, "rejected TLS 1.3")
+}
+
+func TestProbeServicePortViaExec_OldProfileAllVersions(t *testing.T) {
+	// Old profile (min TLS 1.0) requires the server to accept all versions 1.0-1.3.
+	oldPolicy := ResolveTLSProfile(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType})
+	mock := newMockCommand(
+		mockPattern{key: "-cipher",
+			stdout: "CONNECTED(00000003)\n---\nssl handshake failure\n---",
+		},
+		mockPattern{key: "-tls1_3",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		},
+		mockPattern{key: "-tls1_2",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\nCipher    : ECDHE-RSA-AES128-GCM-SHA256\n---",
+		},
+		mockPattern{key: "-tls1_1",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.1\nCipher    : AES128-SHA\n---",
+		},
+		mockPattern{key: "-tls1 ",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1\nCipher    : AES128-SHA\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.0.0.1", 443, oldPolicy)
+	assert.True(t, result.Compliant, "expected compliant: server accepts all TLS versions, got: %s", result.Reason)
+}
+
+func TestProbeServicePortViaExec_OldProfileRejectsTLS11(t *testing.T) {
+	// Old profile server that rejects TLS 1.1 should be non-compliant.
+	oldPolicy := ResolveTLSProfile(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType})
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_1",
+			stdout: "CONNECTED(00000003)\n---\nalert protocol version\nCipher is (NONE)\n---",
+		},
+		mockPattern{key: "-tls1 ",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1\nCipher    : AES128-SHA\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := ProbeServicePortViaExec(mock, ctx, "10.0.0.1", 443, oldPolicy)
+	assert.False(t, result.Compliant, "expected non-compliant: server rejects TLS 1.1 under Old profile")
+	assert.Contains(t, result.Reason, "rejected TLS 1.1")
+}
+
+func TestProbeExecVersion_BelowMinimum_ServerRejects(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_1",
+			stdout: "CONNECTED(00000003)\n---\nalert protocol version\nCipher is (NONE)\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := probeExecVersion(mock, ctx, "10.0.0.1:443", tls.VersionTLS11, false, intermediatePolicy())
+	assert.True(t, result.Compliant, "expected compliant: server correctly rejected below-minimum version")
+}
+
+func TestProbeExecVersion_BelowMinimum_ServerAccepts(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_1",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.1\nCipher    : AES128-SHA\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := probeExecVersion(mock, ctx, "10.0.0.1:443", tls.VersionTLS11, false, intermediatePolicy())
+	assert.False(t, result.Compliant, "expected non-compliant: server accepted below-minimum TLS 1.1")
+	assert.Contains(t, result.Reason, "accepts TLS 1.1")
+}
+
+func TestProbeExecVersion_AboveMinimum_ServerAccepts(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_3",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := probeExecVersion(mock, ctx, "10.0.0.1:443", tls.VersionTLS13, true, intermediatePolicy())
+	assert.True(t, result.Compliant, "expected compliant: server accepts TLS 1.3")
+}
+
+func TestProbeExecVersion_AboveMinimum_ServerRejects(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_3",
+			stdout: "CONNECTED(00000003)\n---\nalert protocol version\nCipher is (NONE)\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := probeExecVersion(mock, ctx, "10.0.0.1:443", tls.VersionTLS13, true, intermediatePolicy())
+	assert.False(t, result.Compliant, "expected non-compliant: server rejected TLS 1.3 required by profile")
+	assert.Contains(t, result.Reason, "rejected TLS 1.3")
+}
+
+func TestClassifyExecNoMinVersion(t *testing.T) {
+	policy := intermediatePolicy()
+
+	tests := []struct {
+		name            string
+		stdout          string
+		expectCompliant bool
+		expectIsTLS     bool
+		expectReachable bool
+		expectReason    string
+	}{
+		{
+			name:            "connection refused",
+			stdout:          "connect:errno=111\nConnection refused",
+			expectCompliant: true,
+			expectIsTLS:     false,
+			expectReachable: false,
+			expectReason:    "port unreachable",
+		},
+		{
+			name:            "errno only",
+			stdout:          "connect:errno=113",
+			expectCompliant: true,
+			expectIsTLS:     false,
+			expectReachable: false,
+			expectReason:    "port unreachable",
+		},
+		{
+			name:            "TLS alert protocol version",
+			stdout:          "CONNECTED(00000003)\nalert protocol version\nCipher is (NONE)",
+			expectCompliant: false,
+			expectIsTLS:     true,
+			expectReachable: true,
+			expectReason:    "does not support TLS 1.2",
+		},
+		{
+			name:            "TLS alert handshake failure",
+			stdout:          "CONNECTED(00000003)\nalert handshake failure\nCipher is (NONE)",
+			expectCompliant: false,
+			expectIsTLS:     true,
+			expectReachable: true,
+			expectReason:    "does not support TLS 1.2",
+		},
+		{
+			name:            "TLS handshake failure",
+			stdout:          "CONNECTED(00000003)\nhandshake failure",
+			expectCompliant: false,
+			expectIsTLS:     true,
+			expectReachable: true,
+			expectReason:    "does not support TLS 1.2",
+		},
+		{
+			name:            "no recognizable output",
+			stdout:          "",
+			expectCompliant: true,
+			expectIsTLS:     false,
+			expectReachable: false,
+			expectReason:    "no recognizable output",
+		},
+		{
+			name:            "garbage output",
+			stdout:          "some random text with no openssl markers",
+			expectCompliant: true,
+			expectIsTLS:     false,
+			expectReachable: false,
+			expectReason:    "no recognizable output",
+		},
+		{
+			name:            "non-TLS service with CONNECTED",
+			stdout:          "CONNECTED(00000003)\nwrite:errno=104\nCipher is (NONE)",
+			expectCompliant: true,
+			expectIsTLS:     false,
+			expectReachable: true,
+			expectReason:    "non-TLS service",
+		},
+		{
+			name:            "non-TLS service with packet length error",
+			stdout:          "CONNECTED(00000003)\npacket length too long\nCipher is (NONE)\nProtocol  : TLSv1.2",
+			expectCompliant: true,
+			expectIsTLS:     false,
+			expectReachable: true,
+			expectReason:    "non-TLS service",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := classifyExecNoMinVersion(tc.stdout, policy)
+			assert.Equal(t, tc.expectCompliant, result.Compliant, "Compliant mismatch")
+			assert.Equal(t, tc.expectIsTLS, result.IsTLS, "IsTLS mismatch")
+			assert.Equal(t, tc.expectReachable, result.Reachable, "Reachable mismatch")
+			assert.Contains(t, result.Reason, tc.expectReason, "Reason mismatch")
+		})
+	}
+}
+
+func TestComputeDisallowedOpenSSLCiphers(t *testing.T) {
+	// Helper: build a set from a slice for easier membership checks.
+	toSet := func(s []string) map[string]bool {
+		m := make(map[string]bool, len(s))
+		for _, v := range s {
+			m[v] = true
+		}
+		return m
+	}
+
+	t.Run("Old profile has no disallowed ciphers", func(t *testing.T) {
+		policy := ResolveTLSProfile(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType})
+		disallowed := computeDisallowedOpenSSLCiphers(policy)
+		assert.Empty(t, disallowed, "Old profile allows all ciphers in opensslToGoCipher")
+	})
+
+	t.Run("Modern profile disallows all TLS 1.2 ciphers", func(t *testing.T) {
+		policy := ResolveTLSProfile(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileModernType})
+		disallowed := computeDisallowedOpenSSLCiphers(policy)
+		assert.Equal(t, len(opensslToGoCipher), len(disallowed),
+			"Modern profile should disallow every cipher in opensslToGoCipher")
+	})
+
+	t.Run("Intermediate profile disallows some ciphers", func(t *testing.T) {
+		policy := intermediatePolicy()
+		disallowed := computeDisallowedOpenSSLCiphers(policy)
+		disallowedSet := toSet(disallowed)
+
+		assert.NotEmpty(t, disallowed)
+		assert.Less(t, len(disallowed), len(opensslToGoCipher),
+			"Intermediate should disallow fewer ciphers than the full set")
+
+		// Intermediate allows ECDHE-RSA-AES128-GCM-SHA256 — it must NOT be disallowed.
+		assert.False(t, disallowedSet["ECDHE-RSA-AES128-GCM-SHA256"],
+			"ECDHE-RSA-AES128-GCM-SHA256 is allowed by Intermediate and should not be disallowed")
+
+		// Intermediate does not allow DES-CBC3-SHA — it must be disallowed.
+		assert.True(t, disallowedSet["DES-CBC3-SHA"],
+			"DES-CBC3-SHA is not in the Intermediate profile and should be disallowed")
+	})
+
+	t.Run("disallowed and allowed are disjoint and cover all ciphers", func(t *testing.T) {
+		policy := intermediatePolicy()
+		disallowed := computeDisallowedOpenSSLCiphers(policy)
+		disallowedSet := toSet(disallowed)
+
+		allowedSet := make(map[string]bool)
+		for _, name := range policy.AllowedCipherNames {
+			if _, hasGoMapping := opensslToGoCipher[name]; hasGoMapping {
+				allowedSet[name] = true
+			}
+		}
+
+		for name := range opensslToGoCipher {
+			inAllowed := allowedSet[name]
+			inDisallowed := disallowedSet[name]
+			assert.NotEqual(t, inAllowed, inDisallowed,
+				"cipher %s must be in exactly one of allowed or disallowed (allowed=%v, disallowed=%v)",
+				name, inAllowed, inDisallowed)
+		}
+	})
+}
+
+func TestOpensslHandshakeRejected(t *testing.T) {
+	tests := []struct {
+		name     string
+		output   string
+		expected bool
+	}{
+		{"cipher none", "CONNECTED(00000003)\nCipher is (NONE)\nProtocol  : TLSv1.2", true},
+		{"alert protocol version", "CONNECTED(00000003)\nalert protocol version", true},
+		{"handshake failure", "CONNECTED(00000003)\nhandshake failure", true},
+		{"successful handshake", "CONNECTED(00000003)\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384", false},
+		{"empty output", "", false},
+		{"unrelated error", "CONNECTED(00000003)\npacket length too long", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, opensslHandshakeRejected(tc.output))
+		})
+	}
+}
+
+func TestOcpVersionToGoVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    configv1.TLSProtocolVersion
+		expected uint16
+	}{
+		{"TLS 1.0", configv1.VersionTLS10, tls.VersionTLS10},
+		{"TLS 1.1", configv1.VersionTLS11, tls.VersionTLS11},
+		{"TLS 1.2", configv1.VersionTLS12, tls.VersionTLS12},
+		{"TLS 1.3", configv1.VersionTLS13, tls.VersionTLS13},
+		{"empty string defaults to TLS 1.2", "", tls.VersionTLS12},
+		{"unknown defaults to TLS 1.2", "VersionTLS99", tls.VersionTLS12},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, ocpVersionToGoVersion(tc.input))
+		})
+	}
+}
+
+func TestOpensslVersionFlag_Default(t *testing.T) {
+	assert.Equal(t, opensslFlagTLS12, opensslVersionFlag(0x0000))
+}
+
+func TestOpensslVersionName(t *testing.T) {
+	tests := []struct {
+		ver      uint16
+		expected string
+	}{
+		{tls.VersionTLS10, opensslProtoNameTLS10},
+		{tls.VersionTLS11, opensslProtoNameTLS11},
+		{tls.VersionTLS12, opensslProtoNameTLS12},
+		{tls.VersionTLS13, opensslProtoNameTLS13},
+		{0x0000, opensslProtoNameTLS12},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.expected, func(t *testing.T) {
+			assert.Equal(t, tc.expected, opensslVersionName(tc.ver))
+		})
+	}
+}
+
+func TestExtractOpenSSLCipher(t *testing.T) {
+	tests := []struct {
+		name     string
+		stdout   string
+		expected string
+	}{
+		{"with spaces", "Cipher    : ECDHE-RSA-AES128-GCM-SHA256\nProtocol  : TLSv1.2", "ECDHE-RSA-AES128-GCM-SHA256"},
+		{"without spaces", "Cipher: TLS_AES_256_GCM_SHA384\nProtocol: TLSv1.3", "TLS_AES_256_GCM_SHA384"},
+		{"cipher 0000", "Cipher    : 0000\nProtocol  : TLSv1.2", "0000"},
+		{"no cipher line", "Protocol  : TLSv1.2\nSome other output", "unknown"},
+		{"empty output", "", "unknown"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractOpenSSLCipher(tc.stdout))
+		})
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "short", truncate("short", 200))
+	assert.Equal(t, "abc...", truncate("abcdef", 3))
+	assert.Equal(t, "", truncate("", 10))
+	assert.Equal(t, "exact", truncate("exact", 5))
+}
+
+func TestBuildReportObject(t *testing.T) {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-service",
+			Namespace: "test-ns",
+		},
+	}
+
+	t.Run("compliant with TLS version", func(t *testing.T) {
+		result := TLSProbeResult{
+			Compliant:     true,
+			NegotiatedVer: "TLS 1.3",
+			Reason:        "server honors profile",
+		}
+		ro := buildReportObject(svc, 443, result)
+		assert.Equal(t, testhelper.ServiceType, ro.ObjectType)
+		assertReportField(t, ro, testhelper.Namespace, "test-ns")
+		assertReportField(t, ro, testhelper.ServiceName, "my-service")
+		assertReportField(t, ro, testhelper.PortNumber, "443")
+		assertReportField(t, ro, testhelper.PortProtocol, "TCP")
+		assertReportField(t, ro, testhelper.TLSVersion, "TLS 1.3")
+	})
+
+	t.Run("non-compliant without TLS version", func(t *testing.T) {
+		result := TLSProbeResult{
+			Compliant: false,
+			Reason:    "server rejected TLS 1.2",
+		}
+		ro := buildReportObject(svc, 8080, result)
+		assert.Equal(t, testhelper.ServiceType, ro.ObjectType)
+		assertReportField(t, ro, testhelper.PortNumber, "8080")
+		// NegotiatedVer is empty, so TLSVersion field should not be present.
+		for _, key := range ro.ObjectFieldsKeys {
+			assert.NotEqual(t, testhelper.TLSVersion, key, "TLSVersion should not be set when NegotiatedVer is empty")
+		}
+	})
+}
+
+func assertReportField(t *testing.T, ro *testhelper.ReportObject, key, expectedValue string) {
+	t.Helper()
+	for i, k := range ro.ObjectFieldsKeys {
+		if k == key {
+			assert.Equal(t, expectedValue, ro.ObjectFieldsValues[i], "field %s", key)
+			return
+		}
+	}
+	t.Errorf("field %q not found in report object", key)
+}
+
+func TestProbeExecCipherCompliance_ServerAcceptsDisallowed(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-cipher",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\nCipher    : DES-CBC3-SHA\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := probeExecCipherCompliance(mock, ctx, "10.0.0.1:443", intermediatePolicy())
+	assert.NotNil(t, result, "expected non-nil result for accepted disallowed cipher")
+	assert.False(t, result.Compliant)
+	assert.Contains(t, result.Reason, "disallowed cipher")
+}
+
+func TestProbeExecCipherCompliance_TLS13SkipsCipherCheck(t *testing.T) {
+	mock := newMockCommand()
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := probeExecCipherCompliance(mock, ctx, "10.0.0.1:443", modernPolicy())
+	assert.Nil(t, result, "Modern profile (TLS 1.3) should skip cipher check")
+}
+
+func TestProbeExecCipherCompliance_ServerRejectsDisallowed(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-cipher",
+			stdout: "CONNECTED(00000003)\n---\nhandshake failure\nCipher is (NONE)\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := probeExecCipherCompliance(mock, ctx, "10.0.0.1:443", intermediatePolicy())
+	assert.Nil(t, result, "expected nil (compliant) when server rejects disallowed ciphers")
+}
+
+func TestProbeExecMinVersion_ServerNegotiatesTLS13WhenMinIs12(t *testing.T) {
+	// Server negotiates TLS 1.3 when we ask for TLS 1.2 minimum — this is fine.
+	mock := newMockCommand(
+		mockPattern{key: "-tls1_2",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		},
+	)
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := probeExecMinVersion(mock, ctx, "10.0.0.1:443", intermediatePolicy())
+	assert.Nil(t, result, "expected nil (success) when server negotiates TLS 1.3 for Intermediate profile")
+}
+
+func TestResolveTLSProfile_UnknownType(t *testing.T) {
+	policy := ResolveTLSProfile(&configv1.TLSSecurityProfile{Type: "SomethingElse"})
+	assert.Equal(t, "Intermediate", policy.ProfileType)
+	assert.Equal(t, uint16(tls.VersionTLS12), policy.MinTLSVersion)
+}
+
+func TestResolveTLSProfile_CustomNilSpec(t *testing.T) {
+	policy := ResolveTLSProfile(&configv1.TLSSecurityProfile{
+		Type:   configv1.TLSProfileCustomType,
+		Custom: nil,
+	})
+	assert.Equal(t, "Intermediate", policy.ProfileType)
+}
+
+func TestHasOpensslOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		stdout   string
+		expected bool
+	}{
+		{"CONNECTED marker", "CONNECTED(00000003)\n---", true},
+		{"errno marker", "connect:errno=111", true},
+		{"SSL keyword", "SSL routines:ssl3_read_bytes", true},
+		{"Cipher keyword", "Cipher    : AES256", true},
+		{"empty output", "", false},
+		{"random text", "some random output", false},
+		{"partial match SSL in word", "SSLv3 not available", true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tc.expected, hasOpensslOutput(tc.stdout))
+		})
+	}
+}
+
+func TestResolveTLSProfile_AllowedCipherNamesPopulated(t *testing.T) {
+	policy := intermediatePolicy()
+	assert.NotEmpty(t, policy.AllowedCipherNames)
+	assert.NotEmpty(t, policy.AllowedCipherIDs)
+	// AllowedCipherNames may be larger than AllowedCipherIDs because
+	// some OpenSSL cipher names lack Go crypto/tls mappings.
+	assert.GreaterOrEqual(t, len(policy.AllowedCipherNames), len(policy.AllowedCipherIDs))
+}
+
+func TestComputeDisallowedOpenSSLCiphers_OldProfileAllowsAll(t *testing.T) {
+	oldPolicy := ResolveTLSProfile(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType})
+	disallowed := computeDisallowedOpenSSLCiphers(oldPolicy)
+	assert.Empty(t, disallowed, "Old profile allows all known ciphers; disallowed should be empty")
+}
+
+func stubProbe(result *TLSProbeResult) func(*checksdb.Check, *provider.TestEnvironment, string, int32, TLSPolicy) *TLSProbeResult {
+	return func(_ *checksdb.Check, _ *provider.TestEnvironment, _ string, _ int32, _ TLSPolicy) *TLSProbeResult {
+		return result
+	}
+}
+
+func TestCheckServiceTLSCompliance_HeadlessServiceSkipped(t *testing.T) {
+	original := probeFunc
+	defer func() { probeFunc = original }()
+	probeFunc = stubProbe(nil)
+
+	env := &provider.TestEnvironment{
+		Services: []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "headless", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "None",
+					Ports:     []corev1.ServicePort{{Port: 443, Protocol: corev1.ProtocolTCP}},
+				},
+			},
+		},
+	}
+	check := &checksdb.Check{}
+	compliant, nonCompliant := CheckServiceTLSCompliance(check, env, intermediatePolicy())
+	assert.Empty(t, compliant)
+	assert.Empty(t, nonCompliant)
+}
+
+func TestCheckServiceTLSCompliance_EmptyClusterIPSkipped(t *testing.T) {
+	original := probeFunc
+	defer func() { probeFunc = original }()
+	probeFunc = stubProbe(nil)
+
+	env := &provider.TestEnvironment{
+		Services: []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "no-ip", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "",
+					Ports:     []corev1.ServicePort{{Port: 443, Protocol: corev1.ProtocolTCP}},
+				},
+			},
+		},
+	}
+	check := &checksdb.Check{}
+	compliant, nonCompliant := CheckServiceTLSCompliance(check, env, intermediatePolicy())
+	assert.Empty(t, compliant)
+	assert.Empty(t, nonCompliant)
+}
+
+func TestCheckServiceTLSCompliance_NonTCPPortSkipped(t *testing.T) {
+	original := probeFunc
+	defer func() { probeFunc = original }()
+	probeFunc = stubProbe(nil)
+
+	env := &provider.TestEnvironment{
+		Services: []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "udp-svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports:     []corev1.ServicePort{{Port: 53, Protocol: corev1.ProtocolUDP}},
+				},
+			},
+		},
+	}
+	check := &checksdb.Check{}
+	compliant, nonCompliant := CheckServiceTLSCompliance(check, env, intermediatePolicy())
+	assert.Empty(t, compliant)
+	assert.Empty(t, nonCompliant)
+}
+
+func TestCheckServiceTLSCompliance_NoProbePods(t *testing.T) {
+	original := probeFunc
+	defer func() { probeFunc = original }()
+	probeFunc = stubProbe(nil)
+
+	env := &provider.TestEnvironment{
+		Services: []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports:     []corev1.ServicePort{{Port: 443, Protocol: corev1.ProtocolTCP}},
+				},
+			},
+		},
+	}
+	check := &checksdb.Check{}
+	compliant, nonCompliant := CheckServiceTLSCompliance(check, env, intermediatePolicy())
+	assert.Len(t, compliant, 1)
+	assert.Empty(t, nonCompliant)
+	assertReportField(t, compliant[0], testhelper.ServiceName, "my-svc")
+}
+
+func TestCheckServiceTLSCompliance_Unreachable(t *testing.T) {
+	original := probeFunc
+	defer func() { probeFunc = original }()
+	probeFunc = stubProbe(&TLSProbeResult{
+		Compliant: false,
+		IsTLS:     false,
+		Reachable: false,
+		Reason:    "connection refused",
+	})
+
+	env := &provider.TestEnvironment{
+		Services: []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "unreachable", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports:     []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}},
+				},
+			},
+		},
+	}
+	check := &checksdb.Check{}
+	compliant, nonCompliant := CheckServiceTLSCompliance(check, env, intermediatePolicy())
+	assert.Len(t, compliant, 1, "unreachable port should be treated as compliant")
+	assert.Empty(t, nonCompliant)
+}
+
+func TestCheckServiceTLSCompliance_Compliant(t *testing.T) {
+	original := probeFunc
+	defer func() { probeFunc = original }()
+	probeFunc = stubProbe(&TLSProbeResult{
+		Compliant:     true,
+		IsTLS:         true,
+		Reachable:     true,
+		NegotiatedVer: "TLSv1.3",
+		Reason:        "TLS 1.3 negotiated",
+	})
+
+	env := &provider.TestEnvironment{
+		Services: []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "secure-svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.1",
+					Ports:     []corev1.ServicePort{{Port: 443, Protocol: corev1.ProtocolTCP}},
+				},
+			},
+		},
+	}
+	check := &checksdb.Check{}
+	compliant, nonCompliant := CheckServiceTLSCompliance(check, env, intermediatePolicy())
+	assert.Len(t, compliant, 1)
+	assert.Empty(t, nonCompliant)
+	assertReportField(t, compliant[0], testhelper.ServiceName, "secure-svc")
+}
+
+func TestCheckServiceTLSCompliance_NonCompliant(t *testing.T) {
+	original := probeFunc
+	defer func() { probeFunc = original }()
+	probeFunc = stubProbe(&TLSProbeResult{
+		Compliant:     false,
+		IsTLS:         true,
+		Reachable:     true,
+		NegotiatedVer: "TLSv1",
+		Reason:        "server accepts TLS 1.0, below minimum TLS 1.2",
+	})
+
+	env := &provider.TestEnvironment{
+		Services: []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "insecure-svc", Namespace: "ns"},
+				Spec: corev1.ServiceSpec{
+					ClusterIP: "10.0.0.2",
+					Ports:     []corev1.ServicePort{{Port: 8443, Protocol: corev1.ProtocolTCP}},
+				},
+			},
+		},
+	}
+	check := &checksdb.Check{}
+	compliant, nonCompliant := CheckServiceTLSCompliance(check, env, intermediatePolicy())
+	assert.Empty(t, compliant)
+	assert.Len(t, nonCompliant, 1)
+	assertReportField(t, nonCompliant[0], testhelper.ServiceName, "insecure-svc")
+}
+
+func TestCheckServiceTLSCompliance_MixedServices(t *testing.T) {
+	original := probeFunc
+	defer func() { probeFunc = original }()
+
+	callCount := 0
+	probeFunc = func(_ *checksdb.Check, _ *provider.TestEnvironment, _ string, port int32, _ TLSPolicy) *TLSProbeResult {
+		callCount++
+		if port == 443 {
+			return &TLSProbeResult{Compliant: true, IsTLS: true, Reachable: true, Reason: "OK"}
+		}
+		return &TLSProbeResult{Compliant: false, IsTLS: true, Reachable: true, Reason: "bad TLS"}
+	}
+
+	env := &provider.TestEnvironment{
+		Services: []*corev1.Service{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "headless", Namespace: "ns"},
+				Spec:       corev1.ServiceSpec{ClusterIP: "None", Ports: []corev1.ServicePort{{Port: 443, Protocol: corev1.ProtocolTCP}}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "good-svc", Namespace: "ns"},
+				Spec:       corev1.ServiceSpec{ClusterIP: "10.0.0.1", Ports: []corev1.ServicePort{{Port: 443, Protocol: corev1.ProtocolTCP}}},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "bad-svc", Namespace: "ns"},
+				Spec:       corev1.ServiceSpec{ClusterIP: "10.0.0.2", Ports: []corev1.ServicePort{{Port: 8080, Protocol: corev1.ProtocolTCP}}},
+			},
+		},
+	}
+	check := &checksdb.Check{}
+	compliant, nonCompliant := CheckServiceTLSCompliance(check, env, intermediatePolicy())
+	assert.Len(t, compliant, 1)
+	assert.Len(t, nonCompliant, 1)
+	assert.Equal(t, 2, callCount, "headless service should not trigger a probe")
+}


### PR DESCRIPTION
## Summary
- Add `networking-tls-minimum-version` check that probes service ClusterIPs via openssl against the cluster TLS security profile
- Read APIServer CR on OCP 4.22 and later; fall back to Intermediate on non-OCP; skip below 4.22
- Add `IsPortTLS` helper (used by #3614) and `GetOCPVersionBelowSkipFn`
- Add CI scenarios: tls13-only and tls12-only fail Intermediate; tls12-allowed and plain-http pass
- Classify as Optional across Extended, Telco, Non-Telco, and Far-Edge

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [redhat-best-practices-for-k8s/certsuite#3614](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3614) | feat: add unsecured container ports TLS detection test | Open |
| [redhat-best-practices-for-k8s/certsuite-probe#84](https://github.com/redhat-best-practices-for-k8s/certsuite-probe/pull/84) | Add testssl.sh v3.2.3 to probe image | Merged |

## Upstream References
- [OpenShift 4.22 release notes](https://docs.openshift.com/container-platform/4.22/release_notes/)

## Test Plan
- [ ] CI passes
- [ ] Unit tests cover the four-step openssl probe (below-min, min version, above-min, cipher)
- [ ] CI scenarios: tls13-only fail, tls12-only fail, tls12-allowed pass, plain-http pass
- [ ] QE smoke tests pass in CI
