### PR TITLE
Restrict top-level token permissions in upload-release-assets workflow

### DIFF
--- a/.github/workflows/upload-release-assets.yaml
+++ b/.github/workflows/upload-release-assets.yaml
@@ -5,12 +5,14 @@ on:
     types: [published]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   upload-release-assets:
     name: Upload release assets
     runs-on: ubuntu-24.04
+    permissions:
+      contents: write
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary

- Moves `contents: write` from top-level to job-level permissions in `upload-release-assets.yaml`, setting the top-level default to `contents: read`
- Follows the principle of least privilege by granting write access only at the narrowest scope needed

Addresses [Scorecard Token-Permissions alert #180](https://github.com/redhat-best-practices-for-k8s/certsuite/security/code-scanning/180).

## Note on the other 3 Token-Permissions alerts

The remaining open Token-Permissions alerts (#225, #224, #158) flag **job-level** `contents: write` permissions in `parser-update.yaml`, `probe-update.yaml`, and `update-rhcos-mapping.yml`. These workflows already follow best practices:

- Top-level permissions are set to `contents: read`
- Write permissions are scoped to the individual job that needs them
- The `contents: write` and `pull-requests: write` permissions are required by `peter-evans/create-pull-request` to push branches and create PRs

These alerts cannot be resolved without breaking the workflows. Scorecard flags any `write` permission regardless of whether it is necessary.

## Test plan

- [ ] Verify the `upload-release-assets` workflow runs successfully on the next release (triggered by `release: published`)
- [ ] Confirm the workflow can still upload binary tarballs to GitHub releases

## Related PRs

**Token Permissions:**
- certsuite-qe: https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1371
- certsuite-sample-workload: https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/pull/650
- telco-bot: https://github.com/redhat-best-practices-for-k8s/telco-bot/pull/117
- certsuite-operator: https://github.com/redhat-best-practices-for-k8s/certsuite-operator/pull/285
- certsuite-probe: https://github.com/redhat-best-practices-for-k8s/certsuite-probe/pull/67
- parser: https://github.com/redhat-best-practices-for-k8s/parser/pull/100
- certsuite-claim: https://github.com/redhat-best-practices-for-k8s/certsuite-claim/pull/163
- perfdive: https://github.com/redhat-best-practices-for-k8s/perfdive/pull/50
- certsuite-overview: https://github.com/redhat-best-practices-for-k8s/certsuite-overview/pull/120
- custom-catalog-builder: https://github.com/redhat-best-practices-for-k8s/custom-catalog-builder/pull/20
- guide: https://github.com/redhat-best-practices-for-k8s/guide/pull/27
- kpi-collection-tool: https://github.com/redhat-best-practices-for-k8s/kpi-collection-tool/pull/67
- certsuite-operator-plugin: https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin/pull/10
- certsuite-operator-plugin-teset: https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin-teset/pull/2

- quick-k8s: https://github.com/palmsoftware/quick-k8s/pull/93
- quick-ocp: https://github.com/palmsoftware/quick-ocp/pull/45
- quick-cleanup: https://github.com/palmsoftware/quick-cleanup/pull/4

**Pinned Dependencies:**
- certsuite: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3470
- certsuite-qe: https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1372
- certsuite-sample-workload: https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/pull/651

Ref: CNFCERT-1353

