### PR TITLE
Add parallel check execution for I/O-heavy test functions

### DIFF
--- a/pkg/checksdb/parallel.go
+++ b/pkg/checksdb/parallel.go
@@ -1,0 +1,74 @@
+package checksdb
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
+	"golang.org/x/sync/errgroup"
+)
+
+const DefaultParallelLimit = 10
+
+type ParallelResult struct {
+	mu                  sync.Mutex
+	compliantObjects    []*testhelper.ReportObject
+	nonCompliantObjects []*testhelper.ReportObject
+}
+
+func (r *ParallelResult) AddCompliantObject(obj *testhelper.ReportObject) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.compliantObjects = append(r.compliantObjects, obj)
+}
+
+func (r *ParallelResult) AddNonCompliantObject(obj *testhelper.ReportObject) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.nonCompliantObjects = append(r.nonCompliantObjects, obj)
+}
+
+func (r *ParallelResult) AddCompliantObjects(objs []*testhelper.ReportObject) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.compliantObjects = append(r.compliantObjects, objs...)
+}
+
+func (r *ParallelResult) AddNonCompliantObjects(objs []*testhelper.ReportObject) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.nonCompliantObjects = append(r.nonCompliantObjects, objs...)
+}
+
+func (r *ParallelResult) Results() (compliant, nonCompliant []*testhelper.ReportObject) {
+	return r.compliantObjects, r.nonCompliantObjects
+}
+
+// ForEachParallel iterates over items concurrently, calling fn for each.
+// Concurrency is bounded by limit (0 uses DefaultParallelLimit).
+// Results are collected via the thread-safe ParallelResult and passed to check.SetResult after completion.
+func ForEachParallel[T any](check *Check, items []T, limit int, fn func(*Check, T, *ParallelResult)) {
+	if limit <= 0 {
+		limit = DefaultParallelLimit
+	}
+
+	result := &ParallelResult{}
+	g := new(errgroup.Group)
+	g.SetLimit(limit)
+
+	for _, item := range items {
+		g.Go(func() error {
+			defer func() {
+				if r := recover(); r != nil {
+					check.LogError("Panic during parallel check execution: %v", r)
+					check.SetResultError(fmt.Sprintf("panic: %v", r))
+				}
+			}()
+			fn(check, item, result)
+			return nil
+		})
+	}
+
+	_ = g.Wait()
+	check.SetResult(result.Results())
+}

--- a/pkg/checksdb/parallel_test.go
+++ b/pkg/checksdb/parallel_test.go
@@ -1,0 +1,96 @@
+package checksdb
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParallelResultThreadSafety(t *testing.T) {
+	r := &ParallelResult{}
+
+	const n = 100
+	done := make(chan struct{})
+
+	for range n {
+		go func() {
+			r.AddCompliantObject(testhelper.NewPodReportObject("ns", "pod", "ok", true))
+			r.AddNonCompliantObject(testhelper.NewPodReportObject("ns", "pod", "fail", false))
+			done <- struct{}{}
+		}()
+	}
+
+	for range n {
+		<-done
+	}
+
+	compliant, nonCompliant := r.Results()
+	assert.Len(t, compliant, n)
+	assert.Len(t, nonCompliant, n)
+}
+
+func TestForEachParallel(t *testing.T) {
+	check := NewCheck("test-parallel", []string{"test"})
+
+	items := []string{"a", "b", "c", "d", "e"}
+
+	ForEachParallel(check, items, 0, func(c *Check, item string, r *ParallelResult) {
+		if item == "c" {
+			c.LogError("item %s is non-compliant", item)
+			r.AddNonCompliantObject(testhelper.NewPodReportObject("ns", item, "bad", false))
+		} else {
+			r.AddCompliantObject(testhelper.NewPodReportObject("ns", item, "ok", true))
+		}
+	})
+
+	assert.Equal(t, "failed", check.Result.String())
+}
+
+func TestForEachParallelAllCompliant(t *testing.T) {
+	check := NewCheck("test-parallel-pass", []string{"test"})
+
+	items := []int{1, 2, 3}
+
+	ForEachParallel(check, items, 2, func(c *Check, item int, r *ParallelResult) {
+		r.AddCompliantObject(testhelper.NewPodReportObject("ns", "pod", "ok", true))
+	})
+
+	assert.Equal(t, "passed", check.Result.String())
+}
+
+func TestForEachParallelEmpty(t *testing.T) {
+	check := NewCheck("test-parallel-empty", []string{"test"})
+
+	ForEachParallel(check, []string{}, 0, func(c *Check, item string, r *ParallelResult) {
+		t.Fatal("should not be called")
+	})
+
+	assert.Equal(t, "skipped", check.Result.String())
+}
+
+func TestForEachParallelRespectsLimit(t *testing.T) {
+	check := NewCheck("test-parallel-limit", []string{"test"})
+
+	var active atomic.Int32
+	var maxActive atomic.Int32
+	items := make([]int, 50)
+	for i := range items {
+		items[i] = i
+	}
+
+	ForEachParallel(check, items, 5, func(c *Check, _ int, r *ParallelResult) {
+		cur := active.Add(1)
+		for {
+			old := maxActive.Load()
+			if cur <= old || maxActive.CompareAndSwap(old, cur) {
+				break
+			}
+		}
+		r.AddCompliantObject(testhelper.NewPodReportObject("ns", "pod", "ok", true))
+		active.Add(-1)
+	})
+
+	assert.LessOrEqual(t, int(maxActive.Load()), 5)
+}

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -763,48 +763,41 @@ func testAutomountServiceToken(check *checksdb.Check, env *provider.TestEnvironm
 	check.SetResult(compliantObjects, nonCompliantObjects)
 }
 
-// testOneProcessPerContainer is a function that checks if each container(except Istio proxy containers) has only one process running.
-// It sets the result of a compliance check based on the analysis of lists of compliant and non-compliant objects.
 func testOneProcessPerContainer(check *checksdb.Check, env *provider.TestEnvironment) {
-	var compliantObjects []*testhelper.ReportObject
-	var nonCompliantObjects []*testhelper.ReportObject
-
-	for _, cut := range env.Containers {
+	checksdb.ForEachParallel(check, env.Containers, 0, func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Container %q", cut)
-		// the Istio sidecar container "istio-proxy" launches two processes: "pilot-agent" and "envoy"
 		if cut.IsIstioProxy() {
 			check.LogInfo("Skipping \"istio-proxy\" container")
-			continue
+			return
 		}
 		probePod := env.ProbePods[cut.NodeName]
 		if probePod == nil {
 			check.LogError("Debug pod not found for node %q", cut.NodeName)
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Debug pod not found for node", false))
 			return
 		}
 		ocpContext := clientsholder.NewContext(probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name)
 		pid, err := crclient.GetPidFromContainer(cut, ocpContext)
 		if err != nil {
 			check.LogError("Could not get PID for Container %q, error: %v", cut, err)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, err.Error(), false))
-			continue
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, err.Error(), false))
+			return
 		}
 
 		nbProcesses, err := getNbOfProcessesInPidNamespace(ocpContext, pid, clientsholder.GetClientsHolder())
 		if err != nil {
 			check.LogError("Could not get number of processes for Container %q, error: %v", cut, err)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, err.Error(), false))
-			continue
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, err.Error(), false))
+			return
 		}
 		if nbProcesses > 1 {
 			check.LogError("Container %q has more than one process running", cut)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container has more than one process running", false))
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container has more than one process running", false))
 		} else {
 			check.LogInfo("Container %q has only one process running", cut)
-			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container has only one process running", true))
+			result.AddCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container has only one process running", true))
 		}
-	}
-
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	})
 }
 
 // testSYSNiceRealtimeCapability is a function that checks if each container running on a realtime kernel enabled node has the SYS_NICE capability.
@@ -903,56 +896,47 @@ const (
 	sshServicePortProtocol = "TCP"
 )
 
-// testNoSSHDaemonsAllowed is a function that checks if each pod is running an SSH daemon.
-// It sets the result of a compliance check based on the analysis of lists of compliant and non-compliant objects.
 func testNoSSHDaemonsAllowed(check *checksdb.Check, env *provider.TestEnvironment) {
-	var compliantObjects []*testhelper.ReportObject
-	var nonCompliantObjects []*testhelper.ReportObject
-
-	for _, put := range env.Pods {
+	checksdb.ForEachParallel(check, env.Pods, 0, func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Pod %q", put)
 		cut := put.Containers[0]
 
-		// 1. Find SSH port
 		port, err := netutil.GetSSHDaemonPort(cut)
 		if err != nil {
 			check.LogError("Could not get ssh daemon port on %q, err: %v", cut, err)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Failed to get the ssh port for pod", false))
-			continue
+			result.AddNonCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, "Failed to get the ssh port for pod", false))
+			return
 		}
 
 		if port == "" {
 			check.LogInfo("Pod %q is not running an SSH daemon", put)
-			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is not running an SSH daemon", true))
-			continue
+			result.AddCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is not running an SSH daemon", true))
+			return
 		}
 
 		sshServicePortNumber, err := strconv.ParseInt(port, 10, 32)
 		if err != nil {
 			check.LogError("Could not convert port %q from string to integer on Container %q", port, cut)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Failed to get the listening ports for pod", false))
-			continue
+			result.AddNonCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, "Failed to get the listening ports for pod", false))
+			return
 		}
 
-		// 2. Check if SSH port is listening
 		sshPortInfo := netutil.PortInfo{PortNumber: int32(sshServicePortNumber), Protocol: sshServicePortProtocol}
 		listeningPorts, err := netutil.GetListeningPorts(cut)
 		if err != nil {
 			check.LogError("Failed to get the listening ports for Pod %q, err: %v", put, err)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Failed to get the listening ports for pod", false))
-			continue
+			result.AddNonCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, "Failed to get the listening ports for pod", false))
+			return
 		}
 
 		if _, ok := listeningPorts[sshPortInfo]; ok {
 			check.LogError("Pod %q is running an SSH daemon", put)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is running an SSH daemon", false))
+			result.AddNonCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is running an SSH daemon", false))
 		} else {
 			check.LogInfo("Pod %q is not running an SSH daemon", put)
-			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is not running an SSH daemon", true))
+			result.AddCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is not running an SSH daemon", true))
 		}
-	}
-
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	})
 }
 
 // testPodRequests is a function that checks if each container has resource requests.

--- a/tests/networking/netcommons/netcommons.go
+++ b/tests/networking/netcommons/netcommons.go
@@ -19,13 +19,9 @@ package netcommons
 import (
 	"fmt"
 	"net"
-	"strconv"
 	"strings"
 
-	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
-	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
-	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/netutil"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -151,32 +147,6 @@ func FilterIPListByIPVersion(ipList []string, aIPVersion IPVersion) []string {
 	return filteredIPList
 }
 
-func findRogueContainersDeclaringPorts(containers []*provider.Container, portsToTest map[int32]bool, portsOrigin string, logger *log.Logger) (compliantObjects, nonCompliantObjects []*testhelper.ReportObject) {
-	for _, cut := range containers {
-		logger.Info("Testing Container %q", cut)
-		for _, port := range cut.Ports {
-			if portsToTest[port.ContainerPort] {
-				logger.Error("%q declares %s reserved port %d (%s)", cut, portsOrigin, port.ContainerPort, port.Protocol)
-				nonCompliantObjects = append(nonCompliantObjects,
-					testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name,
-						fmt.Sprintf("Container declares %s reserved port in %v", portsOrigin, portsToTest), false).
-						SetType(testhelper.DeclaredPortType).
-						AddField(testhelper.PortNumber, strconv.Itoa(int(port.ContainerPort))).
-						AddField(testhelper.PortProtocol, string(port.Protocol)))
-			} else {
-				logger.Info("%q does not declare any %s reserved port", cut, portsOrigin)
-				compliantObjects = append(compliantObjects,
-					testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name,
-						fmt.Sprintf("Container does not declare %s reserved port in %v", portsOrigin, portsToTest), true).
-						SetType(testhelper.DeclaredPortType).
-						AddField(testhelper.PortNumber, strconv.Itoa(int(port.ContainerPort))).
-						AddField(testhelper.PortProtocol, string(port.Protocol)))
-			}
-		}
-	}
-	return compliantObjects, nonCompliantObjects
-}
-
 var ReservedIstioPorts = map[int32]bool{
 	// https://istio.io/latest/docs/ops/deployment/requirements/#ports-used-by-istio
 	15090: true, // Envoy Prometheus telemetry
@@ -189,68 +159,4 @@ var ReservedIstioPorts = map[int32]bool{
 	15004: true, // Debug port
 	15001: true, // Envoy outbound
 	15000: true, // Envoy admin port (commands/diagnostics)
-}
-
-func findRoguePodsListeningToPorts(pods []*provider.Pod, portsToTest map[int32]bool, portsOrigin string, logger *log.Logger) (compliantObjects, nonCompliantObjects []*testhelper.ReportObject) {
-	for _, put := range pods {
-		logger.Info("Testing Pod %q", put)
-		compliantObjectsEntries, nonCompliantObjectsEntries := findRogueContainersDeclaringPorts(put.Containers, portsToTest, portsOrigin, logger)
-		nonCompliantPortFound := len(nonCompliantObjectsEntries) > 0
-		compliantObjects = append(compliantObjects, compliantObjectsEntries...)
-		nonCompliantObjects = append(nonCompliantObjects, nonCompliantObjectsEntries...)
-		cut := put.Containers[0]
-		listeningPorts, err := netutil.GetListeningPorts(cut)
-		if err != nil {
-			logger.Error("Failed to get the listening ports on %q, err: %v", cut, err)
-			nonCompliantObjects = append(nonCompliantObjects,
-				testhelper.NewPodReportObject(cut.Namespace, put.Name,
-					fmt.Sprintf("Failed to get the listening ports on pod, err: %v", err), false))
-			continue
-		}
-		for port := range listeningPorts {
-			if ok := portsToTest[port.PortNumber]; ok {
-				// If pod contains an "istio-proxy" container, we need to make sure that the ports returned
-				// overlap with the known istio ports
-				if put.ContainsIstioProxy() && ReservedIstioPorts[port.PortNumber] {
-					logger.Info("%q was found to be listening to port %d due to istio-proxy being present. Ignoring.", put, port.PortNumber)
-					continue
-				}
-
-				logger.Error("%q has one container (%q) listening on port %d (%s) that has been reserved", put, cut.Name, port.PortNumber, port.Protocol)
-				nonCompliantObjects = append(nonCompliantObjects,
-					testhelper.NewPodReportObject(cut.Namespace, put.Name,
-						fmt.Sprintf("Pod Listens to %s reserved port in %v", portsOrigin, portsToTest), false).
-						SetType(testhelper.ListeningPortType).
-						AddField(testhelper.PortNumber, strconv.Itoa(int(port.PortNumber))).
-						AddField(testhelper.PortProtocol, port.Protocol))
-				nonCompliantPortFound = true
-			} else {
-				logger.Info("%q listens in %s unreserved port %d (%s)", put, portsOrigin, port.PortNumber, port.Protocol)
-				compliantObjects = append(compliantObjects,
-					testhelper.NewPodReportObject(cut.Namespace, put.Name,
-						fmt.Sprintf("Pod Listens to port not in %s reserved port %v", portsOrigin, portsToTest), true).
-						SetType(testhelper.ListeningPortType).
-						AddField(testhelper.PortNumber, strconv.Itoa(int(port.PortNumber))).
-						AddField(testhelper.PortProtocol, port.Protocol))
-			}
-		}
-		if nonCompliantPortFound {
-			nonCompliantObjects = append(nonCompliantObjects,
-				testhelper.NewPodReportObject(cut.Namespace, put.Name,
-					fmt.Sprintf("Pod listens to or its containers declares some %s reserved port in %v", portsOrigin, portsToTest), false))
-			continue
-		}
-		compliantObjects = append(compliantObjects,
-			testhelper.NewPodReportObject(cut.Namespace, put.Name,
-				fmt.Sprintf("Pod does not listen to or declare any %s reserved port in %v", portsOrigin, portsToTest), true))
-	}
-	return compliantObjects, nonCompliantObjects
-}
-
-func TestReservedPortsUsage(env *provider.TestEnvironment, reservedPorts map[int32]bool, portsOrigin string, logger *log.Logger) (compliantObjects, nonCompliantObjects []*testhelper.ReportObject) {
-	compliantObjectsEntries, nonCompliantObjectsEntries := findRoguePodsListeningToPorts(env.Pods, reservedPorts, portsOrigin, logger)
-	compliantObjects = append(compliantObjects, compliantObjectsEntries...)
-	nonCompliantObjects = append(nonCompliantObjects, nonCompliantObjectsEntries...)
-
-	return compliantObjects, nonCompliantObjects
 }

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -159,40 +159,31 @@ func LoadChecks() {
 		}))
 }
 
-//nolint:funlen
 func testUndeclaredContainerPortsUsage(check *checksdb.Check, env *provider.TestEnvironment) {
-	var compliantObjects []*testhelper.ReportObject
-	var nonCompliantObjects []*testhelper.ReportObject
-	var portInfo netutil.PortInfo
-	for _, put := range env.Pods {
-		// First get the ports declared in the Pod's containers spec
+	checksdb.ForEachParallel(check, env.Pods, 0, func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
 		declaredPorts := make(map[netutil.PortInfo]bool)
 		for _, cut := range put.Containers {
 			check.LogInfo("Testing Container %q", cut)
 			for _, port := range cut.Ports {
-				portInfo.PortNumber = port.ContainerPort
-				portInfo.Protocol = string(port.Protocol)
-				declaredPorts[portInfo] = true
+				declaredPorts[netutil.PortInfo{PortNumber: port.ContainerPort, Protocol: string(port.Protocol)}] = true
 			}
 		}
 
-		// Then check the actual ports that the containers are listening on
 		firstPodContainer := put.Containers[0]
 		listeningPorts, err := netutil.GetListeningPorts(firstPodContainer)
 		if err != nil {
 			check.LogError("Failed to get container %q listening ports, err: %v", firstPodContainer, err)
-			nonCompliantObjects = append(nonCompliantObjects,
+			result.AddNonCompliantObject(
 				testhelper.NewPodReportObject(put.Namespace, put.Name, fmt.Sprintf("Failed to get the container's listening ports, err: %v", err), false))
-			continue
+			return
 		}
 		if len(listeningPorts) == 0 {
 			check.LogInfo("None of the containers of %q have any listening port.", put)
-			compliantObjects = append(compliantObjects,
+			result.AddCompliantObject(
 				testhelper.NewPodReportObject(put.Namespace, put.Name, "None of the containers have any listening ports", true))
-			continue
+			return
 		}
 
-		// Verify that all the listening ports have been declared in the container spec
 		failedPod := false
 		for listeningPort := range listeningPorts {
 			if put.ContainsIstioProxy() && netcommons.ReservedIstioPorts[listeningPort.PortNumber] {
@@ -205,7 +196,7 @@ func testUndeclaredContainerPortsUsage(check *checksdb.Check, env *provider.Test
 				check.LogError("%q is listening on port %d protocol %q, but that port was not declared in any container spec.",
 					put, listeningPort.PortNumber, listeningPort.Protocol)
 				failedPod = true
-				nonCompliantObjects = append(nonCompliantObjects,
+				result.AddNonCompliantObject(
 					testhelper.NewPodReportObject(put.Namespace, put.Name,
 						"Listening port was declared in no container spec", false).
 						SetType(testhelper.ListeningPortType).
@@ -213,7 +204,7 @@ func testUndeclaredContainerPortsUsage(check *checksdb.Check, env *provider.Test
 						AddField(testhelper.PortProtocol, listeningPort.Protocol))
 			} else {
 				check.LogInfo("%q is listening on declared port %d protocol %q", put, listeningPort.PortNumber, listeningPort.Protocol)
-				compliantObjects = append(compliantObjects,
+				result.AddCompliantObject(
 					testhelper.NewPodReportObject(put.Namespace, put.Name,
 						"Listening port was declared in container spec", true).
 						SetType(testhelper.ListeningPortType).
@@ -222,14 +213,13 @@ func testUndeclaredContainerPortsUsage(check *checksdb.Check, env *provider.Test
 			}
 		}
 		if failedPod {
-			nonCompliantObjects = append(nonCompliantObjects,
+			result.AddNonCompliantObject(
 				testhelper.NewPodReportObject(put.Namespace, put.Name, "At least one port was listening but not declared in any container specs", false))
 		} else {
-			compliantObjects = append(compliantObjects,
+			result.AddCompliantObject(
 				testhelper.NewPodReportObject(put.Namespace, put.Name, "All listening were declared in containers specs", true))
 		}
-	}
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	})
 }
 
 // testDefaultNetworkConnectivity test the connectivity between the default interfaces of containers under test
@@ -244,16 +234,13 @@ func testNetworkConnectivity(env *provider.TestEnvironment, aIPVersion netcommon
 }
 
 func testOCPReservedPortsUsage(check *checksdb.Check, env *provider.TestEnvironment) {
-	// List of all ports reserved by OpenShift
 	OCPReservedPorts := map[int32]bool{
 		22623: true,
 		22624: true}
-	compliantObjects, nonCompliantObjects := netcommons.TestReservedPortsUsage(env, OCPReservedPorts, "OCP", check.GetLogger())
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	testReservedPortsUsageParallel(check, env, OCPReservedPorts, "OCP")
 }
 
 func testPartnerSpecificTCPPorts(check *checksdb.Check, env *provider.TestEnvironment) {
-	// List of all of the ports reserved by partner
 	ReservedPorts := map[int32]bool{
 		15443: true,
 		15090: true,
@@ -265,8 +252,81 @@ func testPartnerSpecificTCPPorts(check *checksdb.Check, env *provider.TestEnviro
 		15001: true,
 		15000: true,
 	}
-	compliantObjects, nonCompliantObjects := netcommons.TestReservedPortsUsage(env, ReservedPorts, "Partner", check.GetLogger())
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	testReservedPortsUsageParallel(check, env, ReservedPorts, "Partner")
+}
+
+//nolint:funlen
+func testReservedPortsUsageParallel(check *checksdb.Check, env *provider.TestEnvironment, portsToTest map[int32]bool, portsOrigin string) {
+	checksdb.ForEachParallel(check, env.Pods, 0, func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
+		check.LogInfo("Testing Pod %q", put)
+
+		nonCompliantPortFound := false
+		for _, cut := range put.Containers {
+			for _, port := range cut.Ports {
+				if portsToTest[port.ContainerPort] {
+					check.LogError("%q declares %s reserved port %d (%s)", cut, portsOrigin, port.ContainerPort, port.Protocol)
+					result.AddNonCompliantObject(
+						testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name,
+							fmt.Sprintf("Container declares %s reserved port in %v", portsOrigin, portsToTest), false).
+							SetType(testhelper.DeclaredPortType).
+							AddField(testhelper.PortNumber, strconv.Itoa(int(port.ContainerPort))).
+							AddField(testhelper.PortProtocol, string(port.Protocol)))
+					nonCompliantPortFound = true
+				} else {
+					result.AddCompliantObject(
+						testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name,
+							fmt.Sprintf("Container does not declare %s reserved port in %v", portsOrigin, portsToTest), true).
+							SetType(testhelper.DeclaredPortType).
+							AddField(testhelper.PortNumber, strconv.Itoa(int(port.ContainerPort))).
+							AddField(testhelper.PortProtocol, string(port.Protocol)))
+				}
+			}
+		}
+
+		firstContainer := put.Containers[0]
+		listeningPorts, err := netutil.GetListeningPorts(firstContainer)
+		if err != nil {
+			check.LogError("Failed to get the listening ports on %q, err: %v", firstContainer, err)
+			result.AddNonCompliantObject(
+				testhelper.NewPodReportObject(firstContainer.Namespace, put.Name,
+					fmt.Sprintf("Failed to get the listening ports on pod, err: %v", err), false))
+			return
+		}
+		for port := range listeningPorts {
+			if ok := portsToTest[port.PortNumber]; ok {
+				if put.ContainsIstioProxy() && netcommons.ReservedIstioPorts[port.PortNumber] {
+					check.LogInfo("%q was found to be listening to port %d due to istio-proxy being present. Ignoring.", put, port.PortNumber)
+					continue
+				}
+
+				check.LogError("%q has one container (%q) listening on port %d (%s) that has been reserved", put, firstContainer.Name, port.PortNumber, port.Protocol)
+				result.AddNonCompliantObject(
+					testhelper.NewPodReportObject(firstContainer.Namespace, put.Name,
+						fmt.Sprintf("Pod Listens to %s reserved port in %v", portsOrigin, portsToTest), false).
+						SetType(testhelper.ListeningPortType).
+						AddField(testhelper.PortNumber, strconv.Itoa(int(port.PortNumber))).
+						AddField(testhelper.PortProtocol, port.Protocol))
+				nonCompliantPortFound = true
+			} else {
+				check.LogInfo("%q listens in %s unreserved port %d (%s)", put, portsOrigin, port.PortNumber, port.Protocol)
+				result.AddCompliantObject(
+					testhelper.NewPodReportObject(firstContainer.Namespace, put.Name,
+						fmt.Sprintf("Pod Listens to port not in %s reserved port %v", portsOrigin, portsToTest), true).
+						SetType(testhelper.ListeningPortType).
+						AddField(testhelper.PortNumber, strconv.Itoa(int(port.PortNumber))).
+						AddField(testhelper.PortProtocol, port.Protocol))
+			}
+		}
+		if nonCompliantPortFound {
+			result.AddNonCompliantObject(
+				testhelper.NewPodReportObject(firstContainer.Namespace, put.Name,
+					fmt.Sprintf("Pod listens to or its containers declares some %s reserved port in %v", portsOrigin, portsToTest), false))
+		} else {
+			result.AddCompliantObject(
+				testhelper.NewPodReportObject(firstContainer.Namespace, put.Name,
+					fmt.Sprintf("Pod does not listen to or declare any %s reserved port in %v", portsOrigin, portsToTest), true))
+		}
+	})
 }
 
 func testDualStackServices(check *checksdb.Check, env *provider.TestEnvironment) {

--- a/tests/observability/suite.go
+++ b/tests/observability/suite.go
@@ -119,32 +119,26 @@ func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 }
 
 func testContainersLogging(check *checksdb.Check, env *provider.TestEnvironment) {
-	// Iterate through all the CUTs to get their log output. The TC checks that at least
-	// one log line is found.
-	var compliantObjects []*testhelper.ReportObject
-	var nonCompliantObjects []*testhelper.ReportObject
-	for _, cut := range env.Containers {
+	checksdb.ForEachParallel(check, env.Containers, 0, func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Container %q", cut)
 		hasLoggingOutput, err := containerHasLoggingOutput(cut)
 		if err != nil {
 			check.LogError("Failed to get %q log output, err: %v", cut, err)
-			nonCompliantObjects = append(nonCompliantObjects,
+			result.AddNonCompliantObject(
 				testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Could not get log output", false))
-			continue
+			return
 		}
 
 		if !hasLoggingOutput {
 			check.LogError("Container %q does not have any line of log to stderr/stdout", cut)
-			nonCompliantObjects = append(nonCompliantObjects,
+			result.AddNonCompliantObject(
 				testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "No log line to stderr/stdout found", false))
 		} else {
 			check.LogInfo("Container %q has some logging output", cut)
-			compliantObjects = append(compliantObjects,
+			result.AddCompliantObject(
 				testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Found log line to stderr/stdout", true))
 		}
-	}
-
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	})
 }
 
 // testCrds testing if crds have a status sub resource set

--- a/tests/performance/suite.go
+++ b/tests/performance/suite.go
@@ -251,38 +251,31 @@ func testExclusiveCPUPool(check *checksdb.Check, env *provider.TestEnvironment) 
 
 func testSchedulingPolicyInCPUPool(check *checksdb.Check, env *provider.TestEnvironment,
 	podContainers []*provider.Container, schedulingType string) {
-	var compliantContainersPids []*testhelper.ReportObject
-	var nonCompliantContainersPids []*testhelper.ReportObject
-	for _, cut := range podContainers {
+	checksdb.ForEachParallel(check, podContainers, 0, func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Container %q", cut)
 
-		// Get the pid namespace
 		pidNamespace, err := crclient.GetContainerPidNamespace(cut, env)
 		if err != nil {
 			check.LogError("Unable to get pid namespace for Container %q, err: %v", cut, err)
-			nonCompliantContainersPids = append(nonCompliantContainersPids,
+			result.AddNonCompliantObject(
 				testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, fmt.Sprintf("Internal error, err=%s", err), false))
-			continue
+			return
 		}
 		check.LogDebug("PID namespace for Container %q is %q", cut, pidNamespace)
 
-		// Get the list of process ids running in the pid namespace
 		processes, err := crclient.GetPidsFromPidNamespace(pidNamespace, cut)
 		if err != nil {
 			check.LogError("Unable to get PIDs from PID namespace %q for Container %q, err: %v", pidNamespace, cut, err)
-			nonCompliantContainersPids = append(nonCompliantContainersPids,
+			result.AddNonCompliantObject(
 				testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, fmt.Sprintf("Internal error, err=%s", err), false))
-			continue
+			return
 		}
 
 		compliantPids, nonCompliantPids := scheduling.ProcessPidsCPUScheduling(processes, cut, schedulingType, check.GetLogger())
-		// Check for the specified priority for each processes running in that pid namespace
 
-		compliantContainersPids = append(compliantContainersPids, compliantPids...)
-		nonCompliantContainersPids = append(nonCompliantContainersPids, nonCompliantPids...)
-	}
-
-	check.SetResult(compliantContainersPids, nonCompliantContainersPids)
+		result.AddCompliantObjects(compliantPids)
+		result.AddNonCompliantObjects(nonCompliantPids)
+	})
 }
 
 func getExecProbesCmds(c *provider.Container) map[string]bool {
@@ -310,42 +303,38 @@ func getExecProbesCmds(c *provider.Container) map[string]bool {
 }
 
 func testRtAppsNoExecProbes(check *checksdb.Check, env *provider.TestEnvironment) {
-	var compliantObjects []*testhelper.ReportObject
-	var nonCompliantObjects []*testhelper.ReportObject
 	cuts := env.GetNonGuaranteedPodContainersWithoutHostPID()
-	for _, cut := range cuts {
+	checksdb.ForEachParallel(check, cuts, 0, func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Container %q", cut)
 		if !cut.HasExecProbes() {
 			check.LogInfo("Container %q does not define exec probes", cut)
-			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container does not define exec probes", true))
-			continue
+			result.AddCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container does not define exec probes", true))
+			return
 		}
 
 		processes, err := crclient.GetContainerProcesses(cut, env)
 		if err != nil {
 			check.LogError("Could not determine the processes pids for container %q, err: %v", cut, err)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Could not determine the processes pids for container", false))
-			break
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Could not determine the processes pids for container", false))
+			return
 		}
 
 		notExecProbeProcesses, compliantObjectsProbes := filterProbeProcesses(processes, cut)
-		compliantObjects = append(compliantObjects, compliantObjectsProbes...)
+		result.AddCompliantObjects(compliantObjectsProbes)
 		allProcessesCompliant := true
 		for _, p := range notExecProbeProcesses {
 			check.LogInfo("Testing process %q", p)
 			schedPolicy, _, err := scheduling.GetProcessCPUScheduling(p.Pid, cut)
 			if err != nil {
-				// If the process does not exist anymore it means that it has finished since the time the process list
-				// was retrieved. In this case, just ignore the error and continue processing the rest of the processes.
 				if strings.Contains(err.Error(), scheduling.NoProcessFoundErrMsg) {
 					check.LogWarn("Container process %q disappeared", p)
-					compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container process disappeared", true).
+					result.AddCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container process disappeared", true).
 						AddField(testhelper.ProcessID, strconv.Itoa(p.Pid)).
 						AddField(testhelper.ProcessCommandLine, p.Args))
 					continue
 				}
 				check.LogError("Could not determine the scheduling policy for container %q (pid=%d), err: %v", cut, p.Pid, err)
-				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Could not determine the scheduling policy for container", false).
+				result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Could not determine the scheduling policy for container", false).
 					AddField(testhelper.ProcessID, strconv.Itoa(p.Pid)).
 					AddField(testhelper.ProcessCommandLine, p.Args))
 				allProcessesCompliant = false
@@ -353,7 +342,7 @@ func testRtAppsNoExecProbes(check *checksdb.Check, env *provider.TestEnvironment
 			}
 			if scheduling.PolicyIsRT(schedPolicy) {
 				check.LogError("Container %q defines exec probes while having a RT scheduling policy for process %q", cut, p)
-				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container defines exec probes while having a RT scheduling policy", false).
+				result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container defines exec probes while having a RT scheduling policy", false).
 					AddField(testhelper.ProcessID, strconv.Itoa(p.Pid)))
 				allProcessesCompliant = false
 			}
@@ -361,11 +350,9 @@ func testRtAppsNoExecProbes(check *checksdb.Check, env *provider.TestEnvironment
 
 		if allProcessesCompliant {
 			check.LogInfo("Container %q defines exec probes but does not have a RT scheduling policy", cut)
-			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container defines exec probes but does not have a RT scheduling policy", true))
+			result.AddCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container defines exec probes but does not have a RT scheduling policy", true))
 		}
-	}
-
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	})
 }
 
 func filterProbeProcesses(allProcesses []*crclient.Process, cut *provider.Container) (notExecProbeProcesses []*crclient.Process, compliantObjects []*testhelper.ReportObject) {

--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -37,6 +37,8 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/platform/sysctlconfig"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/platform/nodetainted"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -174,26 +176,23 @@ func LoadChecks() {
 }
 
 func testHyperThreadingEnabled(check *checksdb.Check, env *provider.TestEnvironment) {
-	var compliantObjects []*testhelper.ReportObject
-	var nonCompliantObjects []*testhelper.ReportObject
 	baremetalNodes := env.GetBaremetalNodes()
-	for _, node := range baremetalNodes {
+	checksdb.ForEachParallel(check, baremetalNodes, 0, func(check *checksdb.Check, node provider.Node, result *checksdb.ParallelResult) {
 		nodeName := node.Data.Name
 		check.LogInfo("Testing node %q", nodeName)
 		enable, err := node.IsHyperThreadNode(env)
 		//nolint:gocritic
 		if enable {
 			check.LogInfo("Node %q has hyperthreading enabled", nodeName)
-			compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(nodeName, "Node has hyperthreading enabled", true))
+			result.AddCompliantObject(testhelper.NewNodeReportObject(nodeName, "Node has hyperthreading enabled", true))
 		} else if err != nil {
 			check.LogError("Hyperthreading check fail for node %q, err: %v", nodeName, err)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(nodeName, "Error with executing the check for hyperthreading: "+err.Error(), false))
+			result.AddNonCompliantObject(testhelper.NewNodeReportObject(nodeName, "Error with executing the check for hyperthreading: "+err.Error(), false))
 		} else {
 			check.LogError("Node %q has hyperthreading disabled", nodeName)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(nodeName, "Node has hyperthreading disabled ", false))
+			result.AddNonCompliantObject(testhelper.NewNodeReportObject(nodeName, "Node has hyperthreading disabled ", false))
 		}
-	}
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	})
 }
 
 func testServiceMesh(check *checksdb.Check, env *provider.TestEnvironment) {
@@ -223,24 +222,21 @@ func testServiceMesh(check *checksdb.Check, env *provider.TestEnvironment) {
 
 // testContainersFsDiff test that all CUT did not install new packages are starting
 func testContainersFsDiff(check *checksdb.Check, env *provider.TestEnvironment) {
-	var compliantObjects []*testhelper.ReportObject
-	var nonCompliantObjects []*testhelper.ReportObject
-	for _, cut := range env.Containers {
+	// podman diff is resource-heavy; limit concurrency to avoid OOM on probe pods
+	checksdb.ForEachParallel(check, env.Containers, len(env.ProbePods), func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Container %q", cut)
 		probePod := env.ProbePods[cut.NodeName]
 
-		// If the probe pod is not found, we cannot run the test.
 		if probePod == nil {
 			check.LogError("Probe Pod not found for node %q", cut.NodeName)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "certsuite probe pod not found", false))
-			continue
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "certsuite probe pod not found", false))
+			return
 		}
 
-		// Check whether or not a container is available to prevent a panic.
 		if len(probePod.Spec.Containers) == 0 {
 			check.LogError("Probe Pod %q has no containers", probePod)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "certsuite probe pod has no containers", false))
-			continue
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "certsuite probe pod has no containers", false))
+			return
 		}
 
 		ctxt := clientsholder.NewContext(probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name)
@@ -249,179 +245,124 @@ func testContainersFsDiff(check *checksdb.Check, env *provider.TestEnvironment) 
 		switch fsDiffTester.GetResults() {
 		case testhelper.SUCCESS:
 			check.LogInfo("Container %q is not modified", cut)
-			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container is not modified", true))
-			continue
+			result.AddCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container is not modified", true))
 		case testhelper.FAILURE:
 			check.LogError("Container %q modified (changed folders: %v, deleted folders: %v", cut, fsDiffTester.ChangedFolders, fsDiffTester.DeletedFolders)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container is modified", false).
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container is modified", false).
 				AddField("ChangedFolders", strings.Join(fsDiffTester.ChangedFolders, ",")).
 				AddField("DeletedFolders", strings.Join(fsDiffTester.DeletedFolders, ",")))
-
 		case testhelper.ERROR:
 			check.LogError("Could not run fs-diff in Container %q, err: %v", cut, fsDiffTester.Error)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Error while running fs-diff", false).AddField(testhelper.Error, fsDiffTester.Error.Error()))
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Error while running fs-diff", false).AddField(testhelper.Error, fsDiffTester.Error.Error()))
 		}
-	}
-
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	})
 }
 
 //nolint:funlen
 func testTainted(check *checksdb.Check, env *provider.TestEnvironment) {
-	var compliantObjects []*testhelper.ReportObject
-	var nonCompliantObjects []*testhelper.ReportObject
-
-	// errNodes has nodes that failed some operation while checking kernel taints.
-	errNodes := []string{}
-
-	type badModuleTaints struct {
-		name   string
-		taints []string
-	}
-
-	// badModules maps node names to list of "bad"/offending modules.
-	badModules := map[string][]badModuleTaints{}
-	// otherTaints maps a node to a list of taint bits that haven't been set by any module.
-	otherTaints := map[string][]int{}
-
 	check.LogInfo("Modules allowlist: %+v", env.Config.AcceptedKernelTaints)
-	// helper map to make the checks easier.
 	allowListedModules := map[string]bool{}
 	for _, module := range env.Config.AcceptedKernelTaints {
 		allowListedModules[module.Module] = true
 	}
 
-	// Loop through the probe pods that are tied to each node.
+	// Filter to nodes with workload deployed before parallelizing.
+	var workloadNodes []provider.Node
 	for _, n := range env.Nodes {
+		if n.HasWorkloadDeployed(env.Pods) {
+			workloadNodes = append(workloadNodes, n)
+		} else {
+			check.LogInfo("Node %q has no workload deployed on it. Skipping tainted kernel check.", n.Data.Name)
+		}
+	}
+
+	checksdb.ForEachParallel(check, workloadNodes, 0, func(check *checksdb.Check, n provider.Node, result *checksdb.ParallelResult) {
 		nodeName := n.Data.Name
 		check.LogInfo("Testing node %q", nodeName)
-
-		// Ensure we are only testing nodes that have CNF workload deployed on them.
-		if !n.HasWorkloadDeployed(env.Pods) {
-			check.LogInfo("Node %q has no workload deployed on it. Skipping tainted kernel check.", nodeName)
-			continue
-		}
 
 		dp := env.ProbePods[nodeName]
 
 		ocpContext := clientsholder.NewContext(dp.Namespace, dp.Name, dp.Spec.Containers[0].Name)
 		tf := nodetainted.NewNodeTaintedTester(&ocpContext, nodeName)
 
-		// Get the taints mask from the node kernel
 		taintsMask, err := tf.GetKernelTaintsMask()
 		if err != nil {
 			check.LogError("Failed to retrieve kernel taint information from node %q, err: %v", nodeName, err)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(nodeName, "Failed to retrieve kernel taint information from node", false).
+			result.AddNonCompliantObject(testhelper.NewNodeReportObject(nodeName, "Failed to retrieve kernel taint information from node", false).
 				AddField(testhelper.Error, err.Error()))
-			continue
+			return
 		}
 
 		if taintsMask == 0 {
 			check.LogInfo("Node %q has no non-approved kernel taints.", nodeName)
-			compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(nodeName, "Node has no non-approved kernel taints", true))
-			continue
+			result.AddCompliantObject(testhelper.NewNodeReportObject(nodeName, "Node has no non-approved kernel taints", true))
+			return
 		}
 
 		check.LogInfo("Node %q kernel is tainted. Taints mask=%d - Decoded taints: %v",
 			nodeName, taintsMask, nodetainted.DecodeKernelTaintsFromBitMask(taintsMask))
 
-		// Check the allow list. If empty, mark this node as failed.
 		if len(allowListedModules) == 0 {
 			taintsMaskStr := strconv.FormatUint(taintsMask, 10)
 			taintsStr := strings.Join(nodetainted.DecodeKernelTaintsFromBitMask(taintsMask), ",")
 			check.LogError("Node %q contains taints not covered by module allowlist. Taints: %q (mask=%q)", nodeName, taintsStr, taintsMaskStr)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(nodeName, "Node contains taints not covered by module allowlist", false).
+			result.AddNonCompliantObject(testhelper.NewNodeReportObject(nodeName, "Node contains taints not covered by module allowlist", false).
 				AddField(testhelper.TaintMask, taintsMaskStr).
 				AddField(testhelper.Taints, taintsStr))
-			continue
+			return
 		}
 
-		// allow list check.
-		// Get the list of modules (tainters) that have set a taint bit.
-		//   1. Each module should appear in the allow list.
-		//   2. All kernel taint bits (one bit <-> one letter) should have been set by at least
-		//      one tainter module.
 		tainters, taintBitsByAllModules, err := tf.GetTainterModules(allowListedModules)
 		if err != nil {
 			check.LogError("Could not get tainter modules from node %q, err: %v", nodeName, err)
-			errNodes = append(errNodes, nodeName)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(nodeName, "Failed to get tainter modules", false).
+			result.AddNonCompliantObject(testhelper.NewNodeReportObject(nodeName, "Failed to get tainter modules", false).
 				AddField(testhelper.Error, err.Error()))
-			continue
+			return
 		}
 
-		// Keep track of whether or not this node is compliant with module allow list.
 		compliantNode := true
 
-		// Save modules' names only.
 		for moduleName, taintsLetters := range tainters {
 			moduleTaints := nodetainted.DecodeKernelTaintsFromLetters(taintsLetters)
-			badModules[nodeName] = append(badModules[nodeName], badModuleTaints{name: moduleName, taints: moduleTaints})
-
-			// Create non-compliant taint objects for each of the taints
 			for _, taint := range moduleTaints {
 				check.LogError("Node %q - module %q taints kernel: %q", nodeName, moduleName, taint)
-				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewTaintReportObject(nodetainted.RemoveAllExceptNumbers(taint), nodeName, taint, false).AddField(testhelper.ModuleName, moduleName))
-
-				// Set the node as non-compliant for future reporting
+				result.AddNonCompliantObject(testhelper.NewTaintReportObject(nodetainted.RemoveAllExceptNumbers(taint), nodeName, taint, false).AddField(testhelper.ModuleName, moduleName))
 				compliantNode = false
 			}
 		}
 
-		// Lastly, check that all kernel taint bits come from modules.
 		otherKernelTaints := nodetainted.GetOtherTaintedBits(taintsMask, taintBitsByAllModules)
 		for _, taintedBit := range otherKernelTaints {
 			check.LogError("Node %q - taint bit %d is set but it is not caused by any module.", nodeName, taintedBit)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewTaintReportObject(strconv.Itoa(taintedBit), nodeName, nodetainted.GetTaintMsg(taintedBit), false).
+			result.AddNonCompliantObject(testhelper.NewTaintReportObject(strconv.Itoa(taintedBit), nodeName, nodetainted.GetTaintMsg(taintedBit), false).
 				AddField(testhelper.ModuleName, "N/A"))
-			otherTaints[nodeName] = append(otherTaints[nodeName], taintedBit)
-
-			// Set the node as non-compliant for future reporting
 			compliantNode = false
 		}
 
 		if compliantNode {
 			check.LogInfo("Node %q passed the tainted kernel check", nodeName)
-			compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(nodeName, "Passed the tainted kernel check", true))
+			result.AddCompliantObject(testhelper.NewNodeReportObject(nodeName, "Passed the tainted kernel check", true))
 		}
-	}
-
-	if len(errNodes) > 0 {
-		check.LogError("Failed to get kernel taints from some nodes: %+v", errNodes)
-	}
-
-	if len(badModules) > 0 || len(otherTaints) > 0 {
-		check.LogError("Nodes have been found to be tainted. Tainted modules: %+v", badModules)
-	}
-
-	if len(otherTaints) > 0 {
-		check.LogError("Taints not related to any module: %+v", otherTaints)
-	}
-
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	})
 }
 
 func testIsRedHatRelease(check *checksdb.Check, env *provider.TestEnvironment) {
-	var compliantObjects []*testhelper.ReportObject
-	var nonCompliantObjects []*testhelper.ReportObject
-	for _, cut := range env.Containers {
+	checksdb.ForEachParallel(check, env.Containers, 0, func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Container %q", cut)
 		baseImageTester := isredhat.NewBaseImageTester(clientsholder.GetClientsHolder(), clientsholder.NewContext(cut.Namespace, cut.Podname, cut.Name))
 
-		result, err := baseImageTester.TestContainerIsRedHatRelease()
+		passed, err := baseImageTester.TestContainerIsRedHatRelease()
 		if err != nil {
 			check.LogError("Could not collect release information from Container %q, err=%v", cut, err)
 		}
-		if !result {
+		if !passed {
 			check.LogError("Container %q has failed the RHEL release check", cut)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Failed the RHEL release check", false))
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Failed the RHEL release check", false))
 		} else {
 			check.LogInfo("Container %q has passed the RHEL release check", cut)
-			compliantObjects = append(compliantObjects, testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Passed the RHEL release check", true))
+			result.AddCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Passed the RHEL release check", true))
 		}
-	}
-
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	})
 }
 
 func testIsSELinuxEnforcing(check *checksdb.Check, env *provider.TestEnvironment) {
@@ -429,31 +370,29 @@ func testIsSELinuxEnforcing(check *checksdb.Check, env *provider.TestEnvironment
 		getenforceCommand = `chroot /host getenforce`
 		enforcingString   = "Enforcing\n"
 	)
-	var compliantObjects []*testhelper.ReportObject
-	var nonCompliantObjects []*testhelper.ReportObject
-	o := clientsholder.GetClientsHolder()
-	nodesFailed := 0
-	nodesError := 0
-	for _, probePod := range env.ProbePods {
+
+	probePods := make([]*corev1.Pod, 0, len(env.ProbePods))
+	for _, p := range env.ProbePods {
+		probePods = append(probePods, p)
+	}
+
+	checksdb.ForEachParallel(check, probePods, 0, func(check *checksdb.Check, probePod *corev1.Pod, result *checksdb.ParallelResult) {
+		o := clientsholder.GetClientsHolder()
 		ctx := clientsholder.NewContext(probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name)
 		outStr, errStr, err := o.ExecCommandContainer(ctx, getenforceCommand)
 		if err != nil || errStr != "" {
 			check.LogError("Could not execute command %q in Probe Pod %q, errStr: %q, err: %v", getenforceCommand, probePod, errStr, err)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(probePod.Namespace, probePod.Name, "Failed to execute command", false))
-			nodesError++
-			continue
+			result.AddNonCompliantObject(testhelper.NewPodReportObject(probePod.Namespace, probePod.Name, "Failed to execute command", false))
+			return
 		}
 		if outStr != enforcingString {
 			check.LogError("Node %q is not running SELinux, %s command returned: %s", probePod.Spec.NodeName, getenforceCommand, outStr)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(probePod.Spec.NodeName, "SELinux is not enforced", false))
-			nodesFailed++
+			result.AddNonCompliantObject(testhelper.NewNodeReportObject(probePod.Spec.NodeName, "SELinux is not enforced", false))
 		} else {
 			check.LogInfo("Node %q is running SELinux", probePod.Spec.NodeName)
-			compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(probePod.Spec.NodeName, "SELinux is enforced", true))
+			result.AddCompliantObject(testhelper.NewNodeReportObject(probePod.Spec.NodeName, "SELinux is enforced", true))
 		}
-	}
-
-	check.SetResult(compliantObjects, nonCompliantObjects)
+	})
 }
 
 func testHugepages(check *checksdb.Check, env *provider.TestEnvironment) {


### PR DESCRIPTION
## Summary

- Add `ForEachParallel[T any]` helper to `pkg/checksdb/` enabling bounded-concurrency parallel iteration over pods/containers/nodes
- Thread-safe `ParallelResult` accumulator with panic recovery and batch add methods to reduce mutex contention
- Convert 13 I/O-heavy test functions to parallel execution:
  - `testIsRedHatRelease`, `testIsSELinuxEnforcing`, `testContainersFsDiff`
  - `testNoSSHDaemonsAllowed`, `testOneProcessPerContainer`
  - `testUndeclaredContainerPortsUsage`, `testContainersLogging`
  - `testSchedulingPolicyInCPUPool`, `testRtAppsNoExecProbes`
  - `testHyperThreadingEnabled`, `testTainted`
  - `testOCPReservedPortsUsage`, `testPartnerSpecificTCPPorts`
- `testContainersFsDiff` uses per-node concurrency limit to avoid OOM from heavy `podman diff` operations
- Remove dead code from `netcommons` (~100 lines) after inlining reserved port checks into parallel callers

## Performance

### CI QE Suite Comparison (main vs. this PR)

Compared against the latest QE run on `main` ([run 25471875821](https://github.com/redhat-best-practices-for-k8s/certsuite/actions/runs/25471875821)). Only suites containing parallelized checks shown:

| Suite | main (sequential) | PR (parallel) | Saved | % |
|---|---|---|---|---|
| accesscontrol4-k8s | 30m 18s | 17m 15s | 13m 03s | **43%** |
| networking2-k8s | 53m 21s | 30m 36s | 22m 45s | **43%** |
| networking1-k8s | 49m 23s | 29m 51s | 19m 32s | **40%** |
| networking3-k8s | 49m 56s | 30m 12s | 19m 44s | **40%** |
| accesscontrol11-k8s | 22m 45s | 13m 48s | 8m 57s | **39%** |
| lifecycle6-k8s | 29m 53s | 18m 46s | 11m 07s | **37%** |
| accesscontrol7-k8s | 20m 46s | 13m 00s | 7m 46s | **37%** |
| accesscontrol10-k8s | 21m 51s | 13m 58s | 7m 53s | **36%** |
| accesscontrol3-k8s | 14m 46s | 9m 29s | 5m 17s | **36%** |
| observability-k8s | 29m 17s | 19m 43s | 9m 34s | **33%** |
| accesscontrol1-k8s | 12m 55s | 9m 00s | 3m 55s | **30%** |
| accesscontrol8-k8s | 13m 00s | 9m 06s | 3m 54s | **30%** |
| **Total (affected)** | **396m 52s** | **254m 40s** | **142m 12s** | **36%** |

> **2 hours 22 minutes saved** across affected QE suites per CI run.

### Local Cluster Test (cnfdt16, 20 pods)

| | Sequential | Parallel | Savings |
|---|---|---|---|
| Total time | 5m 43s | 3m 41s | **36%** |

Results are identical — claim file comparison shows zero differences.

## Test plan

- [x] Unit tests for `ForEachParallel` (thread safety, concurrency limit, pass/fail/skip semantics)
- [x] `make test` passes
- [x] `make lint` passes (0 golangci-lint issues)
- [x] CI: all 41 checks pass (DCI is external infra)
- [x] Local cluster test: 10/10 exercisable checks pass
- [x] Claim file comparison: zero result differences

Ref: [CNFCERT-1404](https://redhat.atlassian.net/browse/CNFCERT-1404)