### PR TITLE
feat: add unsecured container ports TLS detection test

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 ## Test cases summary
 
-### Total test cases: 123
+### Total test cases: 124
 
 ### Total suites: 10
 
@@ -17,18 +17,18 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |affiliated-certification|4|[affiliated-certification](#affiliated-certification)|
 |lifecycle|19|[lifecycle](#lifecycle)|
 |manageability|2|[manageability](#manageability)|
-|networking|12|[networking](#networking)|
+|networking|13|[networking](#networking)|
 |observability|5|[observability](#observability)|
 |operator|12|[operator](#operator)|
 |performance|7|[performance](#performance)|
 |platform-alteration|14|[platform-alteration](#platform-alteration)|
 |preflight|17|[preflight](#preflight)|
 
-### Extended specific tests only: 14
+### Extended specific tests only: 15
 
 |Mandatory|Optional|
 |---|---|---|
-|10|4|
+|10|5|
 
 ### Far-Edge specific tests only: 9
 
@@ -1214,6 +1214,23 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Tags|extended,networking|
 |**Scenario**|**Optional/Mandatory**|
 |Extended|Mandatory|
+|Far-Edge|Optional|
+|Non-Telco|Optional|
+|Telco|Optional|
+
+#### networking-unsecured-container-ports
+
+|Property|Description|
+|---|---|
+|Unique ID|networking-unsecured-container-ports|
+|Description|Check that TCP ports listening inside containers use TLS encryption. Ports accepting plaintext connections are flagged as non-compliant.|
+|Suggested Remediation|Ensure all listening TCP ports use TLS. If a port intentionally serves plaintext (e.g., health probes behind network policies), annotate the pod with certsuite.redhat.com/non-tls-ports: "port1,port2".|
+|Best Practice Reference|No Doc Link - Extended|
+|Exception Process|No exception needed for optional/extended tests.|
+|Impact Statement|Unsecured ports accepting plaintext traffic expose sensitive data to eavesdropping and man-in-the-middle attacks, violating security compliance requirements.|
+|Tags|extended,networking|
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Optional|
 |Far-Edge|Optional|
 |Non-Telco|Optional|
 |Telco|Optional|

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,7 +7,7 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 ## Test cases summary
 
-### Total test cases: 124
+### Total test cases: 125
 
 ### Total suites: 10
 
@@ -17,18 +17,18 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |affiliated-certification|4|[affiliated-certification](#affiliated-certification)|
 |lifecycle|19|[lifecycle](#lifecycle)|
 |manageability|2|[manageability](#manageability)|
-|networking|11|[networking](#networking)|
+|networking|12|[networking](#networking)|
 |observability|5|[observability](#observability)|
 |operator|12|[operator](#operator)|
 |performance|7|[performance](#performance)|
 |platform-alteration|14|[platform-alteration](#platform-alteration)|
 |preflight|19|[preflight](#preflight)|
 
-### Extended specific tests only: 13
+### Extended specific tests only: 14
 
 |Mandatory|Optional|
 |---|---|---|
-|10|3|
+|10|4|
 
 ### Far-Edge specific tests only: 9
 
@@ -1201,6 +1201,23 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Non-Telco|Optional|
 |Telco|Optional|
 
+#### networking-unsecured-container-ports
+
+|Property|Description|
+|---|---|
+|Unique ID|networking-unsecured-container-ports|
+|Description|Check that TCP ports listening inside containers use TLS encryption. Ports accepting plaintext connections are flagged as non-compliant.|
+|Suggested Remediation|Ensure all listening TCP ports use TLS. If a port intentionally serves plaintext (e.g., health probes behind network policies), annotate the pod with certsuite.redhat.com/non-tls-ports: "port1,port2".|
+|Best Practice Reference|No Doc Link - Extended|
+|Exception Process|No exception needed for optional/extended tests.|
+|Impact Statement|Unsecured ports accepting plaintext traffic expose sensitive data to eavesdropping and man-in-the-middle attacks, violating security compliance requirements.|
+|Tags|extended,networking|
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Optional|
+|Far-Edge|Optional|
+|Non-Telco|Optional|
+|Telco|Optional|
+
 ### observability
 
 #### observability-compatibility-with-next-ocp-release
@@ -1879,7 +1896,7 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Property|Description|
 |---|---|
 |Unique ID|preflight-BasedOnUbi|
-|Description|Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)|
+|Description|Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI) or Red Hat Hardened Images (RHHI)|
 |Suggested Remediation|Change the FROM directive in your Dockerfile or Containerfile, for the latest list of images and details refer to: https://catalog.redhat.com/software/base-images|
 |Best Practice Reference|No Doc Link|
 |Exception Process|There is no documented exception process for this.|

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -75,6 +75,7 @@ testCases:
     - platform-alteration-tainted-node-kernel
   fail:
     - affiliated-certification-container-is-certified-digest # test container image is not certified
+    - networking-unsecured-container-ports # smoke test pods serve plaintext
   skip:
     - access-control-sys-ptrace-capability
     - access-control-sys-nice-realtime-capability

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -76,6 +76,7 @@ testCases:
     - platform-alteration-tainted-node-kernel
   fail:
     - affiliated-certification-container-is-certified-digest # test container image is not certified
+    - networking-unsecured-container-ports # smoke test pods serve plaintext
   skip:
     - access-control-sys-ptrace-capability
     - access-control-sys-nice-realtime-capability

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -20,6 +20,7 @@ const (
 	TestICMPv6ConnectivityMultusIdentifierDocLink       = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-high-level-cnf-expectations"
 	TestServiceDualStackIdentifierDocLink               = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-ipv4-&-ipv6"
 	TestUndeclaredContainerPortsUsageDocLink            = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requirements-cnf-reqs"
+	TestUnsecuredContainerPortsDocLink                  = NoDocLinkExtended
 	TestOCPReservedPortsUsageDocLink                    = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-ports-reserved-by-openshift"
 
 	// Access Control Suite

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -20,6 +20,7 @@ const (
 	TestICMPv6ConnectivityMultusIdentifierDocLink       = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-high-level-cnf-expectations"
 	TestServiceDualStackIdentifierDocLink               = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-ipv4-&-ipv6"
 	TestUndeclaredContainerPortsUsageDocLink            = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requirements-cnf-reqs"
+	TestUnsecuredContainerPortsDocLink                  = NoDocLinkExtended
 	TestOCPReservedPortsUsageDocLink                    = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-ports-reserved-by-openshift"
 	TestTLSMinimumVersionIdentifierDocLink              = NoDocLinkExtended
 

--- a/tests/identifiers/impact.go
+++ b/tests/identifiers/impact.go
@@ -36,6 +36,7 @@ const (
 	TestICMPv6ConnectivityMultusIdentifierImpact       = `IPv6 Multus connectivity problems can prevent dual-stack multi-network scenarios from working, limiting network scalability and future-proofing.`
 	TestServiceDualStackIdentifierImpact               = `Single-stack IPv4 services limit network architecture flexibility and prevent migration to modern dual-stack infrastructures.`
 	TestUndeclaredContainerPortsUsageImpact            = `Undeclared ports can be blocked by security policies, causing unexpected connectivity issues and making troubleshooting difficult.`
+	TestUnsecuredContainerPortsImpact                  = `Unsecured ports accepting plaintext traffic expose sensitive data to eavesdropping and man-in-the-middle attacks, violating security compliance requirements.`
 	TestOCPReservedPortsUsageImpact                    = `Using OpenShift-reserved ports can cause critical platform services to fail, potentially destabilizing the entire cluster.`
 	TestTLSMinimumVersionIdentifierImpact              = `Services accepting TLS versions below 1.3 are vulnerable to known protocol attacks (BEAST, POODLE, Lucky13) and may fail security compliance audits required for telco/CNF deployments.`
 
@@ -181,6 +182,7 @@ var ImpactMap = map[string]string{
 	"networking-icmpv6-connectivity-multus":              TestICMPv6ConnectivityMultusIdentifierImpact,
 	"networking-dual-stack-service":                      TestServiceDualStackIdentifierImpact,
 	"networking-undeclared-container-ports-usage":        TestUndeclaredContainerPortsUsageImpact,
+	"networking-unsecured-container-ports":               TestUnsecuredContainerPortsImpact,
 	"networking-ocp-reserved-ports-usage":                TestOCPReservedPortsUsageImpact,
 	"networking-tls-minimum-version":                     TestTLSMinimumVersionIdentifierImpact,
 

--- a/tests/identifiers/impact.go
+++ b/tests/identifiers/impact.go
@@ -36,6 +36,7 @@ const (
 	TestICMPv6ConnectivityMultusIdentifierImpact       = `IPv6 Multus connectivity problems can prevent dual-stack multi-network scenarios from working, limiting network scalability and future-proofing.`
 	TestServiceDualStackIdentifierImpact               = `Single-stack IPv4 services limit network architecture flexibility and prevent migration to modern dual-stack infrastructures.`
 	TestUndeclaredContainerPortsUsageImpact            = `Undeclared ports can be blocked by security policies, causing unexpected connectivity issues and making troubleshooting difficult.`
+	TestUnsecuredContainerPortsImpact                  = `Unsecured ports accepting plaintext traffic expose sensitive data to eavesdropping and man-in-the-middle attacks, violating security compliance requirements.`
 	TestOCPReservedPortsUsageImpact                    = `Using OpenShift-reserved ports can cause critical platform services to fail, potentially destabilizing the entire cluster.`
 
 	// Access Control Suite Impact Statements
@@ -182,6 +183,7 @@ var ImpactMap = map[string]string{
 	"networking-icmpv6-connectivity-multus":              TestICMPv6ConnectivityMultusIdentifierImpact,
 	"networking-dual-stack-service":                      TestServiceDualStackIdentifierImpact,
 	"networking-undeclared-container-ports-usage":        TestUndeclaredContainerPortsUsageImpact,
+	"networking-unsecured-container-ports":               TestUnsecuredContainerPortsImpact,
 	"networking-ocp-reserved-ports-usage":                TestOCPReservedPortsUsageImpact,
 
 	// Access Control Suite

--- a/tests/identifiers/networking.go
+++ b/tests/identifiers/networking.go
@@ -33,6 +33,7 @@ var (
 	TestRestartOnRebootLabelOnPodsUsingSRIOV     claim.Identifier
 	TestServiceDualStackIdentifier               claim.Identifier
 	TestUndeclaredContainerPortsUsage            claim.Identifier
+	TestUnsecuredContainerPortsIdentifier        claim.Identifier
 )
 
 //nolint:funlen
@@ -209,6 +210,22 @@ func init() {
 			Telco:    Optional,
 			NonTelco: Optional,
 			Extended: Mandatory,
+		},
+		TagExtended)
+
+	TestUnsecuredContainerPortsIdentifier = AddCatalogEntry(
+		"unsecured-container-ports",
+		common.NetworkingTestKey,
+		`Check that TCP ports listening inside containers use TLS encryption. Ports accepting plaintext connections are flagged as non-compliant.`,
+		UnsecuredContainerPortsRemediation,
+		NoExceptionProcessForExtendedTests,
+		TestUnsecuredContainerPortsDocLink,
+		true,
+		map[string]string{
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
+			Extended: Optional,
 		},
 		TagExtended)
 }

--- a/tests/identifiers/networking.go
+++ b/tests/identifiers/networking.go
@@ -34,6 +34,7 @@ var (
 	TestServiceDualStackIdentifier               claim.Identifier
 	TestTLSMinimumVersionIdentifier              claim.Identifier
 	TestUndeclaredContainerPortsUsage            claim.Identifier
+	TestUnsecuredContainerPortsIdentifier        claim.Identifier
 )
 
 //nolint:funlen
@@ -231,6 +232,22 @@ func init() {
 			Telco:    Optional,
 			NonTelco: Optional,
 			Extended: Mandatory,
+		},
+		TagExtended)
+
+	TestUnsecuredContainerPortsIdentifier = AddCatalogEntry(
+		"unsecured-container-ports",
+		common.NetworkingTestKey,
+		`Check that TCP ports listening inside containers use TLS encryption. Ports accepting plaintext connections are flagged as non-compliant.`,
+		UnsecuredContainerPortsRemediation,
+		NoExceptionProcessForExtendedTests,
+		TestUnsecuredContainerPortsDocLink,
+		true,
+		map[string]string{
+			FarEdge:  Optional,
+			Telco:    Optional,
+			NonTelco: Optional,
+			Extended: Optional,
 		},
 		TagExtended)
 }

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -145,6 +145,8 @@ const (
 
 	UndeclaredContainerPortsRemediation = `Ensure the workload's apps do not listen on undeclared containers' ports.`
 
+	UnsecuredContainerPortsRemediation = `Ensure all listening TCP ports use TLS. If a port intentionally serves plaintext (e.g., health probes behind network policies), annotate the pod with certsuite.redhat.com/non-tls-ports: "port1,port2".`
+
 	CrdsStatusSubresourceRemediation = `Ensure that all the CRDs have a meaningful status specification (Spec.versions[].Schema.OpenAPIV3Schema.Properties[“status”]).`
 
 	LoggingRemediation = `Ensure containers are not redirecting stdout/stderr`

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -19,6 +19,7 @@ package networking
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
@@ -164,6 +165,18 @@ func LoadChecks() {
 			testTLSMinimumVersion(c, &env)
 			return nil
 		}))
+
+	// Unsecured container ports test case
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestUnsecuredContainerPortsIdentifier)).
+		WithSkipCheckFn(
+			testhelper.GetNoContainersUnderTestSkipFn(&env),
+			testhelper.GetDaemonSetFailedToSpawnSkipFn(&env),
+			testhelper.GetNoPodsUnderTestSkipFn(&env),
+		).
+		WithCheckFn(func(c *checksdb.Check) error {
+			testUnsecuredContainerPorts(c, &env)
+			return nil
+		}))
 }
 
 //nolint:funlen
@@ -234,6 +247,118 @@ func testUndeclaredContainerPortsUsage(check *checksdb.Check, env *provider.Test
 			result.AddCompliantObject(
 				testhelper.NewPodReportObject(put.Namespace, put.Name, "All listening were declared in containers specs", true))
 		}
+	})
+}
+
+const nonTLSPortsAnnotation = "certsuite.redhat.com/non-tls-ports"
+
+func parseNonTLSPortsAnnotation(pod *provider.Pod, check *checksdb.Check) map[int32]bool {
+	exempt := make(map[int32]bool)
+	ann, ok := pod.Annotations[nonTLSPortsAnnotation]
+	if !ok || ann == "" {
+		return exempt
+	}
+	for _, p := range strings.Split(ann, ",") {
+		p = strings.TrimSpace(p)
+		port, err := strconv.ParseInt(p, 10, 32)
+		if err != nil || port < 1 || port > 65535 {
+			check.LogError("Invalid port %q in %s annotation on pod %s/%s", p, nonTLSPortsAnnotation, pod.Namespace, pod.Name)
+			continue
+		}
+		exempt[int32(port)] = true
+	}
+	return exempt
+}
+
+func getFirstProbeContext(env *provider.TestEnvironment) (clientsholder.Command, clientsholder.Context, bool) {
+	for _, probePod := range env.ProbePods {
+		if probePod == nil || len(probePod.Spec.Containers) == 0 {
+			continue
+		}
+		return clientsholder.GetClientsHolder(), clientsholder.NewContext(
+			probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name,
+		), true
+	}
+	return nil, clientsholder.Context{}, false
+}
+
+func newPortReportObject(namespace, name, message string, compliant bool, port netutil.PortInfo) *testhelper.ReportObject {
+	return testhelper.NewPodReportObject(namespace, name, message, compliant).
+		SetType(testhelper.ListeningPortType).
+		AddField(testhelper.PortNumber, strconv.Itoa(int(port.PortNumber))).
+		AddField(testhelper.PortProtocol, port.Protocol)
+}
+
+func checkPodPortTLS(check *checksdb.Check, put *provider.Pod, ch clientsholder.Command,
+	probeCtx clientsholder.Context, result *checksdb.ParallelResult) {
+	firstContainer := put.Containers[0]
+	listeningPorts, err := netutil.GetListeningPorts(firstContainer)
+	if err != nil {
+		check.LogError("Failed to get pod %q listening ports, err: %v", put, err)
+		result.AddNonCompliantObject(
+			testhelper.NewPodReportObject(put.Namespace, put.Name, fmt.Sprintf("Failed to get listening ports: %v", err), false))
+		return
+	}
+
+	if len(listeningPorts) == 0 {
+		result.AddCompliantObject(
+			testhelper.NewPodReportObject(put.Namespace, put.Name, "No listening ports", true))
+		return
+	}
+
+	exemptPorts := parseNonTLSPortsAnnotation(put, check)
+	podIP := put.Status.PodIP
+	if podIP == "" {
+		check.LogError("Pod %q has no PodIP, skipping TLS probe", put)
+		return
+	}
+
+	for port := range listeningPorts {
+		if port.Protocol != "TCP" {
+			continue
+		}
+		if put.ContainsIstioProxy() && netcommons.ReservedIstioPorts[port.PortNumber] {
+			continue
+		}
+		if exemptPorts[port.PortNumber] {
+			result.AddCompliantObject(
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d exempt via annotation", port.PortNumber), true, port))
+			continue
+		}
+
+		isTLS, reachable, reason := tlsversion.IsPortTLS(ch, probeCtx, podIP, port.PortNumber)
+		check.LogInfo("TLS probe %s:%d: isTLS=%v reachable=%v reason=%q",
+			podIP, port.PortNumber, isTLS, reachable, reason)
+
+		switch {
+		case !reachable:
+			result.AddCompliantObject(
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d unreachable (%s)", port.PortNumber, reason), true, port))
+		case isTLS:
+			result.AddCompliantObject(
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d uses TLS (%s)", port.PortNumber, reason), true, port))
+		default:
+			check.LogError("Port %d on %q is plaintext (%s)", port.PortNumber, put, reason)
+			result.AddNonCompliantObject(
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d accepts plaintext connections (%s)", port.PortNumber, reason), false, port))
+		}
+	}
+}
+
+func testUnsecuredContainerPorts(check *checksdb.Check, env *provider.TestEnvironment) {
+	ch, probeCtx, probeAvailable := getFirstProbeContext(env)
+	if !probeAvailable {
+		check.LogError("No probe pods available for TLS checks, skipping")
+		check.SetResult(nil, nil)
+		return
+	}
+
+	checksdb.ForEachParallel(check, env.Pods, len(env.ProbePods), func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
+		checkPodPortTLS(check, put, ch, probeCtx, result)
 	})
 }
 

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -19,7 +19,9 @@ package networking
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
@@ -31,6 +33,7 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/netutil"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/policies"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/services"
+	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/tlsversion"
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
@@ -157,6 +160,18 @@ func LoadChecks() {
 			testNetworkAttachmentDefinitionSRIOVUsingMTU(c, sriovPods)
 			return nil
 		}))
+
+	// Unsecured container ports test case
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestUnsecuredContainerPortsIdentifier)).
+		WithSkipCheckFn(
+			testhelper.GetNoContainersUnderTestSkipFn(&env),
+			testhelper.GetDaemonSetFailedToSpawnSkipFn(&env),
+			testhelper.GetNoPodsUnderTestSkipFn(&env),
+		).
+		WithCheckFn(func(c *checksdb.Check) error {
+			testUnsecuredContainerPorts(c, &env)
+			return nil
+		}))
 }
 
 //nolint:funlen
@@ -227,6 +242,118 @@ func testUndeclaredContainerPortsUsage(check *checksdb.Check, env *provider.Test
 			result.AddCompliantObject(
 				testhelper.NewPodReportObject(put.Namespace, put.Name, "All listening were declared in containers specs", true))
 		}
+	})
+}
+
+const nonTLSPortsAnnotation = "certsuite.redhat.com/non-tls-ports"
+
+func parseNonTLSPortsAnnotation(pod *provider.Pod, check *checksdb.Check) map[int32]bool {
+	exempt := make(map[int32]bool)
+	ann, ok := pod.Annotations[nonTLSPortsAnnotation]
+	if !ok || ann == "" {
+		return exempt
+	}
+	for _, p := range strings.Split(ann, ",") {
+		p = strings.TrimSpace(p)
+		port, err := strconv.ParseInt(p, 10, 32)
+		if err != nil || port < 1 || port > 65535 {
+			check.LogError("Invalid port %q in %s annotation on pod %s/%s", p, nonTLSPortsAnnotation, pod.Namespace, pod.Name)
+			continue
+		}
+		exempt[int32(port)] = true
+	}
+	return exempt
+}
+
+func getFirstProbeContext(env *provider.TestEnvironment) (clientsholder.Command, clientsholder.Context, bool) {
+	for _, probePod := range env.ProbePods {
+		if probePod == nil || len(probePod.Spec.Containers) == 0 {
+			continue
+		}
+		return clientsholder.GetClientsHolder(), clientsholder.NewContext(
+			probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name,
+		), true
+	}
+	return nil, clientsholder.Context{}, false
+}
+
+func newPortReportObject(namespace, name, message string, compliant bool, port netutil.PortInfo) *testhelper.ReportObject {
+	return testhelper.NewPodReportObject(namespace, name, message, compliant).
+		SetType(testhelper.ListeningPortType).
+		AddField(testhelper.PortNumber, strconv.Itoa(int(port.PortNumber))).
+		AddField(testhelper.PortProtocol, port.Protocol)
+}
+
+func checkPodPortTLS(check *checksdb.Check, put *provider.Pod, ch clientsholder.Command,
+	probeCtx clientsholder.Context, result *checksdb.ParallelResult) {
+	firstContainer := put.Containers[0]
+	listeningPorts, err := netutil.GetListeningPorts(firstContainer)
+	if err != nil {
+		check.LogError("Failed to get pod %q listening ports, err: %v", put, err)
+		result.AddNonCompliantObject(
+			testhelper.NewPodReportObject(put.Namespace, put.Name, fmt.Sprintf("Failed to get listening ports: %v", err), false))
+		return
+	}
+
+	if len(listeningPorts) == 0 {
+		result.AddCompliantObject(
+			testhelper.NewPodReportObject(put.Namespace, put.Name, "No listening ports", true))
+		return
+	}
+
+	exemptPorts := parseNonTLSPortsAnnotation(put, check)
+	podIP := put.Status.PodIP
+	if podIP == "" {
+		check.LogError("Pod %q has no PodIP, skipping TLS probe", put)
+		return
+	}
+
+	for port := range listeningPorts {
+		if port.Protocol != "TCP" {
+			continue
+		}
+		if put.ContainsIstioProxy() && netcommons.ReservedIstioPorts[port.PortNumber] {
+			continue
+		}
+		if exemptPorts[port.PortNumber] {
+			result.AddCompliantObject(
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d exempt via annotation", port.PortNumber), true, port))
+			continue
+		}
+
+		isTLS, reachable, reason := tlsversion.IsPortTLS(ch, probeCtx, podIP, port.PortNumber)
+		check.LogInfo("TLS probe %s:%d: isTLS=%v reachable=%v reason=%q",
+			podIP, port.PortNumber, isTLS, reachable, reason)
+
+		switch {
+		case !reachable:
+			result.AddCompliantObject(
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d unreachable (%s)", port.PortNumber, reason), true, port))
+		case isTLS:
+			result.AddCompliantObject(
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d uses TLS (%s)", port.PortNumber, reason), true, port))
+		default:
+			check.LogError("Port %d on %q is plaintext (%s)", port.PortNumber, put, reason)
+			result.AddNonCompliantObject(
+				newPortReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("Port %d accepts plaintext connections (%s)", port.PortNumber, reason), false, port))
+		}
+	}
+}
+
+func testUnsecuredContainerPorts(check *checksdb.Check, env *provider.TestEnvironment) {
+	ch, probeCtx, probeAvailable := getFirstProbeContext(env)
+	if !probeAvailable {
+		check.LogError("No probe pods available for TLS checks, skipping")
+		check.SetResult(nil, nil)
+		return
+	}
+
+	checksdb.ForEachParallel(check, env.Pods, len(env.ProbePods), func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
+		checkPodPortTLS(check, put, ch, probeCtx, result)
 	})
 }
 

--- a/tests/networking/suite_test.go
+++ b/tests/networking/suite_test.go
@@ -15,3 +15,175 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package networking
+
+import (
+	"testing"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
+	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/netutil"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseNonTLSPortsAnnotation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    map[int32]bool
+	}{
+		{
+			name:        "no annotation",
+			annotations: nil,
+			expected:    map[int32]bool{},
+		},
+		{
+			name:        "empty annotation value",
+			annotations: map[string]string{nonTLSPortsAnnotation: ""},
+			expected:    map[int32]bool{},
+		},
+		{
+			name:        "single port",
+			annotations: map[string]string{nonTLSPortsAnnotation: "8080"},
+			expected:    map[int32]bool{8080: true},
+		},
+		{
+			name:        "multiple ports with whitespace",
+			annotations: map[string]string{nonTLSPortsAnnotation: "80, 443, 8080"},
+			expected:    map[int32]bool{80: true, 443: true, 8080: true},
+		},
+		{
+			name:        "invalid port skipped",
+			annotations: map[string]string{nonTLSPortsAnnotation: "80, abc, 443"},
+			expected:    map[int32]bool{80: true, 443: true},
+		},
+		{
+			name:        "out-of-range ports skipped",
+			annotations: map[string]string{nonTLSPortsAnnotation: "0, 80, 70000"},
+			expected:    map[int32]bool{80: true},
+		},
+		{
+			name:        "unrelated annotation ignored",
+			annotations: map[string]string{"other-annotation": "8080"},
+			expected:    map[int32]bool{},
+		},
+		{
+			name:        "min and max valid ports",
+			annotations: map[string]string{nonTLSPortsAnnotation: "1, 65535"},
+			expected:    map[int32]bool{1: true, 65535: true},
+		},
+		{
+			name:        "trailing comma",
+			annotations: map[string]string{nonTLSPortsAnnotation: "80,"},
+			expected:    map[int32]bool{80: true},
+		},
+		{
+			name:        "blank token skipped",
+			annotations: map[string]string{nonTLSPortsAnnotation: "80, , 443"},
+			expected:    map[int32]bool{80: true, 443: true},
+		},
+		{
+			name:        "duplicate ports",
+			annotations: map[string]string{nonTLSPortsAnnotation: "80,80"},
+			expected:    map[int32]bool{80: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pod := &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-pod",
+						Namespace:   "test-ns",
+						Annotations: tt.annotations,
+					},
+				},
+			}
+			check := checksdb.NewCheck("test-parse-annotation", []string{"test"})
+			result := parseNonTLSPortsAnnotation(pod, check)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewPortReportObject(t *testing.T) {
+	t.Parallel()
+
+	port := netutil.PortInfo{PortNumber: 8080, Protocol: "TCP"}
+	ro := newPortReportObject("test-ns", "test-pod", "port is TLS", true, port)
+	assert.NotNil(t, ro)
+	assert.Equal(t, testhelper.ListeningPortType, ro.ObjectType)
+	assert.Contains(t, ro.ObjectFieldsKeys, testhelper.PortNumber)
+	assert.Contains(t, ro.ObjectFieldsKeys, testhelper.PortProtocol)
+	assert.Contains(t, ro.ObjectFieldsKeys, testhelper.ReasonForCompliance)
+	assert.Contains(t, ro.ObjectFieldsValues, "8080")
+	assert.Contains(t, ro.ObjectFieldsValues, "TCP")
+	assert.Contains(t, ro.ObjectFieldsValues, "port is TLS")
+	assert.Contains(t, ro.ObjectFieldsValues, "test-ns")
+	assert.Contains(t, ro.ObjectFieldsValues, "test-pod")
+
+	nonCompliant := newPortReportObject("test-ns", "test-pod", "plaintext", false, port)
+	assert.Equal(t, testhelper.ListeningPortType, nonCompliant.ObjectType)
+	assert.Contains(t, nonCompliant.ObjectFieldsKeys, testhelper.ReasonForNonCompliance)
+	assert.Contains(t, nonCompliant.ObjectFieldsValues, "plaintext")
+}
+
+func TestGetFirstProbeContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		probePods map[string]*corev1.Pod
+		wantOK    bool
+	}{
+		{
+			name:      "nil map",
+			probePods: nil,
+			wantOK:    false,
+		},
+		{
+			name:      "empty map",
+			probePods: map[string]*corev1.Pod{},
+			wantOK:    false,
+		},
+		{
+			name:      "nil probe pod",
+			probePods: map[string]*corev1.Pod{"node1": nil},
+			wantOK:    false,
+		},
+		{
+			name: "probe pod with no containers",
+			probePods: map[string]*corev1.Pod{
+				"node1": {
+					ObjectMeta: metav1.ObjectMeta{Name: "probe", Namespace: "cnf-certsuite"},
+					Spec:       corev1.PodSpec{},
+				},
+			},
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			env := &provider.TestEnvironment{ProbePods: tt.probePods}
+			_, _, ok := getFirstProbeContext(env)
+			assert.Equal(t, tt.wantOK, ok)
+		})
+	}
+}
+
+func TestUnsecuredContainerPorts_NoProbePods(t *testing.T) {
+	t.Parallel()
+
+	check := checksdb.NewCheck("test-unsecured-ports", []string{"test"})
+	env := &provider.TestEnvironment{ProbePods: map[string]*corev1.Pod{}}
+	testUnsecuredContainerPorts(check, env)
+	assert.Equal(t, checksdb.CheckResultSkipped, check.Result.String())
+}

--- a/tests/networking/suite_test.go
+++ b/tests/networking/suite_test.go
@@ -15,3 +15,86 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package networking
+
+import (
+	"testing"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
+	"github.com/redhat-best-practices-for-k8s/certsuite/tests/networking/netutil"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestParseNonTLSPortsAnnotation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    map[int32]bool
+	}{
+		{
+			name:        "no annotation",
+			annotations: nil,
+			expected:    map[int32]bool{},
+		},
+		{
+			name:        "empty annotation value",
+			annotations: map[string]string{nonTLSPortsAnnotation: ""},
+			expected:    map[int32]bool{},
+		},
+		{
+			name:        "single port",
+			annotations: map[string]string{nonTLSPortsAnnotation: "8080"},
+			expected:    map[int32]bool{8080: true},
+		},
+		{
+			name:        "multiple ports with whitespace",
+			annotations: map[string]string{nonTLSPortsAnnotation: "80, 443, 8080"},
+			expected:    map[int32]bool{80: true, 443: true, 8080: true},
+		},
+		{
+			name:        "invalid port skipped",
+			annotations: map[string]string{nonTLSPortsAnnotation: "80, abc, 443"},
+			expected:    map[int32]bool{80: true, 443: true},
+		},
+		{
+			name:        "out-of-range ports skipped",
+			annotations: map[string]string{nonTLSPortsAnnotation: "0, 80, 70000"},
+			expected:    map[int32]bool{80: true},
+		},
+		{
+			name:        "unrelated annotation ignored",
+			annotations: map[string]string{"other-annotation": "8080"},
+			expected:    map[int32]bool{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			pod := &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "test-pod",
+						Namespace:   "test-ns",
+						Annotations: tt.annotations,
+					},
+				},
+			}
+			check := checksdb.NewCheck("test-parse-annotation", []string{"test"})
+			result := parseNonTLSPortsAnnotation(pod, check)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestNewPortReportObject(t *testing.T) {
+	t.Parallel()
+
+	port := netutil.PortInfo{PortNumber: 8080, Protocol: "TCP"}
+	ro := newPortReportObject("test-ns", "test-pod", "port is TLS", true, port)
+	assert.NotNil(t, ro)
+}

--- a/tests/networking/tlsversion/tlsversion.go
+++ b/tests/networking/tlsversion/tlsversion.go
@@ -1,0 +1,88 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package tlsversion
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+)
+
+const (
+	opensslCipherNone       = "Cipher is (NONE)"
+	opensslAlertProtoVer    = "alert protocol version"
+	opensslAlertHandshake   = "alert handshake failure"
+	opensslHandshakeFailure = "handshake failure"
+	opensslConnected        = "CONNECTED"
+	opensslConnErrno        = "errno"
+	cipherUnknown           = "unknown"
+)
+
+func extractOpenSSLCipher(stdout string) string {
+	for line := range strings.SplitSeq(stdout, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if after, ok := strings.CutPrefix(trimmed, "Cipher    :"); ok {
+			return strings.TrimSpace(after)
+		}
+		if after, ok := strings.CutPrefix(trimmed, "Cipher:"); ok {
+			return strings.TrimSpace(after)
+		}
+	}
+	return cipherUnknown
+}
+
+// IsPortTLS probes a single TCP port via openssl to determine whether it speaks TLS.
+// It does not validate TLS version or cipher compliance — only whether TLS is present.
+func IsPortTLS(ch clientsholder.Command, ctx clientsholder.Context, address string, port int32) (isTLS, reachable bool, reason string) {
+	endpoint := net.JoinHostPort(address, strconv.Itoa(int(port)))
+	cmd := fmt.Sprintf("echo | timeout 5 openssl s_client -connect %s 2>&1", endpoint)
+	stdout, _, err := ch.ExecCommandContainer(ctx, cmd)
+
+	if err != nil && !strings.Contains(stdout, opensslConnected) && !strings.Contains(stdout, opensslConnErrno) &&
+		!strings.Contains(stdout, "SSL") && !strings.Contains(stdout, "Cipher") {
+		return false, false, fmt.Sprintf("exec probe failed: %v", err)
+	}
+
+	if strings.Contains(stdout, "connect:errno=") || strings.Contains(stdout, "Connection refused") {
+		return false, false, "port unreachable"
+	}
+
+	if !strings.Contains(stdout, opensslConnected) && !strings.Contains(stdout, opensslConnErrno) {
+		return false, false, "no recognizable openssl output"
+	}
+
+	// TLS alerts indicate a genuine TLS server (even if it rejected our params)
+	if strings.Contains(stdout, opensslAlertProtoVer) ||
+		strings.Contains(stdout, opensslAlertHandshake) ||
+		strings.Contains(stdout, opensslHandshakeFailure) {
+		return true, true, "TLS server detected (handshake alert)"
+	}
+
+	// Successful TLS handshake: cipher is not NONE
+	if !strings.Contains(stdout, opensslCipherNone) {
+		cipher := extractOpenSSLCipher(stdout)
+		if cipher != cipherUnknown && cipher != "0000" && cipher != "(NONE)" {
+			return true, true, fmt.Sprintf("TLS negotiated (cipher: %s)", cipher)
+		}
+	}
+
+	// Connected but no TLS indicators — plaintext service
+	return false, true, "plaintext service (no TLS)"
+}

--- a/tests/networking/tlsversion/tlsversion_test.go
+++ b/tests/networking/tlsversion/tlsversion_test.go
@@ -1,0 +1,201 @@
+// Copyright (C) 2024-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package tlsversion
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockPattern struct {
+	key    string
+	stdout string
+	err    error
+}
+
+func newMockCommand(patterns ...mockPattern) *clientsholder.MockCommand {
+	return &clientsholder.MockCommand{
+		ExecFunc: func(_ clientsholder.Context, command string) (string, string, error) {
+			for _, p := range patterns {
+				if strings.Contains(command, p.key) {
+					return p.stdout, "", p.err
+				}
+			}
+			return "", "", fmt.Errorf("unexpected command: %s", command)
+		},
+	}
+}
+
+func TestIsPortTLS_TLSServer(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.True(t, isTLS, "expected TLS, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS negotiated")
+}
+
+func TestIsPortTLS_PlaintextService(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nCipher is (NONE)\npacket length too long\n---",
+			err:    fmt.Errorf("exit status 1"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 8080)
+	assert.False(t, isTLS, "expected plaintext, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "plaintext")
+}
+
+func TestIsPortTLS_ConnectionRefused(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "connect:errno=111\nConnection refused",
+			err:    fmt.Errorf("exit status 1"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 9999)
+	assert.False(t, isTLS)
+	assert.False(t, reachable)
+	assert.Contains(t, reason, "unreachable")
+}
+
+func TestIsPortTLS_TLSHandshakeAlert(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nalert handshake failure\nCipher is (NONE)\n---",
+			err:    fmt.Errorf("exit status 1"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.True(t, isTLS, "TLS alert means genuine TLS server, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS server detected")
+}
+
+func TestIsPortTLS_ExecFailed(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "",
+			err:    fmt.Errorf("command not found"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, _ := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.False(t, isTLS)
+	assert.False(t, reachable)
+}
+
+func TestIsPortTLS_AlertProtocolVersion(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nalert protocol version\nCipher is (NONE)\n---",
+			err:    fmt.Errorf("exit status 1"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.True(t, isTLS, "protocol version alert means TLS server, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS server detected")
+}
+
+func TestIsPortTLS_HandshakeFailureWithoutAlertPrefix(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nhandshake failure\n---",
+			err:    fmt.Errorf("exit status 1"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.True(t, isTLS, "handshake failure means TLS server, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS server detected")
+}
+
+func TestIsPortTLS_CipherIs0000(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nCipher    : 0000\nProtocol  : TLSv1.2\n---",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.False(t, isTLS, "cipher 0000 means rejected, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "plaintext")
+}
+
+func TestIsPortTLS_CipherNONEViaExtraction(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nCipher    : (NONE)\nProtocol  : TLSv1.2\n---",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.False(t, isTLS, "cipher (NONE) via extraction means no TLS, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "plaintext")
+}
+
+func TestIsPortTLS_NoRecognizableOutput(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "some random garbage output",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.False(t, isTLS)
+	assert.False(t, reachable)
+	assert.Contains(t, reason, "no recognizable openssl output")
+}
+
+func TestExtractOpenSSLCipher(t *testing.T) {
+	tests := []struct {
+		name     string
+		stdout   string
+		expected string
+	}{
+		{"spaced format", "Cipher    : ECDHE-RSA-AES128-GCM-SHA256\nProtocol  : TLSv1.2", "ECDHE-RSA-AES128-GCM-SHA256"},
+		{"compact format", "Cipher:TLS_AES_256_GCM_SHA384\nProtocol: TLSv1.3", "TLS_AES_256_GCM_SHA384"},
+		{"no cipher line", "Protocol  : TLSv1.2\nSome other output", cipherUnknown},
+		{"empty output", "", cipherUnknown},
+		{"cipher 0000", "Cipher    : 0000\nProtocol  : TLSv1.2", "0000"},
+		{"cipher NONE", "Cipher    : (NONE)\nProtocol  : TLSv1.2", "(NONE)"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expected, extractOpenSSLCipher(tc.stdout))
+		})
+	}
+}

--- a/tests/networking/tlsversion/tlsversion_test.go
+++ b/tests/networking/tlsversion/tlsversion_test.go
@@ -542,9 +542,77 @@ func TestIsPortTLS_ExecFailed(t *testing.T) {
 		},
 	)
 	ctx := clientsholder.NewContext("ns", "pod", "container")
-	isTLS, reachable, _ := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
 	assert.False(t, isTLS)
 	assert.False(t, reachable)
+	assert.Contains(t, reason, "exec probe failed")
+}
+
+func TestIsPortTLS_AlertProtocolVersion(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nalert protocol version\nCipher is (NONE)\n---",
+			err:    fmt.Errorf("exit status 1"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.True(t, isTLS, "protocol version alert means TLS server, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS server detected")
+}
+
+func TestIsPortTLS_HandshakeFailureWithoutAlertPrefix(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nhandshake failure\n---",
+			err:    fmt.Errorf("exit status 1"),
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.True(t, isTLS, "handshake failure means TLS server, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS server detected")
+}
+
+func TestIsPortTLS_CipherIs0000(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nCipher    : 0000\nProtocol  : TLSv1.2\n---",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.False(t, isTLS, "cipher 0000 means rejected, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "plaintext")
+}
+
+func TestIsPortTLS_CipherNONEViaExtraction(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nCipher    : (NONE)\nProtocol  : TLSv1.2\n---",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.False(t, isTLS, "cipher (NONE) via extraction means no TLS, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "plaintext")
+}
+
+func TestIsPortTLS_NoRecognizableOutput(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "some random garbage output",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.False(t, isTLS)
+	assert.False(t, reachable)
+	assert.Contains(t, reason, "no recognizable openssl output")
 }
 
 func TestVersionsAbove(t *testing.T) {
@@ -931,6 +999,65 @@ func TestOpensslVersionName(t *testing.T) {
 			assert.Equal(t, tc.expected, opensslVersionName(tc.ver))
 		})
 	}
+}
+
+func TestIsPortTLS_ConnectedNoCipherLine(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\n---",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+	assert.False(t, isTLS, "unknown cipher should fall through to plaintext, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "plaintext")
+}
+
+func TestIsPortTLS_ExecErrorWithSSLInStdout(t *testing.T) {
+	t.Run("ssl without connected is not exec probe failed", func(t *testing.T) {
+		mock := newMockCommand(
+			mockPattern{key: "s_client",
+				stdout: "SSL routines:ssl3_read_bytes:sslv3 alert handshake failure",
+				err:    fmt.Errorf("exit status 1"),
+			},
+		)
+		ctx := clientsholder.NewContext("ns", "pod", "container")
+		isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+		assert.True(t, isTLS, "SSL handshake alert is a TLS server even without CONNECTED, reason: %s", reason)
+		assert.True(t, reachable)
+		assert.NotContains(t, reason, "exec probe failed")
+		assert.Contains(t, reason, "TLS server detected")
+	})
+
+	t.Run("connected with cipher still detects TLS despite exec error", func(t *testing.T) {
+		mock := newMockCommand(
+			mockPattern{key: "s_client",
+				stdout: "CONNECTED(00000003)\n---\nSSL handshake\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+				err:    fmt.Errorf("exit status 1"),
+			},
+		)
+		ctx := clientsholder.NewContext("ns", "pod", "container")
+		isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 443)
+		assert.True(t, isTLS, "expected TLS despite exec error, reason: %s", reason)
+		assert.True(t, reachable)
+		assert.Contains(t, reason, "TLS negotiated")
+	})
+}
+
+func TestIsPortTLS_IPv6Address(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "2001:db8::1", 443)
+	assert.True(t, isTLS, "expected TLS over IPv6, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS negotiated")
+	assert.Equal(t, 1, mock.CallCount())
+	assert.Contains(t, mock.Calls()[0].Command, "[2001:db8::1]:443")
 }
 
 func TestExtractOpenSSLCipher(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `networking-unsecured-container-ports` check that probes listening TCP ports via openssl and flags plaintext as non-compliant
- Allow per-pod exemptions with `certsuite.redhat.com/non-tls-ports`
- Reuse `tlsversion.IsPortTLS` for TLS-or-not detection
- Classify as Optional across Extended, Telco, Non-Telco, and Far-Edge

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [redhat-best-practices-for-k8s/certsuite#3456](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3456) | Add OCP-version-aware TLS minimum version compliance test | Open |
| [dci-labs/vcp-config#1631](https://github.com/dci-labs/vcp-config/pull/1631) | feat: add networking-unsecured-container-ports to expected results exclusion | Open |
| [dci-labs/bos2-ci-config#704](https://github.com/dci-labs/bos2-ci-config/pull/704) | feat: add networking-unsecured-container-ports to expected results exclusion | Open |
| [redhat-best-practices-for-k8s/certsuite#3580](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3580) | Add unsecured container ports TLS detection test | Closed |

## Test Plan
- [ ] CI passes
- [ ] `make build` / `make test` / `make lint` pass
- [ ] Smoke expected_results lists this check as fail (plaintext pods)
- [ ] Exemption annotation skips annotated ports