### PR TITLE
Remove unused constants and variables across codebase

### DIFF
--- a/cmd/certsuite/claim/show/failures/failures.go
+++ b/cmd/certsuite/claim/show/failures/failures.go
@@ -95,9 +95,8 @@ Test Suite: lifecycle
 )
 
 const (
-	outputFormatText    = "text"
-	outputFormatJSON    = "json"
-	outputFarmatInvalid = "invalid"
+	outputFormatText = "text"
+	outputFormatJSON = "json"
 )
 
 var availableOutputFormats = []string{

--- a/cmd/certsuite/upload/results_spreadsheet/const.go
+++ b/cmd/certsuite/upload/results_spreadsheet/const.go
@@ -1,9 +1,8 @@
 package resultsspreadsheet
 
 const (
-	ConclusionSheetName            = "conclusions"
-	RawResultsSheetName            = "raw results"
-	SingleWorkloadResultsSheetName = "results"
+	ConclusionSheetName = "conclusions"
+	RawResultsSheetName = "raw results"
 
 	categoryConclusionsCol        = "Category"
 	workloadVersionConclusionsCol = "Workload Version"

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,11 +15,7 @@ const (
 	Red    = "\033[31m"
 	Green  = "\033[32m"
 	Yellow = "\033[33m"
-	Blue   = "\033[34m"
-	Purple = "\033[35m"
 	Cyan   = "\033[36m"
-	Gray   = "\033[37m"
-	White  = "\033[97m"
 
 	ClearLineCode = "\r\033[2K\r"
 )

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -54,9 +54,6 @@ const (
 	// NonOpenshiftClusterVersion is a fake version number for non openshift clusters (kind/minikube)
 	NonOpenshiftClusterVersion = "0.0.0"
 	tnfCsvTargetLabelName      = "operator"
-	tnfCsvTargetLabelValue     = ""
-	tnfLabelPrefix             = "redhat-best-practices-for-k8s.com"
-	labelTemplate              = "%s/%s"
 )
 
 type PodStates struct {

--- a/pkg/autodiscover/constants.go
+++ b/pkg/autodiscover/constants.go
@@ -16,7 +16,6 @@
 package autodiscover
 
 const (
-	probeHelperPodsLabelName      = "redhat-best-practices-for-k8s.com/app"
-	probeHelperPodsLabelValue     = "certsuite-probe"
-	csvNameWithNamespaceFormatStr = "%s, ns=%s"
+	probeHelperPodsLabelName  = "redhat-best-practices-for-k8s.com/app"
+	probeHelperPodsLabelValue = "certsuite-probe"
 )

--- a/pkg/scheduling/scheduling.go
+++ b/pkg/scheduling/scheduling.go
@@ -45,10 +45,7 @@ const (
 	NoProcessFoundErrMsg = "No such process"
 )
 
-var (
-	CrcClientExecCommandContainerNSEnter = crclient.ExecCommandContainerNSEnter
-	GetProcessCPUSchedulingFn            = GetProcessCPUScheduling
-)
+var GetProcessCPUSchedulingFn = GetProcessCPUScheduling
 
 func parseSchedulingPolicyAndPriority(chrtCommandOutput string) (schedPolicy string, schedPriority int, err error) {
 	/*	Sample output:

--- a/tests/lifecycle/suite.go
+++ b/tests/lifecycle/suite.go
@@ -43,8 +43,6 @@ const (
 	timeoutPodSetReady         = 7 * time.Minute
 	minWorkerNodesForLifecycle = 2
 	statefulSet                = "StatefulSet"
-	localStorage               = "local-storage"
-	intrusiveTcSkippedReason   = "This is an intrusive test case and the flag --intrusive was set"
 )
 
 var (


### PR DESCRIPTION
## Summary

Remove 11 dead declarations found via static analysis across 7 files:

| File | Removed | Why |
|------|---------|-----|
| `cmd/certsuite/claim/show/failures/failures.go` | `outputFarmatInvalid` | Defined with typo, never referenced |
| `pkg/autodiscover/autodiscover.go` | `tnfCsvTargetLabelValue`, `tnfLabelPrefix`, `labelTemplate` | Defined but never used |
| `pkg/autodiscover/constants.go` | `csvNameWithNamespaceFormatStr` | Defined but never used |
| `tests/lifecycle/suite.go` | `localStorage`, `intrusiveTcSkippedReason` | Defined but never used |
| `cmd/certsuite/upload/results_spreadsheet/const.go` | `SingleWorkloadResultsSheetName` | Defined but never used |
| `internal/cli/cli.go` | `Blue`, `Purple`, `Gray`, `White` | Color codes defined but never used |
| `pkg/scheduling/scheduling.go` | `CrcClientExecCommandContainerNSEnter` | Function pointer defined but never called |

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `make test` passes