### PR TITLE
feat: add zone-aware PDB validation for platform upgrade resilience

### DIFF
--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -1665,7 +1665,8 @@ that Node's kernel may not have the same hacks.'`,
 	TestPodDisruptionBudgetIdentifier = AddCatalogEntry(
 		"pod-disruption-budget",
 		common.ObservabilityTestKey,
-		`Checks to see if pod disruption budgets have allowed values for minAvailable and maxUnavailable`,
+		`Checks to see if pod disruption budgets have allowed values for minAvailable and maxUnavailable, `+
+			`and verifies that PDBs are zone-aware (can tolerate an entire zone going offline during platform upgrades)`,
 		PodDisruptionBudgetRemediation,
 		NoExceptions,
 		TestPodDisruptionBudgetIdentifierDocLink,

--- a/tests/identifiers/impact.go
+++ b/tests/identifiers/impact.go
@@ -135,7 +135,7 @@ const (
 	TestLoggingIdentifierImpact                            = `Improper logging configuration prevents log aggregation and monitoring, making troubleshooting and debugging difficult.`
 	TestTerminationMessagePolicyIdentifierImpact           = `Incorrect termination message policies can prevent proper error reporting and make failure diagnosis difficult.`
 	TestCrdsStatusSubresourceIdentifierImpact              = `Missing status subresources prevent proper monitoring and automation based on custom resource states.`
-	TestPodDisruptionBudgetIdentifierImpact                = `Improper disruption budgets can prevent necessary maintenance operations or allow too many pods to be disrupted simultaneously.`
+	TestPodDisruptionBudgetIdentifierImpact                = `Improper disruption budgets can prevent necessary maintenance operations or allow too many pods to be disrupted simultaneously. Non-zone-aware PDBs can block platform upgrades when all workers in a zone need to be drained.`
 	TestAPICompatibilityWithNextOCPReleaseIdentifierImpact = `Deprecated API usage can cause applications to break during OpenShift upgrades, requiring emergency fixes.`
 
 	// Manageability Test Suite Impact Statements

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -163,7 +163,9 @@ const (
 
 	NamespaceResourceQuotaRemediation = `Apply a ResourceQuota to the namespace your workload is running in. The workload's namespace should have resource quota defined.`
 
-	PodDisruptionBudgetRemediation = `Ensure minAvailable is not zero and maxUnavailable does not equal the number of pods in the replica`
+	PodDisruptionBudgetRemediation = `Ensure minAvailable is not zero and maxUnavailable does not equal the number of pods in the replica. ` +
+		`For multi-zone clusters, also ensure the PDB is zone-aware: set maxUnavailable >= ceil(replicas/zones) ` +
+		`or minAvailable <= replicas - ceil(replicas/zones) to allow draining all pods in one zone during platform upgrades.`
 
 	APICompatibilityWithNextOCPReleaseRemediation = `Ensure the APIs the workload uses are compatible with the next OCP version`
 

--- a/tests/observability/pdb/pdb.go
+++ b/tests/observability/pdb/pdb.go
@@ -12,6 +12,18 @@ const (
 	percentageDivisor = 100
 )
 
+// ZoneAwareCheckResult contains the result of a zone-aware PDB validation
+type ZoneAwareCheckResult struct {
+	IsValid             bool
+	BasicCheckError     error
+	ZoneCheckError      error
+	MaxReplicasPerZone  int
+	NumZones            int
+	Replicas            int
+	MinAvailableValue   int
+	MaxUnavailableValue int
+}
+
 // percentageToFloat converts a percentage string to a float
 func percentageToFloat(percentage string) (float64, error) {
 	var percentageFloat float64
@@ -66,11 +78,18 @@ func CheckPDBIsValid(pdb *policyv1.PodDisruptionBudget, replicas *int32) (bool, 
 	return true, nil
 }
 
+// intOrStringToValue converts a PDB value (integer or percentage) to an absolute integer.
+//
+// For integers: returns the value directly (e.g., 3 → 3)
+// For percentages: converts to absolute value using replicas (e.g., "60%" with 5 replicas → 3)
+//
+// This allows uniform comparison regardless of whether the PDB uses integers or percentages.
 func intOrStringToValue(intOrStr *intstr.IntOrString, replicas int32) (int, error) {
 	switch intOrStr.Type {
 	case intstr.Int:
 		return intOrStr.IntValue(), nil
 	case intstr.String:
+		// Convert percentage to absolute value: "60%" with 5 replicas → 0.60 * 5 = 3
 		v, err := percentageToFloat(intOrStr.StrVal)
 		if err != nil {
 			return 0, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
@@ -78,4 +97,126 @@ func intOrStringToValue(intOrStr *intstr.IntOrString, replicas int32) (int, erro
 		return int(math.RoundToEven(v * float64(replicas))), nil
 	}
 	return 0, fmt.Errorf("invalid type: neither int nor percentage")
+}
+
+// CheckPDBIsZoneAware validates that a PDB can tolerate an entire zone going offline.
+// This is important during platform upgrades where all workers in a zone may be unavailable.
+//
+// Formula:
+//
+//	max_replicas_per_zone = ceil(nr_replicas / nr_zones)
+//
+// The PDB must satisfy ONE of these conditions:
+//
+//	For maxUnavailable:
+//	  - Integer: maxUnavailable >= max_replicas_per_zone
+//	  - Percentage: maxUnavailable >= (max_replicas_per_zone / nr_replicas) * 100
+//
+//	For minAvailable:
+//	  - Integer: minAvailable <= (nr_replicas - max_replicas_per_zone)
+//	  - Percentage: minAvailable <= ((nr_replicas - max_replicas_per_zone) / nr_replicas) * 100
+//
+// Example 1: 2 zones, 5 replicas → max_replicas_per_zone = ceil(5/2) = 3
+//   - maxUnavailable >= 3 (int) or >= 60% (3/5 * 100)
+//   - minAvailable <= 2 (int) or <= 40% (2/5 * 100)
+//
+// Example 2: 3 zones, 9 replicas → max_replicas_per_zone = 9/3 = 3
+//   - maxUnavailable >= 3 (int) or >= 33% (3/9 * 100)
+//   - minAvailable <= 6 (int) or <= 66% (6/9 * 100)
+func CheckPDBIsZoneAware(pdb *policyv1.PodDisruptionBudget, replicas *int32, numZones int) *ZoneAwareCheckResult {
+	result := &ZoneAwareCheckResult{
+		NumZones: numZones,
+	}
+
+	var replicaCount int32
+	if replicas != nil {
+		replicaCount = *replicas
+	} else {
+		replicaCount = 1 // default value
+	}
+	result.Replicas = int(replicaCount)
+
+	// Skip zone-aware check for single-zone clusters or SNO
+	if numZones <= 1 {
+		result.IsValid = true
+		return result
+	}
+
+	// Calculate max replicas that could be in a single zone
+	// Using ceiling division: ceil(replicas / zones)
+	maxReplicasPerZone := int(math.Ceil(float64(replicaCount) / float64(numZones)))
+	result.MaxReplicasPerZone = maxReplicasPerZone
+
+	// Get minAvailable and maxUnavailable values
+	var minAvailableValue int
+	var maxUnavailableValue int
+
+	if pdb.Spec.MinAvailable != nil {
+		var err error
+		minAvailableValue, err = intOrStringToValue(pdb.Spec.MinAvailable, replicaCount)
+		if err != nil {
+			result.ZoneCheckError = fmt.Errorf("failed to parse minAvailable: %v", err)
+			return result
+		}
+		result.MinAvailableValue = minAvailableValue
+	}
+
+	if pdb.Spec.MaxUnavailable != nil {
+		var err error
+		maxUnavailableValue, err = intOrStringToValue(pdb.Spec.MaxUnavailable, replicaCount)
+		if err != nil {
+			result.ZoneCheckError = fmt.Errorf("failed to parse maxUnavailable: %v", err)
+			return result
+		}
+		result.MaxUnavailableValue = maxUnavailableValue
+	}
+
+	// Check zone-awareness:
+	// The PDB must allow draining all pods in a single zone during platform upgrades.
+	//
+	// For percentage values, intOrStringToValue() converts them to absolute values:
+	//   e.g., "60%" with 5 replicas → 0.60 * 5 = 3
+	// This is mathematically equivalent to comparing percentages directly:
+	//   (percentage/100) * replicas >= maxReplicasPerZone
+	//   ⟺ percentage >= (maxReplicasPerZone / replicas) * 100
+	//
+	// A PDB typically specifies EITHER maxUnavailable OR minAvailable (not both).
+	// The check passes if the specified constraint allows zone draining.
+
+	isZoneAware := false
+
+	if pdb.Spec.MaxUnavailable != nil {
+		// maxUnavailable check:
+		//   Integer: maxUnavailable >= max_replicas_per_zone
+		//   Percentage: maxUnavailable >= (max_replicas_per_zone / nr_replicas) * 100
+		// Both are handled by comparing the converted absolute value.
+		if maxUnavailableValue >= maxReplicasPerZone {
+			isZoneAware = true
+		}
+	}
+
+	if pdb.Spec.MinAvailable != nil {
+		// minAvailable check:
+		//   Integer: minAvailable <= (nr_replicas - max_replicas_per_zone)
+		//   Percentage: minAvailable <= ((nr_replicas - max_replicas_per_zone) / nr_replicas) * 100
+		// Both are handled by comparing the converted absolute value.
+		maxAllowedMinAvailable := int(replicaCount) - maxReplicasPerZone
+		if minAvailableValue <= maxAllowedMinAvailable {
+			isZoneAware = true
+		}
+	}
+
+	if !isZoneAware {
+		minAllowedMaxUnavailable := maxReplicasPerZone
+		maxAllowedMinAvailable := int(replicaCount) - maxReplicasPerZone
+		result.ZoneCheckError = fmt.Errorf(
+			"PDB is not zone-aware: with %d replicas across %d zones, max %d pods could be in one zone. "+
+				"Either set maxUnavailable >= %d or minAvailable <= %d to survive a zone failure",
+			replicaCount, numZones, maxReplicasPerZone,
+			minAllowedMaxUnavailable, maxAllowedMinAvailable)
+		return result
+	}
+
+	result.IsValid = true
+	return result
 }

--- a/tests/observability/pdb/pdb_test.go
+++ b/tests/observability/pdb/pdb_test.go
@@ -246,3 +246,457 @@ func TestPercentageToFloat(t *testing.T) {
 		assert.Equal(t, tc.expectedErr, err)
 	}
 }
+
+func TestCheckPDBIsZoneAware(t *testing.T) {
+	int32Ptr := func(i int32) *int32 { return &i }
+
+	testCases := []struct {
+		name         string
+		testPDB      *policyv1.PodDisruptionBudget
+		replicas     *int32
+		numZones     int
+		expectedPass bool
+	}{
+		{
+			// Test Case #1 - Single zone cluster, should always pass
+			name: "single zone cluster - always pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 1,
+					},
+				},
+			},
+			replicas:     int32Ptr(1),
+			numZones:     1,
+			expectedPass: true,
+		},
+		{
+			// Test Case #2 - 3 zones, 3 replicas, maxUnavailable=1 - FAIL
+			// ceil(3/3)=1 pod per zone, need maxUnavailable>=1 to survive zone failure
+			// but maxUnavailable=1 means all replicas could be unavailable
+			name: "3 zones 3 replicas maxUnavailable=1 - pass (can lose 1 zone)",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 1,
+					},
+				},
+			},
+			replicas:     int32Ptr(3),
+			numZones:     3,
+			expectedPass: true, // maxUnavailable(1) >= maxReplicasPerZone(1)
+		},
+		{
+			// Test Case #3 - 3 zones, 6 replicas, maxUnavailable=1 - FAIL
+			// ceil(6/3)=2 pods per zone, maxUnavailable=1 is not enough
+			name: "3 zones 6 replicas maxUnavailable=1 - fail",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 1,
+					},
+				},
+			},
+			replicas:     int32Ptr(6),
+			numZones:     3,
+			expectedPass: false, // maxUnavailable(1) < maxReplicasPerZone(2)
+		},
+		{
+			// Test Case #4 - 3 zones, 6 replicas, maxUnavailable=2 - PASS
+			// ceil(6/3)=2 pods per zone, maxUnavailable=2 is enough
+			name: "3 zones 6 replicas maxUnavailable=2 - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 2,
+					},
+				},
+			},
+			replicas:     int32Ptr(6),
+			numZones:     3,
+			expectedPass: true, // maxUnavailable(2) >= maxReplicasPerZone(2)
+		},
+		{
+			// Test Case #5 - 3 zones, 6 replicas, minAvailable=4 - PASS
+			// ceil(6/3)=2 pods per zone, minAvailable<=6-2=4 is enough
+			name: "3 zones 6 replicas minAvailable=4 - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 4,
+					},
+				},
+			},
+			replicas:     int32Ptr(6),
+			numZones:     3,
+			expectedPass: true, // minAvailable(4) <= replicas(6) - maxReplicasPerZone(2)
+		},
+		{
+			// Test Case #6 - 3 zones, 6 replicas, minAvailable=5 - FAIL
+			// ceil(6/3)=2 pods per zone, need minAvailable<=4 to survive zone failure
+			name: "3 zones 6 replicas minAvailable=5 - fail",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 5,
+					},
+				},
+			},
+			replicas:     int32Ptr(6),
+			numZones:     3,
+			expectedPass: false, // minAvailable(5) > replicas(6) - maxReplicasPerZone(2) = 4
+		},
+		{
+			// Test Case #7 - 3 zones, 5 replicas, maxUnavailable=2 - PASS
+			// ceil(5/3)=2 pods per zone, maxUnavailable=2 is enough
+			name: "3 zones 5 replicas maxUnavailable=2 - pass (uneven distribution)",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 2,
+					},
+				},
+			},
+			replicas:     int32Ptr(5),
+			numZones:     3,
+			expectedPass: true, // maxUnavailable(2) >= ceil(5/3) = 2
+		},
+		{
+			// Test Case #8 - percentage based: 3 zones, 9 replicas, maxUnavailable=34% (rounds to 3) - PASS
+			// ceil(9/3)=3 pods per zone, 34% of 9 = 3.06 rounds to 3
+			name: "3 zones 9 replicas maxUnavailable=34% - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "34%",
+					},
+				},
+			},
+			replicas:     int32Ptr(9),
+			numZones:     3,
+			expectedPass: true, // 34% of 9 = 3.06 rounds to 3 >= maxReplicasPerZone(3)
+		},
+		{
+			// Test Case #9 - percentage based: 3 zones, 9 replicas, maxUnavailable=30% (rounds to 3) - PASS
+			// ceil(9/3)=3 pods per zone, 30% of 9 = 2.7 rounds to 3
+			name: "3 zones 9 replicas maxUnavailable=30% - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "30%",
+					},
+				},
+			},
+			replicas:     int32Ptr(9),
+			numZones:     3,
+			expectedPass: true, // 30% of 9 = 2.7 rounds to 3 >= maxReplicasPerZone(3)
+		},
+		{
+			// Test Case #10 - percentage based: 3 zones, 9 replicas, maxUnavailable=20% (rounds to 2) - FAIL
+			// ceil(9/3)=3 pods per zone, 20% of 9 = 1.8 rounds to 2
+			name: "3 zones 9 replicas maxUnavailable=20% - fail",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "20%",
+					},
+				},
+			},
+			replicas:     int32Ptr(9),
+			numZones:     3,
+			expectedPass: false, // 20% of 9 = 1.8 rounds to 2 < maxReplicasPerZone(3)
+		},
+		{
+			// Test Case #11 - 2 zones, 4 replicas, minAvailable=2 - PASS
+			// ceil(4/2)=2 pods per zone, minAvailable<=4-2=2 is enough
+			name: "2 zones 4 replicas minAvailable=2 - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 2,
+					},
+				},
+			},
+			replicas:     int32Ptr(4),
+			numZones:     2,
+			expectedPass: true, // minAvailable(2) <= replicas(4) - maxReplicasPerZone(2) = 2
+		},
+		{
+			// Test Case #12 - 2 zones, 4 replicas, minAvailable=3 - FAIL
+			// ceil(4/2)=2 pods per zone, need minAvailable<=2 to survive zone failure
+			name: "2 zones 4 replicas minAvailable=3 - fail",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 3,
+					},
+				},
+			},
+			replicas:     int32Ptr(4),
+			numZones:     2,
+			expectedPass: false, // minAvailable(3) > replicas(4) - maxReplicasPerZone(2) = 2
+		},
+		{
+			// Test Case #13 - numZones=0 should be treated as single zone
+			name: "0 zones (no zone labels) - treated as single zone, pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 1,
+					},
+				},
+			},
+			replicas:     int32Ptr(1),
+			numZones:     0,
+			expectedPass: true, // No zones = single zone = skip check
+		},
+		// ======================================================================
+		// User-specified test cases (Examples from requirements)
+		// ======================================================================
+		{
+			// Example 1: 2 zones, 5 replicas, max_replicas_per_zone=ceil(5/2)=3
+			// maxUnavailable >= 60% (3/5) should PASS
+			name: "Example1: 2 zones 5 replicas maxUnavailable=60% - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "60%",
+					},
+				},
+			},
+			replicas:     int32Ptr(5),
+			numZones:     2,
+			expectedPass: true, // 60% of 5 = 3 >= max_replicas_per_zone(3)
+		},
+		{
+			// Example 1: 2 zones, 5 replicas, max_replicas_per_zone=ceil(5/2)=3
+			// maxUnavailable < 60% (e.g., 50%) should FAIL
+			name: "Example1: 2 zones 5 replicas maxUnavailable=50% - fail",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "50%",
+					},
+				},
+			},
+			replicas:     int32Ptr(5),
+			numZones:     2,
+			expectedPass: false, // 50% of 5 = 2.5 rounds to 2 < max_replicas_per_zone(3)
+		},
+		{
+			// Example 1: 2 zones, 5 replicas, max_replicas_per_zone=ceil(5/2)=3
+			// minAvailable <= 2 should PASS
+			name: "Example1: 2 zones 5 replicas minAvailable=2 - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 2,
+					},
+				},
+			},
+			replicas:     int32Ptr(5),
+			numZones:     2,
+			expectedPass: true, // minAvailable(2) <= replicas(5) - max_replicas_per_zone(3) = 2
+		},
+		{
+			// Example 1: 2 zones, 5 replicas, max_replicas_per_zone=ceil(5/2)=3
+			// minAvailable > 2 (e.g., 3) should FAIL
+			name: "Example1: 2 zones 5 replicas minAvailable=3 - fail",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 3,
+					},
+				},
+			},
+			replicas:     int32Ptr(5),
+			numZones:     2,
+			expectedPass: false, // minAvailable(3) > replicas(5) - max_replicas_per_zone(3) = 2
+		},
+		{
+			// Example 2: 3 zones, 9 replicas, max_replicas_per_zone=9/3=3
+			// maxUnavailable >= 33% should PASS (33% of 9 = 2.97 rounds to 3)
+			name: "Example2: 3 zones 9 replicas maxUnavailable=33% - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "33%",
+					},
+				},
+			},
+			replicas:     int32Ptr(9),
+			numZones:     3,
+			expectedPass: true, // 33% of 9 = 2.97 rounds to 3 >= max_replicas_per_zone(3)
+		},
+		{
+			// Example 2: 3 zones, 9 replicas, max_replicas_per_zone=9/3=3
+			// maxUnavailable >= 34% should definitely PASS
+			name: "Example2: 3 zones 9 replicas maxUnavailable=34% - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "34%",
+					},
+				},
+			},
+			replicas:     int32Ptr(9),
+			numZones:     3,
+			expectedPass: true, // 34% of 9 = 3.06 rounds to 3 >= max_replicas_per_zone(3)
+		},
+		{
+			// Example 2: 3 zones, 9 replicas, max_replicas_per_zone=9/3=3
+			// maxUnavailable < 33% (e.g., 25%) should FAIL
+			name: "Example2: 3 zones 9 replicas maxUnavailable=25% - fail",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.String,
+						StrVal: "25%",
+					},
+				},
+			},
+			replicas:     int32Ptr(9),
+			numZones:     3,
+			expectedPass: false, // 25% of 9 = 2.25 rounds to 2 < max_replicas_per_zone(3)
+		},
+		{
+			// Example 2: 3 zones, 9 replicas, max_replicas_per_zone=9/3=3
+			// minAvailable <= 6 should PASS
+			name: "Example2: 3 zones 9 replicas minAvailable=6 - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 6,
+					},
+				},
+			},
+			replicas:     int32Ptr(9),
+			numZones:     3,
+			expectedPass: true, // minAvailable(6) <= replicas(9) - max_replicas_per_zone(3) = 6
+		},
+		{
+			// Example 2: 3 zones, 9 replicas, max_replicas_per_zone=9/3=3
+			// minAvailable > 6 (e.g., 7) should FAIL
+			name: "Example2: 3 zones 9 replicas minAvailable=7 - fail",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 7,
+					},
+				},
+			},
+			replicas:     int32Ptr(9),
+			numZones:     3,
+			expectedPass: false, // minAvailable(7) > replicas(9) - max_replicas_per_zone(3) = 6
+		},
+		// ======================================================================
+		// OR logic test cases: when BOTH minAvailable AND maxUnavailable are specified
+		// A PDB typically specifies only ONE, but if both are set, either passing is OK
+		// ======================================================================
+		{
+			// Both specified, both pass - should PASS
+			name: "OR logic: both constraints pass - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 4, // <= 6-2=4 ✓
+					},
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 2, // >= 2 ✓
+					},
+				},
+			},
+			replicas:     int32Ptr(6),
+			numZones:     3,
+			expectedPass: true, // Both constraints allow zone draining
+		},
+		{
+			// Both specified, maxUnavailable passes but minAvailable fails - should PASS (OR logic)
+			name: "OR logic: maxUnavailable ok but minAvailable fails - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 5, // > 6-2=4 ✗
+					},
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 2, // >= 2 ✓
+					},
+				},
+			},
+			replicas:     int32Ptr(6),
+			numZones:     3,
+			expectedPass: true, // maxUnavailable passes, so PDB is zone-aware (OR logic)
+		},
+		{
+			// Both specified, minAvailable passes but maxUnavailable fails - should PASS (OR logic)
+			name: "OR logic: minAvailable ok but maxUnavailable fails - pass",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 4, // <= 6-2=4 ✓
+					},
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 1, // < 2 ✗
+					},
+				},
+			},
+			replicas:     int32Ptr(6),
+			numZones:     3,
+			expectedPass: true, // minAvailable passes, so PDB is zone-aware (OR logic)
+		},
+		{
+			// Both specified, both fail - should FAIL
+			name: "OR logic: both constraints fail - fail",
+			testPDB: &policyv1.PodDisruptionBudget{
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MinAvailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 5, // > 6-2=4 ✗
+					},
+					MaxUnavailable: &intstr.IntOrString{
+						Type:   intstr.Int,
+						IntVal: 1, // < 2 ✗
+					},
+				},
+			},
+			replicas:     int32Ptr(6),
+			numZones:     3,
+			expectedPass: false, // Both constraints fail, so PDB is NOT zone-aware
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := CheckPDBIsZoneAware(tc.testPDB, tc.replicas, tc.numZones)
+			assert.Equal(t, tc.expectedPass, result.IsValid, "Test case: %s", tc.name)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add zone-aware validation to the `pod-disruption-budget` test to ensure workloads can survive an entire zone going offline during platform upgrades
- Add `GetWorkerZoneCount()` to count unique zones from node topology labels (`topology.kubernetes.io/zone`)
- Add `CheckPDBIsZoneAware()` to validate PDBs can tolerate zone drains using the formula: `max_replicas_per_zone = ceil(replicas / zones)`
- PDB passes if: `maxUnavailable >= max_replicas_per_zone` OR `minAvailable <= (replicas - max_replicas_per_zone)`
- Add 27 unit tests covering various zone/replica/PDB combinations
- Update test identifier, impact, and remediation documentation

## Test plan
- [x] All existing PDB tests pass
- [x] 27 new zone-aware test cases pass covering:
  - Single zone clusters (always pass)
  - Multi-zone clusters with integer values
  - Multi-zone clusters with percentage values
  - User-specified examples (2 zones/5 replicas, 3 zones/9 replicas)
  - OR logic when both minAvailable and maxUnavailable are specified
- [ ] Manual testing on multi-zone cluster

Fixes: #3442


Made with [Cursor](https://cursor.com)