### PR TITLE
Replace install-lint auto-install with a presence check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,9 +129,9 @@ install-mac-brew-tools:
 		hadolint \
 		shfmt
 
-# Installs linters
+# Checks if golangci-lint is installed
 install-lint:
-	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@${GOLANGCI_VERSION}
+	@command -v golangci-lint >/dev/null 2>&1 || { echo "golangci-lint is not installed. Please install it: https://golangci-lint.run/welcome/install/"; exit 1; }
 
 install-shfmt:
 	go install mvdan.cc/sh/v3/cmd/shfmt@latest


### PR DESCRIPTION
## Summary
- The `install-lint` Makefile target previously ran `go install` to fetch golangci-lint automatically.
- CI uses a dedicated GitHub Action (`golangci-lint-action`) so auto-install is unnecessary.
- The target now checks if `golangci-lint` is on `$PATH` and exits with an install link if it is not.

## Test plan
- [ ] Run `make install-lint` with golangci-lint installed — should succeed silently.
- [ ] Run `make install-lint` without golangci-lint on PATH — should print install instructions and exit 1.
- [ ] Verify CI lint workflow is unaffected (does not use this target).