### PR TITLE
Fix ICMP connectivity skip reason to appear in claim file

### DIFF
--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -237,7 +237,8 @@ func testNetworkConnectivity(env *provider.TestEnvironment, aIPVersion netcommon
 	netsUnderTest := icmp.BuildNetTestContext(env.Pods, aIPVersion, aType, check.GetLogger())
 	report, skip := icmp.RunNetworkingTests(netsUnderTest, defaultNumPings, aIPVersion, check.GetLogger())
 	if skip {
-		check.LogInfo("There are no %q networks to test with at least 2 pods, skipping test", aIPVersion)
+		check.SetResultSkipped(fmt.Sprintf("There are no %q networks to test with at least 2 pods", aIPVersion))
+		return
 	}
 	check.SetResult(report.CompliantObjectsOut, report.NonCompliantObjectsOut)
 }


### PR DESCRIPTION
## Summary
- When ICMP connectivity checks are skipped because there are no networks with at least 2 pods, the claim file shows a generic skip reason instead of the actual one.
- Use SetResultSkipped with the descriptive reason so it propagates to the claim file's skip reason field.

## Test plan
- [ ] Run ICMP connectivity tests in an environment with fewer than 2 pods per network
- [ ] Verify the claim file's skip reason field shows the specific reason instead of the generic empty-lists message