### PR TITLE
Add unsecured container ports TLS detection test

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 ## Test cases summary
 
-### Total test cases: 121
+### Total test cases: 122
 
 ### Total suites: 10
 
@@ -17,18 +17,18 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |affiliated-certification|4|[affiliated-certification](#affiliated-certification)|
 |lifecycle|19|[lifecycle](#lifecycle)|
 |manageability|2|[manageability](#manageability)|
-|networking|11|[networking](#networking)|
+|networking|12|[networking](#networking)|
 |observability|5|[observability](#observability)|
 |operator|12|[operator](#operator)|
 |performance|7|[performance](#performance)|
 |platform-alteration|14|[platform-alteration](#platform-alteration)|
 |preflight|19|[preflight](#preflight)|
 
-### Extended specific tests only: 13
+### Extended specific tests only: 14
 
 |Mandatory|Optional|
 |---|---|---|
-|10|3|
+|10|4|
 
 ### Far-Edge specific tests only: 9
 
@@ -1146,6 +1146,23 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Tags|extended,networking|
 |**Scenario**|**Optional/Mandatory**|
 |Extended|Mandatory|
+|Far-Edge|Optional|
+|Non-Telco|Optional|
+|Telco|Optional|
+
+#### networking-unsecured-container-ports
+
+|Property|Description|
+|---|---|
+|Unique ID|networking-unsecured-container-ports|
+|Description|Check that TCP ports listening inside containers use TLS encryption. Ports accepting plaintext connections are flagged as non-compliant.|
+|Suggested Remediation|Ensure all listening TCP ports use TLS. If a port intentionally serves plaintext (e.g., health probes behind network policies), annotate the pod with certsuite.redhat.com/non-tls-ports: "port1,port2".|
+|Best Practice Reference|No Doc Link - Extended|
+|Exception Process|No exception needed for optional/extended tests.|
+|Impact Statement|Unsecured ports accepting plaintext traffic expose sensitive data to eavesdropping and man-in-the-middle attacks, violating security compliance requirements.|
+|Tags|extended,networking|
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Optional|
 |Far-Edge|Optional|
 |Non-Telco|Optional|
 |Telco|Optional|

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -72,6 +72,7 @@ testCases:
     - platform-alteration-tainted-node-kernel
   fail:
     - affiliated-certification-container-is-certified-digest # test container image is not certified
+    - networking-unsecured-container-ports # smoke test pods serve plaintext
   skip:
     - access-control-sys-ptrace-capability
     - access-control-sys-nice-realtime-capability

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -20,6 +20,7 @@ const (
 	TestICMPv6ConnectivityMultusIdentifierDocLink       = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-high-level-cnf-expectations"
 	TestServiceDualStackIdentifierDocLink               = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-ipv4-&-ipv6"
 	TestUndeclaredContainerPortsUsageDocLink            = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requirements-cnf-reqs"
+	TestUnsecuredContainerPortsDocLink                  = NoDocLinkExtended
 	TestOCPReservedPortsUsageDocLink                    = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-ports-reserved-by-openshift"
 
 	// Access Control Suite

--- a/tests/identifiers/identifiers.go
+++ b/tests/identifiers/identifiers.go
@@ -160,6 +160,7 @@ var (
 	TestIsRedHatReleaseIdentifier                                    claim.Identifier
 	TestIsSELinuxEnforcingIdentifier                                 claim.Identifier
 	TestUndeclaredContainerPortsUsage                                claim.Identifier
+	TestUnsecuredContainerPortsIdentifier                            claim.Identifier
 	TestOCPReservedPortsUsage                                        claim.Identifier
 	TestLivenessProbeIdentifier                                      claim.Identifier
 	TestReadinessProbeIdentifier                                     claim.Identifier
@@ -1515,6 +1516,22 @@ that Node's kernel may not have the same hacks.'`,
 			Telco:    Optional,
 			NonTelco: Optional,
 			Extended: Mandatory,
+		},
+		TagExtended)
+
+	TestUnsecuredContainerPortsIdentifier = AddCatalogEntry(
+		"unsecured-container-ports",
+		common.NetworkingTestKey,
+		`Check that TCP ports listening inside containers use TLS encryption. Ports accepting plaintext connections are flagged as non-compliant.`,
+		UnsecuredContainerPortsRemediation,
+		NoExceptionProcessForExtendedTests,
+		TestUnsecuredContainerPortsDocLink,
+		true,
+		map[string]string{
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
+			Extended: Optional,
 		},
 		TagExtended)
 

--- a/tests/identifiers/impact.go
+++ b/tests/identifiers/impact.go
@@ -36,6 +36,7 @@ const (
 	TestICMPv6ConnectivityMultusIdentifierImpact       = `IPv6 Multus connectivity problems can prevent dual-stack multi-network scenarios from working, limiting network scalability and future-proofing.`
 	TestServiceDualStackIdentifierImpact               = `Single-stack IPv4 services limit network architecture flexibility and prevent migration to modern dual-stack infrastructures.`
 	TestUndeclaredContainerPortsUsageImpact            = `Undeclared ports can be blocked by security policies, causing unexpected connectivity issues and making troubleshooting difficult.`
+	TestUnsecuredContainerPortsImpact                  = `Unsecured ports accepting plaintext traffic expose sensitive data to eavesdropping and man-in-the-middle attacks, violating security compliance requirements.`
 	TestOCPReservedPortsUsageImpact                    = `Using OpenShift-reserved ports can cause critical platform services to fail, potentially destabilizing the entire cluster.`
 
 	// Access Control Suite Impact Statements
@@ -179,6 +180,7 @@ var ImpactMap = map[string]string{
 	"networking-icmpv6-connectivity-multus":              TestICMPv6ConnectivityMultusIdentifierImpact,
 	"networking-dual-stack-service":                      TestServiceDualStackIdentifierImpact,
 	"networking-undeclared-container-ports-usage":        TestUndeclaredContainerPortsUsageImpact,
+	"networking-unsecured-container-ports":               TestUnsecuredContainerPortsImpact,
 	"networking-ocp-reserved-ports-usage":                TestOCPReservedPortsUsageImpact,
 
 	// Access Control Suite

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -139,6 +139,8 @@ const (
 
 	UndeclaredContainerPortsRemediation = `Ensure the workload's apps do not listen on undeclared containers' ports.`
 
+	UnsecuredContainerPortsRemediation = `Ensure all listening TCP ports use TLS. If a port intentionally serves plaintext (e.g., health probes behind network policies), annotate the pod with certsuite.redhat.com/non-tls-ports: "port1,port2".`
+
 	CrdsStatusSubresourceRemediation = `Ensure that all the CRDs have a meaningful status specification (Spec.versions[].Schema.OpenAPIV3Schema.Properties[“status”]).`
 
 	LoggingRemediation = `Ensure containers are not redirecting stdout/stderr`

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -19,7 +19,9 @@ package networking
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
@@ -31,6 +33,7 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/netutil"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/policies"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/services"
+	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/tlsversion"
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
@@ -157,6 +160,18 @@ func LoadChecks() {
 			testNetworkAttachmentDefinitionSRIOVUsingMTU(c, sriovPods)
 			return nil
 		}))
+
+	// Unsecured container ports test case
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestUnsecuredContainerPortsIdentifier)).
+		WithSkipCheckFn(
+			testhelper.GetNoContainersUnderTestSkipFn(&env),
+			testhelper.GetDaemonSetFailedToSpawnSkipFn(&env),
+			testhelper.GetNoPodsUnderTestSkipFn(&env),
+		).
+		WithCheckFn(func(c *checksdb.Check) error {
+			testUnsecuredContainerPorts(c, &env)
+			return nil
+		}))
 }
 
 //nolint:funlen
@@ -229,6 +244,125 @@ func testUndeclaredContainerPortsUsage(check *checksdb.Check, env *provider.Test
 				testhelper.NewPodReportObject(put.Namespace, put.Name, "All listening were declared in containers specs", true))
 		}
 	}
+	check.SetResult(compliantObjects, nonCompliantObjects)
+}
+
+const nonTLSPortsAnnotation = "certsuite.redhat.com/non-tls-ports"
+
+func parseNonTLSPortsAnnotation(pod *provider.Pod, check *checksdb.Check) map[int32]bool {
+	exempt := make(map[int32]bool)
+	ann, ok := pod.Annotations[nonTLSPortsAnnotation]
+	if !ok || ann == "" {
+		return exempt
+	}
+	for _, p := range strings.Split(ann, ",") {
+		p = strings.TrimSpace(p)
+		port, err := strconv.ParseInt(p, 10, 32)
+		if err != nil {
+			check.LogError("Invalid port %q in %s annotation on pod %s/%s", p, nonTLSPortsAnnotation, pod.Namespace, pod.Name)
+			continue
+		}
+		exempt[int32(port)] = true
+	}
+	return exempt
+}
+
+func getFirstProbeContext(env *provider.TestEnvironment) (clientsholder.Command, clientsholder.Context, bool) {
+	for _, probePod := range env.ProbePods {
+		if probePod == nil || len(probePod.Spec.Containers) == 0 {
+			continue
+		}
+		return clientsholder.GetClientsHolder(), clientsholder.NewContext(
+			probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name,
+		), true
+	}
+	return nil, clientsholder.Context{}, false
+}
+
+func newPortReportObject(namespace, name, message string, compliant bool, port netutil.PortInfo) *testhelper.ReportObject {
+	return testhelper.NewPodReportObject(namespace, name, message, compliant).
+		SetType(testhelper.ListeningPortType).
+		AddField(testhelper.PortNumber, strconv.Itoa(int(port.PortNumber))).
+		AddField(testhelper.PortProtocol, port.Protocol)
+}
+
+func checkPodPortTLS(check *checksdb.Check, put *provider.Pod, ch clientsholder.Command,
+	probeCtx clientsholder.Context) (compliant, nonCompliant []*testhelper.ReportObject) {
+	listeningPorts, err := netutil.GetListeningPorts(put.Containers[0])
+	if err != nil {
+		check.LogError("Failed to get container %q listening ports, err: %v", put.Containers[0], err)
+		return nil, []*testhelper.ReportObject{
+			testhelper.NewPodReportObject(put.Namespace, put.Name, fmt.Sprintf("Failed to get listening ports: %v", err), false),
+		}
+	}
+
+	if len(listeningPorts) == 0 {
+		return []*testhelper.ReportObject{
+			testhelper.NewPodReportObject(put.Namespace, put.Name, "No listening ports", true),
+		}, nil
+	}
+
+	exemptPorts := parseNonTLSPortsAnnotation(put, check)
+	podIP := put.Status.PodIP
+	if podIP == "" {
+		check.LogError("Pod %q has no PodIP, skipping TLS probe", put)
+		return nil, nil
+	}
+
+	for listeningPort := range listeningPorts {
+		if listeningPort.Protocol != "TCP" {
+			continue
+		}
+		if put.ContainsIstioProxy() && netcommons.ReservedIstioPorts[listeningPort.PortNumber] {
+			continue
+		}
+		if exemptPorts[listeningPort.PortNumber] {
+			compliant = append(compliant,
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d exempt via annotation", listeningPort.PortNumber), true, listeningPort))
+			continue
+		}
+
+		isTLS, reachable, reason := tlsversion.IsPortTLS(ch, probeCtx, podIP, listeningPort.PortNumber)
+		check.LogInfo("TLS probe %s:%d: isTLS=%v reachable=%v reason=%q",
+			podIP, listeningPort.PortNumber, isTLS, reachable, reason)
+
+		switch {
+		case !reachable:
+			compliant = append(compliant,
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d unreachable (%s)", listeningPort.PortNumber, reason), true, listeningPort))
+		case isTLS:
+			compliant = append(compliant,
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d uses TLS (%s)", listeningPort.PortNumber, reason), true, listeningPort))
+		default:
+			check.LogError("Port %d on %q is plaintext (%s)", listeningPort.PortNumber, put, reason)
+			nonCompliant = append(nonCompliant,
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d accepts plaintext connections (%s)", listeningPort.PortNumber, reason), false, listeningPort))
+		}
+	}
+
+	return compliant, nonCompliant
+}
+
+func testUnsecuredContainerPorts(check *checksdb.Check, env *provider.TestEnvironment) {
+	var compliantObjects []*testhelper.ReportObject
+	var nonCompliantObjects []*testhelper.ReportObject
+
+	ch, probeCtx, probeAvailable := getFirstProbeContext(env)
+	if !probeAvailable {
+		check.LogError("No probe pods available for TLS checks, skipping")
+		return
+	}
+
+	for _, put := range env.Pods {
+		c, nc := checkPodPortTLS(check, put, ch, probeCtx)
+		compliantObjects = append(compliantObjects, c...)
+		nonCompliantObjects = append(nonCompliantObjects, nc...)
+	}
+
 	check.SetResult(compliantObjects, nonCompliantObjects)
 }
 

--- a/tests/networking/tlsversion/tlsversion.go
+++ b/tests/networking/tlsversion/tlsversion.go
@@ -1,0 +1,97 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package tlsversion
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+)
+
+const (
+	opensslCipherNone       = "Cipher is (NONE)"
+	opensslAlertProtoVer    = "alert protocol version"
+	opensslAlertHandshake   = "alert handshake failure"
+	opensslHandshakeFailure = "handshake failure"
+	opensslConnected        = "CONNECTED"
+	opensslConnErrno        = "errno"
+)
+
+// hasOpensslOutput returns true if stdout contains any recognizable openssl markers,
+// indicating the command ran and produced parseable output even if the handshake failed.
+func hasOpensslOutput(stdout string) bool {
+	return strings.Contains(stdout, opensslConnected) ||
+		strings.Contains(stdout, opensslConnErrno) ||
+		strings.Contains(stdout, "SSL") ||
+		strings.Contains(stdout, "Cipher")
+}
+
+func extractOpenSSLCipher(stdout string) string {
+	for line := range strings.SplitSeq(stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(trimmed, "Cipher    :"); ok {
+			return strings.TrimSpace(after)
+		}
+		if after, ok := strings.CutPrefix(trimmed, "Cipher:"); ok {
+			return strings.TrimSpace(after)
+		}
+	}
+	return "unknown"
+}
+
+// IsPortTLS probes a single TCP port via openssl to determine whether it speaks TLS.
+// It does not validate TLS version or cipher compliance — only whether TLS is present.
+func IsPortTLS(ch clientsholder.Command, ctx clientsholder.Context, address string, port int32) (isTLS, reachable bool, reason string) {
+	endpoint := net.JoinHostPort(address, strconv.Itoa(int(port)))
+	cmd := fmt.Sprintf("echo | timeout 5 openssl s_client -connect %s 2>&1", endpoint)
+	stdout, _, err := ch.ExecCommandContainer(ctx, cmd)
+
+	if err != nil && !hasOpensslOutput(stdout) {
+		return false, false, fmt.Sprintf("exec probe failed: %v", err)
+	}
+
+	if strings.Contains(stdout, "connect:errno=") || strings.Contains(stdout, "Connection refused") {
+		return false, false, "port unreachable"
+	}
+
+	if !hasOpensslOutput(stdout) {
+		return false, false, "no recognizable openssl output"
+	}
+
+	// TLS alerts indicate a genuine TLS server (even if it rejected our params)
+	if strings.Contains(stdout, opensslAlertProtoVer) ||
+		strings.Contains(stdout, opensslAlertHandshake) ||
+		strings.Contains(stdout, opensslHandshakeFailure) {
+		return true, true, "TLS server detected (handshake alert)"
+	}
+
+	// Successful TLS handshake: cipher is not NONE
+	if !strings.Contains(stdout, opensslCipherNone) {
+		if strings.Contains(stdout, "Cipher    :") || strings.Contains(stdout, "Cipher:") {
+			cipher := extractOpenSSLCipher(stdout)
+			if cipher != "" && cipher != "0000" && cipher != "(NONE)" {
+				return true, true, fmt.Sprintf("TLS negotiated (cipher: %s)", cipher)
+			}
+		}
+	}
+
+	// Connected but no TLS indicators — plaintext service
+	return false, true, "plaintext service (no TLS)"
+}

--- a/tests/networking/tlsversion/tlsversion_test.go
+++ b/tests/networking/tlsversion/tlsversion_test.go
@@ -1,0 +1,121 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package tlsversion
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockCommand struct {
+	patterns []mockPattern
+}
+
+type mockPattern struct {
+	key    string
+	result mockExecResult
+}
+
+type mockExecResult struct {
+	stdout string
+	err    error
+}
+
+func newMockCommand(patterns ...mockPattern) *mockCommand {
+	return &mockCommand{patterns: patterns}
+}
+
+func (m *mockCommand) ExecCommandContainer(_ clientsholder.Context, command string) (stdout, stderr string, err error) {
+	for _, p := range m.patterns {
+		if strings.Contains(command, p.key) {
+			return p.result.stdout, "", p.result.err
+		}
+	}
+	return "", "", fmt.Errorf("unexpected command: %s", command)
+}
+
+func TestIsPortTLS_TLSServer(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{"s_client", mockExecResult{
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		}},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.True(t, isTLS, "expected TLS, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS negotiated")
+}
+
+func TestIsPortTLS_PlaintextService(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{"s_client", mockExecResult{
+			stdout: "CONNECTED(00000003)\n---\nCipher is (NONE)\npacket length too long\n---",
+			err:    fmt.Errorf("exit status 1"),
+		}},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 8080)
+	assert.False(t, isTLS, "expected plaintext, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "plaintext")
+}
+
+func TestIsPortTLS_ConnectionRefused(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{"s_client", mockExecResult{
+			stdout: "connect:errno=111\nConnection refused",
+			err:    fmt.Errorf("exit status 1"),
+		}},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 9999)
+	assert.False(t, isTLS)
+	assert.False(t, reachable)
+	assert.Contains(t, reason, "unreachable")
+}
+
+func TestIsPortTLS_TLSHandshakeAlert(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{"s_client", mockExecResult{
+			stdout: "CONNECTED(00000003)\n---\nalert handshake failure\nCipher is (NONE)\n---",
+			err:    fmt.Errorf("exit status 1"),
+		}},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.True(t, isTLS, "TLS alert means genuine TLS server, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS server detected")
+}
+
+func TestIsPortTLS_ExecFailed(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{"s_client", mockExecResult{
+			stdout: "",
+			err:    fmt.Errorf("command not found"),
+		}},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, _ := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.False(t, isTLS)
+	assert.False(t, reachable)
+}


### PR DESCRIPTION
## Summary

- Add **networking-unsecured-container-ports** test that discovers listening TCP ports inside containers (via `ss`) and probes each with openssl from a probe pod to detect plaintext services.
- Ports accepting plaintext connections are flagged as non-compliant.
- Supports pod annotation exemptions (`certsuite.redhat.com/non-tls-ports: "port1,port2"`) for intentionally non-TLS endpoints like health probes behind network policies.
- Skips UDP ports, Istio-reserved ports, and unreachable ports.
- Includes standalone `IsPortTLS` helper in the `tlsversion` package (identical to the copy in #3456 for clean merge).

Classified as Optional across all scenarios (Extended, Telco, Non-Telco, Far-Edge).

Ref: CNF-4491

## Test plan

- [x] `make build` compiles successfully
- [x] `make test` — all unit tests pass (5 IsPortTLS tests)
- [x] `golangci-lint` passes with 0 issues
- [ ] QE smoke tests pass in CI
- [ ] Manual verification on CRC cluster