### PR TITLE
Make Kubernetes client timeout configurable

### DIFF
--- a/docs/runtime-env.md
+++ b/docs/runtime-env.md
@@ -40,3 +40,16 @@ against a private container registry that has self-signed certificates.
 
 Note that you can also specify the probe pod image to use with `SUPPORT_IMAGE`
 environment variable, default to `certsuite-probe:v0.0.37`.
+
+## Client Timeout
+
+`CERTSUITE_CLIENT_TIMEOUT` (default: `10s`) sets the timeout for Kubernetes API
+client operations such as resource discovery and API group listing. Increase
+this value when running against remote or high-latency clusters where the
+default 10-second timeout causes failures during startup.
+
+```shell
+export CERTSUITE_CLIENT_TIMEOUT=30s
+```
+
+Accepts any valid Go duration string (e.g., `15s`, `1m`, `90s`).

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -19,6 +19,7 @@ package clientsholder
 import (
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -59,10 +60,23 @@ import (
 const (
 	DefaultTimeout = 10 * time.Second
 
+	clientTimeoutEnvVar = "CERTSUITE_CLIENT_TIMEOUT"
+
 	defaultCluster = "default-cluster"
 	defaultUser    = "default-user"
 	defaultContext = "default-context"
 )
+
+func getClientTimeout() time.Duration {
+	if v := os.Getenv(clientTimeoutEnvVar); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			log.Info("Using custom client timeout from %s: %v", clientTimeoutEnvVar, d)
+			return d
+		}
+		log.Warn("Invalid %s value %q, using default %v", clientTimeoutEnvVar, v, DefaultTimeout)
+	}
+	return DefaultTimeout
+}
 
 type ClientsHolder struct {
 	RestConfig           *rest.Config
@@ -301,7 +315,7 @@ func newClientsHolder(filenames ...string) (*ClientsHolder, error) { //nolint:fu
 	if err != nil {
 		return nil, fmt.Errorf("failed to get rest.Config: %v", err)
 	}
-	clientsHolder.RestConfig.Timeout = DefaultTimeout
+	clientsHolder.RestConfig.Timeout = getClientTimeout()
 
 	clientsHolder.DynamicClient, err = dynamic.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `CERTSUITE_CLIENT_TIMEOUT` environment variable to override the hardcoded 10-second Kubernetes API client timeout
- Logs the custom timeout value when set, warns on invalid values and falls back to default
- Documents the new env var in `docs/runtime-env.md`

## Problem

The hardcoded `DefaultTimeout = 10 * time.Second` in `internal/clientsholder/clientsholder.go` causes `FATAL: Failed to create k8s clients holder` errors when running against remote or high-latency clusters. The `ServerPreferredResources` discovery call times out before completing, especially on OCP clusters with many CRDs.

## Usage

```shell
export CERTSUITE_CLIENT_TIMEOUT=30s
certsuite run ...
```

Accepts any valid Go duration string (e.g., `15s`, `1m`, `90s`).

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `make test` passes
- [x] Default behavior unchanged when env var is not set