### PR TITLE
Update operator-sdk from v1.41.1 to v1.42.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV \
 
 # Download operator-sdk binary
 ENV \
-	OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.41.1 \
+	OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.42.2 \
 	OSDK_BIN=/usr/local/osdk/bin
 
 RUN \


### PR DESCRIPTION
## Summary
- Updates operator-sdk from v1.41.1 to v1.42.2 in the Dockerfile
- v1.42.2 is a maintenance release with gRPC dependency bump (1.78.0 → 1.79.3) and Ansible plugin sync
- Release: https://github.com/operator-framework/operator-sdk/releases/tag/v1.42.2

Companion PR: https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload/pull/676

Ref: CNFCERT-1387