### PR TITLE
Pin GitHub Actions to SHA hashes in qe-ocp workflows

### DIFF
--- a/.github/workflows/qe-ocp-414-intrusive.yaml
+++ b/.github/workflows/qe-ocp-414-intrusive.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/qe-ocp-414.yaml
+++ b/.github/workflows/qe-ocp-414.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/qe-ocp-416-intrusive.yaml
+++ b/.github/workflows/qe-ocp-416-intrusive.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/qe-ocp-416.yaml
+++ b/.github/workflows/qe-ocp-416.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/qe-ocp-417-intrusive.yaml
+++ b/.github/workflows/qe-ocp-417-intrusive.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/qe-ocp-417.yaml
+++ b/.github/workflows/qe-ocp-417.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 

--- a/.github/workflows/qe-ocp-418-intrusive.yaml
+++ b/.github/workflows/qe-ocp-418-intrusive.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -90,7 +90,7 @@ jobs:
         run: echo "::remove-matcher owner=go::"
 
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.25
+        uses: palmsoftware/quick-ocp@8be2b2ca321e0827467e1acc0a79084f66fc69e5 # v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-418.yaml
+++ b/.github/workflows/qe-ocp-418.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -91,7 +91,7 @@ jobs:
         run: echo "::remove-matcher owner=go::"
 
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -104,7 +104,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.25
+        uses: palmsoftware/quick-ocp@8be2b2ca321e0827467e1acc0a79084f66fc69e5 # v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-419-intrusive.yaml
+++ b/.github/workflows/qe-ocp-419-intrusive.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -90,7 +90,7 @@ jobs:
         run: echo "::remove-matcher owner=go::"
 
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.25
+        uses: palmsoftware/quick-ocp@8be2b2ca321e0827467e1acc0a79084f66fc69e5 # v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-419.yaml
+++ b/.github/workflows/qe-ocp-419.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -91,7 +91,7 @@ jobs:
         run: echo "::remove-matcher owner=go::"
 
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -104,7 +104,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.25
+        uses: palmsoftware/quick-ocp@8be2b2ca321e0827467e1acc0a79084f66fc69e5 # v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-420-intrusive.yaml
+++ b/.github/workflows/qe-ocp-420-intrusive.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -90,7 +90,7 @@ jobs:
         run: echo "::remove-matcher owner=go::"
 
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.25
+        uses: palmsoftware/quick-ocp@8be2b2ca321e0827467e1acc0a79084f66fc69e5 # v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-420.yaml
+++ b/.github/workflows/qe-ocp-420.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -91,7 +91,7 @@ jobs:
         run: echo "::remove-matcher owner=go::"
 
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -104,7 +104,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.25
+        uses: palmsoftware/quick-ocp@8be2b2ca321e0827467e1acc0a79084f66fc69e5 # v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-421-intrusive.yaml
+++ b/.github/workflows/qe-ocp-421-intrusive.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -90,7 +90,7 @@ jobs:
         run: echo "::remove-matcher owner=go::"
 
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -103,7 +103,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.25
+        uses: palmsoftware/quick-ocp@8be2b2ca321e0827467e1acc0a79084f66fc69e5 # v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-421.yaml
+++ b/.github/workflows/qe-ocp-421.yaml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -91,7 +91,7 @@ jobs:
         run: echo "::remove-matcher owner=go::"
 
       - name: Check out code
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.sha }}
 
@@ -104,7 +104,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@v0.0.25
+        uses: palmsoftware/quick-ocp@8be2b2ca321e0827467e1acc0a79084f66fc69e5 # v0.0.25
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true


### PR DESCRIPTION
## Summary

- Pins `actions/checkout` and `palmsoftware/quick-ocp` to commit SHAs instead of mutable version tags across all 14 qe-ocp test workflows
- Hardens CI supply chain against tag tampering (a compromised upstream could move a tag to point at malicious code; SHAs are immutable)

Addresses Scorecard Pinned-Dependencies alerts.

### Changes

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | `@v6.0.2` | `@de0fac2e... # v6.0.2` |
| `palmsoftware/quick-ocp` | `@v0.0.25` | `@8be2b2ca... # v0.0.25` |

### Dependabot compatibility

The existing Dependabot config (`github-actions` ecosystem, weekly, `directory: /`) handles SHA-pinned actions correctly -- it will update both the SHA and the version comment when new releases are available.

### Note

The `Dockerfile:125` Pinned-Dependencies alert for `quay.io/redhat-best-practices-for-k8s/oct:latest` is intentionally left as-is. The oct image is an offline certification database updated 4x daily, and the Dockerfile build must always pull the latest version.

## Test plan

- [ ] Verify qe-ocp workflows trigger and run correctly (checkout and quick-ocp actions resolve to the same code as before)
- [ ] Confirm Dependabot picks up the SHA-pinned actions on its next weekly scan

## Related PRs

**Token Permissions:**
- certsuite: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3469
- certsuite-qe: https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1371
- certsuite-sample-workload: https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/pull/650
- telco-bot: https://github.com/redhat-best-practices-for-k8s/telco-bot/pull/117
- certsuite-operator: https://github.com/redhat-best-practices-for-k8s/certsuite-operator/pull/285
- certsuite-probe: https://github.com/redhat-best-practices-for-k8s/certsuite-probe/pull/67
- parser: https://github.com/redhat-best-practices-for-k8s/parser/pull/100
- certsuite-claim: https://github.com/redhat-best-practices-for-k8s/certsuite-claim/pull/163
- perfdive: https://github.com/redhat-best-practices-for-k8s/perfdive/pull/50
- certsuite-overview: https://github.com/redhat-best-practices-for-k8s/certsuite-overview/pull/120
- custom-catalog-builder: https://github.com/redhat-best-practices-for-k8s/custom-catalog-builder/pull/20
- guide: https://github.com/redhat-best-practices-for-k8s/guide/pull/27
- kpi-collection-tool: https://github.com/redhat-best-practices-for-k8s/kpi-collection-tool/pull/67
- certsuite-operator-plugin: https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin/pull/10
- certsuite-operator-plugin-teset: https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin-teset/pull/2

- quick-k8s: https://github.com/palmsoftware/quick-k8s/pull/93
- quick-ocp: https://github.com/palmsoftware/quick-ocp/pull/45
- quick-cleanup: https://github.com/palmsoftware/quick-cleanup/pull/4

**Pinned Dependencies:**
- certsuite-qe: https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1372
- certsuite-sample-workload: https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/pull/651

Ref: CNFCERT-1353

