### PR TITLE
Fix for github html doc uploader workflow

### DIFF
--- a/.github/actions/documentation/Dockerfile
+++ b/.github/actions/documentation/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-39:9.7@sha256:ee2a11266ec90665de33302f74d913d556cf2dc67d68208cada62de15a6859b9
+FROM registry.access.redhat.com/ubi9/python-312@sha256:0abad955c2c2e4575dc8987d76b8c49a7dd8e0679063e3118dab03c54528232f
 
 # Pin versions in pip.
 # hadolint ignore=DL3013

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
       - main
+  workflow_dispatch:
+
 permissions:
   contents: read
 


### PR DESCRIPTION
Upgrade python to 3.12

The workflow has been failing since PR #3543 was merged, as the new dependencies require python >=3.10.

Failing job:
https://github.com/redhat-best-practices-for-k8s/certsuite/actions/runs/24036088552/job/70095942859#step:3:161
```
ERROR: Ignored the following versions that require a different python
version: 2.33.0 Requires-Python >=3.10; 2.33.1 Requires-Python >=3.10;
2026.2.19 Requires-Python >=3.10; 2026.2.28 Requires-Python >=3.10;
2026.3.32 Requires-Python >=3.10; 2026.4.4 Requires-Python >=3.10;
3.10 Requires-Python >=3.10; 3.10.1 Requires-Python >=3.10;
3.10.2 Requires-Python >=3.10; 4.5.0 Requires-Python >=3.10;
4.5.1 Requires-Python >=3.10; 4.6.0 Requires-Python
>=3.10; 4.7.0 Requires-Python >=3.10; 4.7.1
Requires-Python >=3.10; 4.8.0 Requires-Python >=3.10; 4.9.0
Requires-Python >=3.10; 4.9.1 Requires-Python >=3.10; 4.9.2
Requires-Python >=3.10; 4.9.4 Requires-Python >=3.10; 8.2.0
Requires-Python >=3.10; 8.2.1 Requires-Python >=3.10; 8.2.2
Requires-Python >=3.10; 8.3.0 Requires-Python >=3.10; 8.3.1
Requires-Python >=3.10; 8.3.2 Requires-Python >=3.10; 8.8.0
Requires-Python >=3.10; 8.9.0 Requires-Python >=3.10; 9.0.0
Requires-Python >=3.10
```
Also added manual trigger for doc publich workflow.