### PR TITLE
Update quick-ocp action to v0.0.25

### DIFF
--- a/.github/workflows/qe-ocp-418-intrusive.yaml
+++ b/.github/workflows/qe-ocp-418-intrusive.yaml
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.24
+        uses: palmsoftware/quick-ocp@v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-418.yaml
+++ b/.github/workflows/qe-ocp-418.yaml
@@ -104,7 +104,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.24
+        uses: palmsoftware/quick-ocp@v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-419-intrusive.yaml
+++ b/.github/workflows/qe-ocp-419-intrusive.yaml
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.24
+        uses: palmsoftware/quick-ocp@v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-419.yaml
+++ b/.github/workflows/qe-ocp-419.yaml
@@ -104,7 +104,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.24
+        uses: palmsoftware/quick-ocp@v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-420-intrusive.yaml
+++ b/.github/workflows/qe-ocp-420-intrusive.yaml
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.24
+        uses: palmsoftware/quick-ocp@v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-420.yaml
+++ b/.github/workflows/qe-ocp-420.yaml
@@ -104,7 +104,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.24
+        uses: palmsoftware/quick-ocp@v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true


### PR DESCRIPTION
## Summary
- Bump `palmsoftware/quick-ocp` from v0.0.24 to v0.0.25 across all OCP QE workflow files (4.18, 4.19, 4.20 — both standard and intrusive)
- Release: https://github.com/palmsoftware/quick-ocp/releases/tag/v0.0.25

## Test plan
- [ ] Verify OCP 4.18 workflows use quick-ocp v0.0.25
- [ ] Verify OCP 4.19 workflows use quick-ocp v0.0.25
- [ ] Verify OCP 4.20 workflows use quick-ocp v0.0.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)