### PR TITLE
Update UBI 9.7 build-stage image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.7@sha256:039095faabf1edde946ff528b3b6906efa046ee129f3e33fd933280bb6936221 AS build
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.7@sha256:8805abe5b8a32c826d46926c069f20e6a7f854d59d5bd75c55e68278aea65ccc AS build
 ENV CERTSUITE_DIR=/usr/certsuite
 ENV \
 	CERTSUITE_SRC_DIR=${CERTSUITE_DIR}/src \


### PR DESCRIPTION
## Summary
- Updates the pinned UBI 9.7 digest in the build stage of the Dockerfile
- The previous digest (`sha256:039095fa...`) was removed from `registry.access.redhat.com`, causing all qe-ocp-416 nightly builds to fail at the image build step since April 17

## Test plan
- [ ] Verify the certsuite container image builds successfully
- [ ] Verify qe-ocp-416 nightly workflow passes the build step