### PR TITLE
Wrap bare error returns with fmt.Errorf for better context

### DIFF
--- a/cmd/certsuite/claim/show/csv/csv.go
+++ b/cmd/certsuite/claim/show/csv/csv.go
@@ -96,7 +96,7 @@ func dumpCsv(_ *cobra.Command, _ []string) error {
 	// Check claim format version
 	err = claim.CheckVersion(claimScheme.Claim.Versions.ClaimFormat)
 	if err != nil {
-		return err
+		return fmt.Errorf("claim format version check failed: %w", err)
 	}
 
 	// loads the mapping between CNF name and type

--- a/cmd/certsuite/claim/show/failures/failures.go
+++ b/cmd/certsuite/claim/show/failures/failures.go
@@ -293,7 +293,7 @@ func showFailures(_ *cobra.Command, _ []string) error {
 	// Check claim format version
 	err = claim.CheckVersion(claimScheme.Claim.Versions.ClaimFormat)
 	if err != nil {
-		return err
+		return fmt.Errorf("claim format version check failed: %w", err)
 	}
 
 	// Order test case results by test suite, using a helper map.

--- a/cmd/certsuite/generate/catalog/catalog.go
+++ b/cmd/certsuite/generate/catalog/catalog.go
@@ -76,7 +76,7 @@ type catalogSummary struct {
 func emitTextFromFile(filename string) error {
 	text, err := os.ReadFile(filename)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to read catalog template file %s: %w", filename, err)
 	}
 	fmt.Print(string(text))
 	return nil

--- a/cmd/certsuite/upload/results_spreadsheet/sheet_utils.go
+++ b/cmd/certsuite/upload/results_spreadsheet/sheet_utils.go
@@ -65,7 +65,7 @@ func addBasicFilterToSpreadSheet(srv *sheets.Service, spreadsheet *sheets.Spread
 		Requests: requests,
 	}).Do()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to apply basic filter to spreadsheet: %w", err)
 	}
 	return nil
 }
@@ -107,7 +107,7 @@ func addDescendingSortFilterToSheet(srv *sheets.Service, spreadsheet *sheets.Spr
 		Requests: requests,
 	}).Do()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to apply descending sort filter to sheet %s: %w", sheetName, err)
 	}
 	return nil
 }
@@ -164,5 +164,8 @@ func addFilterByFailedAndMandatoryToSheet(srv *sheets.Service, spreadsheet *shee
 	_, err = srv.Spreadsheets.BatchUpdate(spreadsheet.SpreadsheetId, &sheets.BatchUpdateSpreadsheetRequest{
 		Requests: requests,
 	}).Do()
-	return err
+	if err != nil {
+		return fmt.Errorf("failed to apply filter for failed mandatory tests to sheet %s: %w", sheetName, err)
+	}
+	return nil
 }

--- a/internal/results/rhconnect.go
+++ b/internal/results/rhconnect.go
@@ -142,7 +142,7 @@ func SendResultsToConnectAPI(zipFile, apiKey, connectBaseURL, certID, proxyURL, 
 
 	claimFile, err := os.Open(zipFile)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open zip file %s for upload: %w", zipFile, err)
 	}
 	defer claimFile.Close()
 
@@ -152,25 +152,25 @@ func SendResultsToConnectAPI(zipFile, apiKey, connectBaseURL, certID, proxyURL, 
 	}
 
 	if _, err = io.Copy(fw, claimFile); err != nil {
-		return err
+		return fmt.Errorf("failed to copy zip file to multipart writer: %w", err)
 	}
 
 	// Create a form field
 	err = createFormField(w, "type", "RhocpBestPracticeTestResult")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create 'type' form field: %w", err)
 	}
 
 	// Create a form field
 	err = createFormField(w, "certId", certID)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create 'certId' form field: %w", err)
 	}
 
 	// Create a form field
 	err = createFormField(w, "description", "CNF Test Results")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create 'description' form field: %w", err)
 	}
 
 	w.Close()

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -3,6 +3,7 @@ package collector
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -18,15 +19,15 @@ const (
 func addClaimFileToPostRequest(w *multipart.Writer, claimFilePath string) error {
 	claimFile, err := os.Open(claimFilePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to open claim file %s: %w", claimFilePath, err)
 	}
 	defer claimFile.Close()
 	fw, err := w.CreateFormFile("claimFile", claimFilePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create form file field for claim: %w", err)
 	}
 	if _, err = io.Copy(fw, claimFile); err != nil {
-		return err
+		return fmt.Errorf("failed to copy claim file to multipart writer: %w", err)
 	}
 	return nil
 }
@@ -34,26 +35,26 @@ func addClaimFileToPostRequest(w *multipart.Writer, claimFilePath string) error 
 func addVarFieldsToPostRequest(w *multipart.Writer, executedBy, partnerName, password string) error {
 	fw, err := w.CreateFormField("executed_by")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create form field 'executed_by': %w", err)
 	}
 	if _, err = fw.Write([]byte(executedBy)); err != nil {
-		return err
+		return fmt.Errorf("failed to write 'executed_by' field: %w", err)
 	}
 
 	fw, err = w.CreateFormField("partner_name")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create form field 'partner_name': %w", err)
 	}
 	if _, err = fw.Write([]byte(partnerName)); err != nil {
-		return err
+		return fmt.Errorf("failed to write 'partner_name' field: %w", err)
 	}
 
 	fw, err = w.CreateFormField("decoded_password")
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create form field 'decoded_password': %w", err)
 	}
 	if _, err = fw.Write([]byte(password)); err != nil {
-		return err
+		return fmt.Errorf("failed to write 'decoded_password' field: %w", err)
 	}
 	return nil
 }
@@ -80,7 +81,7 @@ func createSendToCollectorPostRequest(endPoint, claimFilePath, executedBy, partn
 	// Create POST request with the form-data as body
 	req, err := http.NewRequest("POST", endPoint, &buffer)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create POST request to %s: %w", endPoint, err)
 	}
 	req.Header.Set("Content-Type", w.FormDataContentType())
 
@@ -91,7 +92,7 @@ func SendClaimFileToCollector(endPoint, claimFilePath, executedBy, partnerName, 
 	// Temporary end point
 	postReq, err := createSendToCollectorPostRequest(endPoint, claimFilePath, executedBy, partnerName, password)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create collector POST request: %w", err)
 	}
 
 	client := &http.Client{
@@ -99,7 +100,7 @@ func SendClaimFileToCollector(endPoint, claimFilePath, executedBy, partnerName, 
 	}
 	resp, err := client.Do(postReq)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to send claim file to collector at %s: %w", endPoint, err)
 	}
 	defer resp.Body.Close()
 	return nil

--- a/pkg/provider/containers.go
+++ b/pkg/provider/containers.go
@@ -108,7 +108,7 @@ func (c *Container) SetPreflightResults(preflightImageCache map[string]Preflight
 	// Create artifacts handler
 	artifactsWriter, err := artifacts.NewMapWriter()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create artifacts writer for container preflight check: %w", err)
 	}
 	ctx := artifacts.ContextWithWriter(context.TODO(), artifactsWriter)
 

--- a/pkg/provider/operators.go
+++ b/pkg/provider/operators.go
@@ -86,7 +86,7 @@ func (op *Operator) SetPreflightResults(env *TestEnvironment) error {
 	// Create artifacts handler
 	artifactsWriter, err := artifacts.NewMapWriter()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create artifacts writer for operator preflight check: %w", err)
 	}
 	ctx := artifacts.ContextWithWriter(context.TODO(), artifactsWriter)
 	opts := []plibOperator.Option{}
@@ -337,7 +337,7 @@ func getOperatorTargetNamespaces(namespace string) ([]string, error) {
 	list, err := client.OlmClient.OperatorsV1().OperatorGroups(namespace).List(
 		context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list operator groups in namespace %s: %w", namespace, err)
 	}
 
 	if len(list.Items) == 0 {
@@ -352,7 +352,7 @@ func GetAllOperatorGroups() ([]*olmv1.OperatorGroup, error) {
 
 	list, err := client.OlmClient.OperatorsV1().OperatorGroups("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil && !k8serrors.IsNotFound(err) {
-		return nil, err
+		return nil, fmt.Errorf("failed to list all operator groups: %w", err)
 	}
 
 	if k8serrors.IsNotFound(err) {

--- a/tests/lifecycle/podrecreation/podrecreation.go
+++ b/tests/lifecycle/podrecreation/podrecreation.go
@@ -53,7 +53,7 @@ func CordonHelper(name, operation string) error {
 		// Fetch node object
 		node, err := clients.K8sClient.CoreV1().Nodes().Get(context.TODO(), name, metav1.GetOptions{})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get node %s: %w", name, err)
 		}
 		switch operation {
 		case Cordon:
@@ -65,7 +65,10 @@ func CordonHelper(name, operation string) error {
 		}
 		// Update the node
 		_, err = clients.K8sClient.CoreV1().Nodes().Update(context.TODO(), node, metav1.UpdateOptions{})
-		return err
+		if err != nil {
+			return fmt.Errorf("failed to update node %s: %w", name, err)
+		}
+		return nil
 	})
 	if retryErr != nil {
 		log.Error("can not %s node: %s, err=%v", operation, name, retryErr)
@@ -124,8 +127,7 @@ func deletePod(pod *corev1.Pod, mode string, wg *sync.WaitGroup) error {
 		GracePeriodSeconds: &gracePeriodSeconds,
 	})
 	if err != nil {
-		log.Error("Error deleting %s err: %v", pod.String(), err)
-		return err
+		return fmt.Errorf("failed to delete pod %s/%s: %w", pod.Namespace, pod.Name, err)
 	}
 	if mode == DeleteBackground {
 		return nil

--- a/tests/lifecycle/scaling/crd_scaling.go
+++ b/tests/lifecycle/scaling/crd_scaling.go
@@ -21,6 +21,7 @@ package scaling
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
@@ -89,13 +90,12 @@ func scaleCrHelper(scalesGetter scale.ScalesGetter, rc schema.GroupResource, aut
 		name := autoscalerpram.GetName()
 		scalingObject, err := scalesGetter.Scales(namespace).Get(context.TODO(), rc, name, metav1.GetOptions{})
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get scale object for %s/%s: %w", namespace, name, err)
 		}
 		scalingObject.Spec.Replicas = replicas
 		_, err = scalesGetter.Scales(namespace).Update(context.TODO(), rc, scalingObject, metav1.UpdateOptions{})
 		if err != nil {
-			logger.Error("Cannot update DynamicClient, err=%v", err)
-			return err
+			return fmt.Errorf("failed to update scale object for %s/%s: %w", namespace, name, err)
 		}
 		if !podsets.WaitForScalingToComplete(namespace, name, timeout, rc, logger) {
 			logger.Error("Cannot update CR %s:%s", namespace, name)
@@ -166,15 +166,13 @@ func scaleHpaCRDHelper(hpscaler hps.HorizontalPodAutoscalerInterface, hpaName, c
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		hpa, err := hpscaler.Get(context.TODO(), hpaName, metav1.GetOptions{})
 		if err != nil {
-			logger.Error("Cannot update autoscaler to scale %s:%s, err=%v", namespace, crName, err)
-			return err
+			return fmt.Errorf("failed to get HPA %s in namespace %s: %w", hpaName, namespace, err)
 		}
 		hpa.Spec.MinReplicas = &min
 		hpa.Spec.MaxReplicas = max
 		_, err = hpscaler.Update(context.TODO(), hpa, metav1.UpdateOptions{})
 		if err != nil {
-			logger.Error("Cannot update autoscaler to scale %s:%s, err=%v", namespace, crName, err)
-			return err
+			return fmt.Errorf("failed to update HPA %s in namespace %s: %w", hpaName, namespace, err)
 		}
 		if !podsets.WaitForScalingToComplete(namespace, crName, timeout, groupResourceSchema, logger) {
 			logger.Error("Cannot update CR %s:%s", namespace, crName)

--- a/tests/lifecycle/scaling/deployment_scaling.go
+++ b/tests/lifecycle/scaling/deployment_scaling.go
@@ -20,6 +20,7 @@ package scaling
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
@@ -88,14 +89,12 @@ func scaleDeploymentHelper(client typedappsv1.AppsV1Interface, deployment *appsv
 		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
 		dp, err := client.Deployments(deployment.Namespace).Get(context.TODO(), deployment.Name, v1machinery.GetOptions{})
 		if err != nil {
-			logger.Error("Failed to get latest version of Deployment %s:%s", deployment.Namespace, deployment.Name)
-			return err
+			return fmt.Errorf("failed to get deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
 		}
 		dp.Spec.Replicas = &replicas
 		_, err = client.Deployments(deployment.Namespace).Update(context.TODO(), dp, v1machinery.UpdateOptions{})
 		if err != nil {
-			logger.Error("Cannot update Deployment %s:%s", deployment.Namespace, deployment.Name)
-			return err
+			return fmt.Errorf("failed to update deployment %s/%s: %w", deployment.Namespace, deployment.Name, err)
 		}
 		if !podsets.WaitForDeploymentSetReady(deployment.Namespace, deployment.Name, timeout, logger) {
 			logger.Error("Cannot update Deployment %s:%s", deployment.Namespace, deployment.Name)
@@ -164,15 +163,13 @@ func scaleHpaDeploymentHelper(hpscaler hps.HorizontalPodAutoscalerInterface, hpa
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		hpa, err := hpscaler.Get(context.TODO(), hpaName, v1machinery.GetOptions{})
 		if err != nil {
-			logger.Error("Cannot update autoscaler to scale %s:%s , err=%v", namespace, deploymentName, err)
-			return err
+			return fmt.Errorf("failed to get HPA %s in namespace %s: %w", hpaName, namespace, err)
 		}
 		hpa.Spec.MinReplicas = &min
 		hpa.Spec.MaxReplicas = max
 		_, err = hpscaler.Update(context.TODO(), hpa, v1machinery.UpdateOptions{})
 		if err != nil {
-			logger.Error("Cannot update autoscaler to scale %s:%s, err=%v", namespace, deploymentName, err)
-			return err
+			return fmt.Errorf("failed to update HPA %s in namespace %s: %w", hpaName, namespace, err)
 		}
 		if !podsets.WaitForDeploymentSetReady(namespace, deploymentName, timeout, logger) {
 			logger.Error("Deployment not ready after scale operation %s:%s", namespace, deploymentName)

--- a/tests/lifecycle/scaling/statefulset_scaling.go
+++ b/tests/lifecycle/scaling/statefulset_scaling.go
@@ -20,6 +20,7 @@ package scaling
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
@@ -88,14 +89,12 @@ func scaleStatefulsetHelper(clients *clientsholder.ClientsHolder, ssClient v1.St
 		// RetryOnConflict uses exponential backoff to avoid exhausting the apiserver
 		ss, err := ssClient.Get(context.TODO(), name, v1machinery.GetOptions{})
 		if err != nil {
-			logger.Error("Failed to get latest version of statefulset %s:%s with error %s", namespace, name, err)
-			return err
+			return fmt.Errorf("failed to get statefulset %s/%s: %w", namespace, name, err)
 		}
 		ss.Spec.Replicas = &replicas
 		_, err = clients.K8sClient.AppsV1().StatefulSets(namespace).Update(context.TODO(), ss, v1machinery.UpdateOptions{})
 		if err != nil {
-			logger.Error("Cannot update statefulset %s:%s", namespace, name)
-			return err
+			return fmt.Errorf("failed to update statefulset %s/%s: %w", namespace, name, err)
 		}
 		if !podsets.WaitForStatefulSetReady(namespace, name, timeout, logger) {
 			logger.Error("Cannot update statefulset %s:%s", namespace, name)
@@ -165,15 +164,13 @@ func scaleHpaStatefulSetHelper(hpscaler hps.HorizontalPodAutoscalerInterface, hp
 	retryErr := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		hpa, err := hpscaler.Get(context.TODO(), hpaName, v1machinery.GetOptions{})
 		if err != nil {
-			logger.Error("Cannot update autoscaler to scale %s:%s, err=%v", namespace, statefulsetName, err)
-			return err
+			return fmt.Errorf("failed to get HPA %s in namespace %s: %w", hpaName, namespace, err)
 		}
 		hpa.Spec.MinReplicas = &min
 		hpa.Spec.MaxReplicas = max
 		_, err = hpscaler.Update(context.TODO(), hpa, v1machinery.UpdateOptions{})
 		if err != nil {
-			logger.Error("Cannot update autoscaler to scale %s:%s, err=%v", namespace, statefulsetName, err)
-			return err
+			return fmt.Errorf("failed to update HPA %s in namespace %s: %w", hpaName, namespace, err)
 		}
 		if !podsets.WaitForStatefulSetReady(namespace, statefulsetName, timeout, logger) {
 			logger.Error("StatefulSet not ready after scale operation %s:%s", namespace, statefulsetName)


### PR DESCRIPTION
## Summary

- Replace bare `return err` statements across 13 files with `fmt.Errorf("...: %w", err)` to provide actionable context when errors propagate up the call chain
- Covers collector uploads, Red Hat Connect API calls, Kubernetes scaling operations, pod lifecycle helpers, claim file parsing, and spreadsheet utilities
- All error wrapping uses `%w` verb for proper error chain unwrapping

## Related to

- [redhat-best-practices-for-k8s/certsuite#3730](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3730) — `%w` error wrapping in certsuite (open)
- [openshift/tls-scanner#70](https://github.com/openshift/tls-scanner/pull/70) — `%w` error wrapping in tls-scanner (merged)
- [openshift-kni/commatrix#482](https://github.com/openshift-kni/commatrix/pull/482) — `%w` error wrapping in commatrix (merged)
- [crc-org/crc#5180](https://github.com/crc-org/crc/pull/5180) — `%w` error wrapping in crc (merged)
- [openshift-kni/lifecycle-agent#6319](https://github.com/openshift-kni/lifecycle-agent/pull/6319) — bare error wrapping in lifecycle-agent (open)
- [redhat-best-practices-for-k8s/certsuite#3633](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3633) — bare error wrapping in certsuite (merged)

## Test plan

- [x] `make test` — all unit tests pass
- [x] `golangci-lint` — 0 issues
- [x] QE smoke tests pass in CI