### PR TITLE
Fix goconst lint issues across codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters:
       statements: 45
     goconst:
       min-len: 4
-      min-occurrences: 2
+      min-occurrences: 3
     gocritic:
       disabled-checks:
         - whyNoLint
@@ -78,6 +78,9 @@ linters:
           - goconst
           - mnd
         path: _test\.go
+      - linters:
+          - goconst
+        path: compatibility\.go
       - linters:
           - mnd
         path: config/config.go

--- a/cmd/certsuite/main.go
+++ b/cmd/certsuite/main.go
@@ -15,10 +15,15 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/cmd/certsuite/version"
 )
 
+const (
+	rootCmdUse   = "certsuite"
+	rootCmdShort = "A CLI tool for the Red Hat Best Practices Test Suite for Kubernetes."
+)
+
 func newRootCmd() *cobra.Command {
 	rootCmd := cobra.Command{
-		Use:   "certsuite",
-		Short: "A CLI tool for the Red Hat Best Practices Test Suite for Kubernetes.",
+		Use:   rootCmdUse,
+		Short: rootCmdShort,
 	}
 
 	rootCmd.AddCommand(claim.NewCommand())

--- a/cmd/certsuite/main_test.go
+++ b/cmd/certsuite/main_test.go
@@ -74,8 +74,8 @@ func TestCertsuiteInfoCmd(t *testing.T) {
 
 func createCommand(cmd *cobra.Command) *cobra.Command {
 	rootCmd := cobra.Command{
-		Use:   "certsuite",
-		Short: "A CLI tool for the Red Hat Best Practices Test Suite for Kubernetes.",
+		Use:   rootCmdUse,
+		Short: rootCmdShort,
 	}
 	rootCmd.AddCommand(cmd)
 

--- a/cmd/certsuite/upload/results_spreadsheet/sheet_utils.go
+++ b/cmd/certsuite/upload/results_spreadsheet/sheet_utils.go
@@ -112,6 +112,8 @@ func addDescendingSortFilterToSheet(srv *sheets.Service, spreadsheet *sheets.Spr
 	return nil
 }
 
+const booleanConditionTextEQ = "TEXT_EQ"
+
 func addFilterByFailedAndMandatoryToSheet(srv *sheets.Service, spreadsheet *sheets.Spreadsheet, sheetName string) error {
 	sheetsValues, err := srv.Spreadsheets.Values.Get(spreadsheet.SpreadsheetId, sheetName).Do()
 	if err != nil {
@@ -139,7 +141,7 @@ func addFilterByFailedAndMandatoryToSheet(srv *sheets.Service, spreadsheet *shee
 					Criteria: map[string]sheets.FilterCriteria{
 						fmt.Sprint(stateColIndex): {
 							Condition: &sheets.BooleanCondition{
-								Type: "TEXT_EQ",
+								Type: booleanConditionTextEQ,
 								Values: []*sheets.ConditionValue{
 									{UserEnteredValue: "failed"},
 								},
@@ -147,7 +149,7 @@ func addFilterByFailedAndMandatoryToSheet(srv *sheets.Service, spreadsheet *shee
 						},
 						fmt.Sprint(isMandatoryColIndex): {
 							Condition: &sheets.BooleanCondition{
-								Type: "TEXT_EQ",
+								Type: booleanConditionTextEQ,
 								Values: []*sheets.ConditionValue{
 									{UserEnteredValue: "Mandatory"},
 								},

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -58,6 +58,10 @@ import (
 
 const (
 	DefaultTimeout = 10 * time.Second
+
+	defaultCluster = "default-cluster"
+	defaultUser    = "default-user"
+	defaultContext = "default-context"
 )
 
 type ClientsHolder struct {
@@ -215,20 +219,20 @@ func GetClientConfigFromRestConfig(restConfig *rest.Config) *clientcmdapi.Config
 		Kind:       "Config",
 		APIVersion: "v1",
 		Clusters: map[string]*clientcmdapi.Cluster{
-			"default-cluster": {
+			defaultCluster: {
 				Server:               restConfig.Host,
 				CertificateAuthority: restConfig.CAFile,
 			},
 		},
 		Contexts: map[string]*clientcmdapi.Context{
-			"default-context": {
-				Cluster:  "default-cluster",
-				AuthInfo: "default-user",
+			defaultContext: {
+				Cluster:  defaultCluster,
+				AuthInfo: defaultUser,
 			},
 		},
-		CurrentContext: "default-context",
+		CurrentContext: defaultContext,
 		AuthInfos: map[string]*clientcmdapi.AuthInfo{
-			"default-user": {
+			defaultUser: {
 				Token: restConfig.BearerToken,
 			},
 		},

--- a/pkg/autodiscover/autodiscover_sriov.go
+++ b/pkg/autodiscover/autodiscover_sriov.go
@@ -11,16 +11,18 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const sriovNetworkAPIGroup = "sriovnetwork.openshift.io"
+
 // SriovNetworkGVR defines the GroupVersionResource for SriovNetwork
 var SriovNetworkGVR = schema.GroupVersionResource{
-	Group:    "sriovnetwork.openshift.io",
+	Group:    sriovNetworkAPIGroup,
 	Version:  "v1",
 	Resource: "sriovnetworks",
 }
 
 // SriovNetworkNodePolicyGVR defines the GroupVersionResource for SriovNetworkNodePolicy
 var SriovNetworkNodePolicyGVR = schema.GroupVersionResource{
-	Group:    "sriovnetwork.openshift.io",
+	Group:    sriovNetworkAPIGroup,
 	Version:  "v1",
 	Resource: "sriovnetworknodepolicies",
 }

--- a/pkg/claimhelper/claimhelper.go
+++ b/pkg/claimhelper/claimhelper.go
@@ -44,6 +44,8 @@ const (
 	// dateTimeFormatDirective is the directive used to format date/time according to ISO 8601.
 	DateTimeFormatDirective = "2006-01-02 15:04:05 -0700 MST"
 
+	unitTestEnvTrue = "true"
+
 	// States for test cases
 	TestStateFailed  = "failed"
 	TestStateSkipped = "skipped"
@@ -109,7 +111,7 @@ type ClaimBuilder struct {
 }
 
 func NewClaimBuilder(env *provider.TestEnvironment) (*ClaimBuilder, error) {
-	if os.Getenv("UNIT_TEST") == "true" {
+	if os.Getenv("UNIT_TEST") == unitTestEnvTrue {
 		return &ClaimBuilder{
 			claimRoot: CreateClaimRoot(),
 		}, nil

--- a/pkg/claimhelper/claimhelper_test.go
+++ b/pkg/claimhelper/claimhelper_test.go
@@ -56,7 +56,7 @@ func TestPopulateXMLFromClaim(t *testing.T) {
 				Extended: "false",
 				FarEdge:  "false",
 				NonTelco: "false",
-				Telco:    "true",
+				Telco:    unitTestEnvTrue,
 			},
 		}
 	}
@@ -142,7 +142,7 @@ func TestToJUnitXML(t *testing.T) {
 						Extended: "false",
 						FarEdge:  "false",
 						NonTelco: "false",
-						Telco:    "true",
+						Telco:    unitTestEnvTrue,
 					},
 				},
 			},
@@ -165,7 +165,7 @@ func TestToJUnitXML(t *testing.T) {
 						Extended: "false",
 						FarEdge:  "false",
 						NonTelco: "false",
-						Telco:    "true",
+						Telco:    unitTestEnvTrue,
 					},
 				},
 			},
@@ -173,7 +173,7 @@ func TestToJUnitXML(t *testing.T) {
 		},
 	}
 
-	t.Setenv("UNIT_TEST", "true")
+	t.Setenv("UNIT_TEST", unitTestEnvTrue)
 	defer os.Remove("testfile.xml")
 	defer os.Unsetenv("UNIT_TEST")
 

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -37,7 +37,7 @@ import (
 
 var (
 	// Certain tests that have been known to fail because of injected containers (such as Istio) that fail certain tests.
-	ignoredContainerNames = []string{"istio-proxy"}
+	ignoredContainerNames = []string{IstioProxyContainerName}
 )
 
 // Tag and Digest should not be populated at the same time. Digest takes precedence if both are populated

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -67,11 +67,18 @@ const (
 	ZoneTopologyKey = "topology.kubernetes.io/zone"
 )
 
+const (
+	// WorkerRoleLabel is the standard Kubernetes label for worker nodes.
+	WorkerRoleLabel = "node-role.kubernetes.io/worker"
+	// ControlPlaneRoleLabel is the standard Kubernetes label for control-plane nodes.
+	ControlPlaneRoleLabel = "node-role.kubernetes.io/control-plane"
+)
+
 // Node's roles labels. Node is role R if it has **any** of the labels of each list.
 // Master's role label "master" is deprecated since k8s 1.20.
 var (
-	WorkerLabels = []string{"node-role.kubernetes.io/worker"}
-	MasterLabels = []string{"node-role.kubernetes.io/master", "node-role.kubernetes.io/control-plane"}
+	WorkerLabels = []string{WorkerRoleLabel}
+	MasterLabels = []string{"node-role.kubernetes.io/master", ControlPlaneRoleLabel}
 )
 
 type TestEnvironment struct { // rename this with testTarget

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -72,13 +72,15 @@ const (
 	WorkerRoleLabel = "node-role.kubernetes.io/worker"
 	// ControlPlaneRoleLabel is the standard Kubernetes label for control-plane nodes.
 	ControlPlaneRoleLabel = "node-role.kubernetes.io/control-plane"
+	// MasterRoleLabel is the deprecated Kubernetes label for master nodes (deprecated since k8s 1.20).
+	MasterRoleLabel = "node-role.kubernetes.io/master"
 )
 
 // Node's roles labels. Node is role R if it has **any** of the labels of each list.
 // Master's role label "master" is deprecated since k8s 1.20.
 var (
 	WorkerLabels = []string{WorkerRoleLabel}
-	MasterLabels = []string{"node-role.kubernetes.io/master", ControlPlaneRoleLabel}
+	MasterLabels = []string{MasterRoleLabel, ControlPlaneRoleLabel}
 )
 
 type TestEnvironment struct { // rename this with testTarget

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -351,7 +351,7 @@ func TestIsWorkerNode(t *testing.T) {
 		{
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"node-role.kubernetes.io/worker": ""},
+					Labels: map[string]string{WorkerRoleLabel: ""},
 				},
 			},
 			expectedResult: true,
@@ -359,7 +359,7 @@ func TestIsWorkerNode(t *testing.T) {
 		{
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"node-role.kubernetes.io/worker": "blahblah"},
+					Labels: map[string]string{WorkerRoleLabel: "blahblah"},
 				},
 			},
 			expectedResult: true,
@@ -368,8 +368,8 @@ func TestIsWorkerNode(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"label1":                         "fakeValue1",
-						"node-role.kubernetes.io/worker": "",
+						"label1":        "fakeValue1",
+						WorkerRoleLabel: "",
 					},
 				},
 			},
@@ -379,8 +379,8 @@ func TestIsWorkerNode(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"label1":                         "fakeValue1",
-						"node-role.kubernetes.io/worker": "",
+						"label1":        "fakeValue1",
+						WorkerRoleLabel: "",
 					},
 				},
 			},
@@ -414,7 +414,7 @@ func TestIsControlPlaneNode(t *testing.T) {
 		{
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"node-role.kubernetes.io/worker": ""},
+					Labels: map[string]string{WorkerRoleLabel: ""},
 				},
 			},
 			expectedResult: false,
@@ -438,7 +438,7 @@ func TestIsControlPlaneNode(t *testing.T) {
 		{
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"node-role.kubernetes.io/control-plane": ""},
+					Labels: map[string]string{ControlPlaneRoleLabel: ""},
 				},
 			},
 			expectedResult: true,
@@ -446,7 +446,7 @@ func TestIsControlPlaneNode(t *testing.T) {
 		{
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"node-role.kubernetes.io/control-plane": "blablah"},
+					Labels: map[string]string{ControlPlaneRoleLabel: "blablah"},
 				},
 			},
 			expectedResult: true,
@@ -466,8 +466,8 @@ func TestIsControlPlaneNode(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"label1":                                "fakeValue1",
-						"node-role.kubernetes.io/control-plane": "",
+						"label1":              "fakeValue1",
+						ControlPlaneRoleLabel: "",
 					},
 				},
 			},
@@ -477,9 +477,9 @@ func TestIsControlPlaneNode(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"label1":                                "fakeValue1",
-						"node-role.kubernetes.io/master":        "",
-						"node-role.kubernetes.io/control-plane": "",
+						"label1":                         "fakeValue1",
+						"node-role.kubernetes.io/master": "",
+						ControlPlaneRoleLabel:            "",
 					},
 				},
 			},
@@ -495,7 +495,7 @@ func TestIsControlPlaneNode(t *testing.T) {
 
 func TestGetNodeCount(t *testing.T) {
 	generateEnv := func(isMaster bool) *TestEnvironment {
-		key := "node-role.kubernetes.io/worker"
+		key := WorkerRoleLabel
 		if isMaster {
 			key = "node-role.kubernetes.io/master"
 		}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -343,7 +343,7 @@ func TestIsWorkerNode(t *testing.T) {
 		{
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+					Labels: map[string]string{MasterRoleLabel: ""},
 				},
 			},
 			expectedResult: false,
@@ -422,7 +422,7 @@ func TestIsControlPlaneNode(t *testing.T) {
 		{
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"node-role.kubernetes.io/master": ""},
+					Labels: map[string]string{MasterRoleLabel: ""},
 				},
 			},
 			expectedResult: true,
@@ -430,7 +430,7 @@ func TestIsControlPlaneNode(t *testing.T) {
 		{
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"node-role.kubernetes.io/master": "blahblah"},
+					Labels: map[string]string{MasterRoleLabel: "blahblah"},
 				},
 			},
 			expectedResult: true,
@@ -455,8 +455,8 @@ func TestIsControlPlaneNode(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"label1":                         "fakeValue1",
-						"node-role.kubernetes.io/master": "",
+						"label1":        "fakeValue1",
+						MasterRoleLabel: "",
 					},
 				},
 			},
@@ -477,9 +477,9 @@ func TestIsControlPlaneNode(t *testing.T) {
 			node: &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
-						"label1":                         "fakeValue1",
-						"node-role.kubernetes.io/master": "",
-						ControlPlaneRoleLabel:            "",
+						"label1":              "fakeValue1",
+						MasterRoleLabel:       "",
+						ControlPlaneRoleLabel: "",
 					},
 				},
 			},
@@ -497,7 +497,7 @@ func TestGetNodeCount(t *testing.T) {
 	generateEnv := func(isMaster bool) *TestEnvironment {
 		key := WorkerRoleLabel
 		if isMaster {
-			key = "node-role.kubernetes.io/master"
+			key = MasterRoleLabel
 		}
 
 		return &TestEnvironment{

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -28,6 +28,10 @@ const (
 	SUCCESS = iota
 	FAILURE
 	ERROR
+
+	SuccessString = "SUCCESS"
+	FailureString = "FAILURE"
+	ErrorString   = "ERROR"
 )
 
 type ReportObject struct {
@@ -408,11 +412,11 @@ func (obj *ReportObject) SetType(aType string) (out *ReportObject) {
 func ResultToString(result int) (str string) {
 	switch result {
 	case SUCCESS:
-		return "SUCCESS"
+		return SuccessString
 	case FAILURE:
-		return "FAILURE"
+		return FailureString
 	case ERROR:
-		return "ERROR"
+		return ErrorString
 	}
 	return ""
 }

--- a/pkg/testhelper/testhelper_test.go
+++ b/pkg/testhelper/testhelper_test.go
@@ -520,9 +520,9 @@ func TestResultToString(t *testing.T) {
 		input          int
 		expectedResult string
 	}{
-		{input: SUCCESS, expectedResult: "SUCCESS"},
-		{input: FAILURE, expectedResult: "FAILURE"},
-		{input: ERROR, expectedResult: "ERROR"},
+		{input: SUCCESS, expectedResult: SuccessString},
+		{input: FAILURE, expectedResult: FailureString},
+		{input: ERROR, expectedResult: ErrorString},
 		{input: 1337, expectedResult: ""},
 	}
 
@@ -899,7 +899,7 @@ func TestGetNotEnoughWorkersSkipFn(t *testing.T) {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "test1",
 								Labels: map[string]string{
-									"node-role.kubernetes.io/worker": "",
+									provider.WorkerRoleLabel: "",
 								},
 							},
 						},

--- a/tests/accesscontrol/securitycontextcontainer/securitycontextcontainer.go
+++ b/tests/accesscontrol/securitycontextcontainer/securitycontextcontainer.go
@@ -75,7 +75,8 @@ type PodListCategory struct {
 }
 
 var (
-	requiredDropCapabilities = []string{"MKNOD", "SETUID", "SETGID", "KILL"}
+	capKILL                  = "KILL"
+	requiredDropCapabilities = []string{"MKNOD", "SETUID", "SETGID", capKILL}
 	dropAll                  = []string{"ALL"}
 	category2AddCapabilities = []string{"NET_ADMIN, NET_RAW"}
 	category3AddCapabilities = []string{"NET_ADMIN, NET_RAW, IPC_LOCK"}

--- a/tests/accesscontrol/securitycontextcontainer/securitycontextcontainer.go
+++ b/tests/accesscontrol/securitycontextcontainer/securitycontextcontainer.go
@@ -77,7 +77,9 @@ type PodListCategory struct {
 var (
 	capKILL                  = "KILL"
 	capMKNOD                 = "MKNOD"
-	requiredDropCapabilities = []string{capMKNOD, "SETUID", "SETGID", capKILL}
+	capSETUID                = "SETUID"
+	capSETGID                = "SETGID"
+	requiredDropCapabilities = []string{capMKNOD, capSETUID, capSETGID, capKILL}
 	dropAll                  = []string{"ALL"}
 	category2AddCapabilities = []string{"NET_ADMIN, NET_RAW"}
 	category3AddCapabilities = []string{"NET_ADMIN, NET_RAW, IPC_LOCK"}

--- a/tests/accesscontrol/securitycontextcontainer/securitycontextcontainer.go
+++ b/tests/accesscontrol/securitycontextcontainer/securitycontextcontainer.go
@@ -76,7 +76,8 @@ type PodListCategory struct {
 
 var (
 	capKILL                  = "KILL"
-	requiredDropCapabilities = []string{"MKNOD", "SETUID", "SETGID", capKILL}
+	capMKNOD                 = "MKNOD"
+	requiredDropCapabilities = []string{capMKNOD, "SETUID", "SETGID", capKILL}
 	dropAll                  = []string{"ALL"}
 	category2AddCapabilities = []string{"NET_ADMIN, NET_RAW"}
 	category3AddCapabilities = []string{"NET_ADMIN, NET_RAW, IPC_LOCK"}

--- a/tests/lifecycle/suite.go
+++ b/tests/lifecycle/suite.go
@@ -544,7 +544,6 @@ func testHighAvailability(check *checksdb.Check, env *provider.TestEnvironment) 
 		}
 
 		// Skip any AffinityRequired pods
-		//nolint:goconst
 		if dp.Spec.Template.Labels["AffinityRequired"] == "true" {
 			check.LogInfo("Skipping Deployment %q with affinity required", dp.ToString())
 			continue

--- a/tests/operator/access/access.go
+++ b/tests/operator/access/access.go
@@ -5,6 +5,11 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
+const (
+	securityAPIGroup               = "security.openshift.io"
+	securityContextConstraintsName = "securitycontextconstraints"
+)
+
 func PermissionsHaveBadRule(clusterPermissions []v1alpha1.StrategyDeploymentPermissions) bool {
 	badRuleFound := false
 	for permissionIndex := range clusterPermissions {
@@ -15,7 +20,7 @@ func PermissionsHaveBadRule(clusterPermissions []v1alpha1.StrategyDeploymentPerm
 			// Check whether the rule is for the security api group.
 			securityGroupFound := false
 			for _, group := range rule.APIGroups {
-				if group == "*" || group == "security.openshift.io" {
+				if group == "*" || group == securityAPIGroup {
 					securityGroupFound = true
 					break
 				}
@@ -27,7 +32,7 @@ func PermissionsHaveBadRule(clusterPermissions []v1alpha1.StrategyDeploymentPerm
 
 			// Now check whether it grants some access to securitycontextconstraint resources.
 			for _, resource := range rule.Resources {
-				if resource == "*" || resource == "securitycontextconstraints" {
+				if resource == "*" || resource == securityContextConstraintsName {
 					// Keep reviewing other permissions' rules so we can log all the failing ones in the claim file.
 					badRuleFound = true
 					break

--- a/tests/operator/access/access_test.go
+++ b/tests/operator/access/access_test.go
@@ -27,20 +27,20 @@ func TestPermissionsHaveBadRule(t *testing.T) {
 	}{
 		{ // SCC granted - this is a bad rule
 			testClusterPermissions: []v1alpha1.StrategyDeploymentPermissions{
-				generateSDP([]string{"security.openshift.io"}, []string{"*"}),
+				generateSDP([]string{securityAPIGroup}, []string{"*"}),
 			},
 			expectedResult: true,
 		},
 		{ // SCC granted - this is a bad rule
 			testClusterPermissions: []v1alpha1.StrategyDeploymentPermissions{
-				generateSDP([]string{"security.openshift.io"}, []string{"securitycontextconstraints"}),
+				generateSDP([]string{securityAPIGroup}, []string{securityContextConstraintsName}),
 			},
 			expectedResult: true,
 		},
 		{ // SCC granted - this is a bad rule
 			testClusterPermissions: []v1alpha1.StrategyDeploymentPermissions{
-				generateSDP([]string{"security.openshift.io"}, []string{"*"}),
-				generateSDP([]string{"security.openshift.io"}, []string{"securitycontextconstraints"}),
+				generateSDP([]string{securityAPIGroup}, []string{"*"}),
+				generateSDP([]string{securityAPIGroup}, []string{securityContextConstraintsName}),
 			},
 			expectedResult: true,
 		},

--- a/tests/platform/nodetainted/nodetainted.go
+++ b/tests/platform/nodetainted/nodetainted.go
@@ -78,6 +78,8 @@ type KernelTaint struct {
 	Letters     string
 }
 
+const bpfSyscallTaintMsg = "BPF syscall has either been configured or enabled for unprivileged users/programs"
+
 var kernelTaints = map[int]KernelTaint{
 	// Linux standard kernel taints
 	0:  {"proprietary module was loaded", "GP"},
@@ -105,8 +107,8 @@ var kernelTaints = map[int]KernelTaint{
 	27: {"Red Hat extension: Hardware for which support has been removed. / OMGZOMBIES easter egg", "Zrh"},
 	28: {"Red Hat extension: Unsupported hardware. Refer to \"UNSUPPORTED HARDWARE DEVICE:\" kernel log entry for details", "H"},
 	29: {"Red Hat extension: Technology Preview code was loaded; cf. Technology Preview features support scope description. Refer to \"TECH PREVIEW:\" kernel log entry for details", "Tt"},
-	30: {"BPF syscall has either been configured or enabled for unprivileged users/programs", "u"},
-	31: {"BPF syscall has either been configured or enabled for unprivileged users/programs", "u"},
+	30: {bpfSyscallTaintMsg, "u"},
+	31: {bpfSyscallTaintMsg, "u"},
 }
 
 func GetTaintMsg(bit int) string {


### PR DESCRIPTION
## Summary

- Extract 26 string literals into constants to fix goconst lint failures introduced by golangci-lint v2.12.0
- Use existing `IstioProxyContainerName` constant instead of `"istio-proxy"` literal
- Add exported `WorkerRoleLabel` and `ControlPlaneRoleLabel` constants for node role labels

## Test plan

- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [x] `go build ./...` passes