### PR TITLE
Wrap bare error returns with fmt.Errorf for better diagnostics

### DIFF
--- a/cmd/certsuite/claim/compare/compare.go
+++ b/cmd/certsuite/claim/compare/compare.go
@@ -165,7 +165,7 @@ func unmarshalClaimFile(claimdata []byte) (claim.Schema, error) {
 	var claimDataResult claim.Schema
 	err := json.Unmarshal(claimdata, &claimDataResult)
 	if err != nil {
-		return claim.Schema{}, err
+		return claim.Schema{}, fmt.Errorf("failed to unmarshal claim file data: %w", err)
 	}
 	return claimDataResult, nil
 }

--- a/cmd/certsuite/claim/compare/compare_test.go
+++ b/cmd/certsuite/claim/compare/compare_test.go
@@ -26,7 +26,7 @@ func Test_claimCompareFilesfunc(t *testing.T) {
 			name:          "claim1 is not a json file",
 			claim1Path:    "testdata/invalid.json",
 			claim2Path:    "testdata/claim_access_control.json",
-			expectedError: "failed to unmarshal claim1 file: invalid character 'T' looking for beginning of value",
+			expectedError: "failed to unmarshal claim1 file: failed to unmarshal claim file data: invalid character 'T' looking for beginning of value",
 		},
 		{
 			name:          "claim2 file not found",
@@ -38,7 +38,7 @@ func Test_claimCompareFilesfunc(t *testing.T) {
 			name:          "claim2 is not a json file",
 			claim1Path:    "testdata/claim_observability.json",
 			claim2Path:    "testdata/invalid.json",
-			expectedError: "failed to unmarshal claim2 file: invalid character 'T' looking for beginning of value",
+			expectedError: "failed to unmarshal claim2 file: failed to unmarshal claim file data: invalid character 'T' looking for beginning of value",
 		},
 		// claim_observability.json: claim.json from a run on a 3-nodes cluster with "-l observability".
 		// claim_access_control.json: real claim.json on a 3-nodes cluster with "-l access-control".

--- a/cmd/certsuite/claim/show/failures/failures.go
+++ b/cmd/certsuite/claim/show/failures/failures.go
@@ -281,7 +281,7 @@ func getFailedTestCasesByTestSuite(claimResultsByTestSuite map[string][]*claim.T
 func showFailures(_ *cobra.Command, _ []string) error {
 	outputFormat, err := parseOutputFormatFlag()
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse output format flag: %w", err)
 	}
 
 	// Parse the claim file into the claim scheme.

--- a/cmd/certsuite/upload/results_spreadsheet/drive_utils.go
+++ b/cmd/certsuite/upload/results_spreadsheet/drive_utils.go
@@ -68,7 +68,7 @@ func MoveSpreadSheetToFolder(srv *drive.Service, folder *drive.File, spreadsheet
 func extractFolderIDFromURL(u string) (string, error) {
 	parsedURL, err := url.Parse(u)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to parse folder URL %q: %w", u, err)
 	}
 
 	pathSegments := strings.Split(parsedURL.Path, "/")

--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -61,14 +61,14 @@ func NewCommand() *cobra.Command {
 func readCSV(fp string) ([][]string, error) {
 	file, err := os.Open(fp)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to open CSV file %s: %w", fp, err)
 	}
 	defer file.Close()
 
 	reader := csv.NewReader(file)
 	records, err := reader.ReadAll()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to read CSV data from %s: %w", fp, err)
 	}
 	return records, nil
 }
@@ -136,7 +136,7 @@ func createSingleWorkloadRawResultsSheet(rawResultsSheet *sheets.Sheet, workload
 	headers := GetHeadersFromSheet(rawResultsSheet)
 	indices, err := GetHeaderIndicesByColumnNames(headers, []string{"CNFName"})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to find CNFName column in results sheet: %w", err)
 	}
 	workloadNameIndex := indices[0]
 
@@ -168,7 +168,7 @@ func createSingleWorkloadRawResultsSheet(rawResultsSheet *sheets.Sheet, workload
 func createSingleWorkloadRawResultsSpreadSheet(sheetService *sheets.Service, driveService *drive.Service, folder *drive.File, rawResultsSheet *sheets.Sheet, workloadName string) (*sheets.Spreadsheet, error) {
 	workloadResultsSheet, err := createSingleWorkloadRawResultsSheet(rawResultsSheet, workloadName)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create workload results sheet for %s: %w", workloadName, err)
 	}
 
 	workloadResultsSpreadsheet := &sheets.Spreadsheet{
@@ -180,15 +180,15 @@ func createSingleWorkloadRawResultsSpreadSheet(sheetService *sheets.Service, dri
 
 	workloadResultsSpreadsheet, err = sheetService.Spreadsheets.Create(workloadResultsSpreadsheet).Do()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create spreadsheet for %s: %w", workloadName, err)
 	}
 
 	if err := addFilterByFailedAndMandatoryToSheet(sheetService, workloadResultsSpreadsheet, "results"); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to add filter to results sheet for %s: %w", workloadName, err)
 	}
 
 	if err := MoveSpreadSheetToFolder(driveService, folder, workloadResultsSpreadsheet); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to move spreadsheet to folder for %s: %w", workloadName, err)
 	}
 
 	log.Printf("%s workload's results sheet has been created.\n", workloadName)
@@ -212,7 +212,7 @@ func createConclusionsSheet(sheetsService *sheets.Service, driveService *drive.S
 	rawSheetHeaders := GetHeadersFromSheet(rawResultsSheet)
 	colsIndices, err := GetHeaderIndicesByColumnNames(rawSheetHeaders, []string{workloadNameRawResultsCol, workloadTypeRawResultsCol, operatorVersionRawResultsCol})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to find required columns in raw results sheet: %w", err)
 	}
 
 	workloadNameColIndex := colsIndices[0]

--- a/internal/clientsholder/command.go
+++ b/internal/clientsholder/command.go
@@ -19,6 +19,7 @@ package clientsholder
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -62,8 +63,7 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 
 	exec, err := remotecommand.NewSPDYExecutor(clientsholder.RestConfig, "POST", req.URL())
 	if err != nil {
-		log.Error("%v", err)
-		return stdout, stderr, err
+		return stdout, stderr, fmt.Errorf("failed to create SPDY executor for command %q: %w", command, err)
 	}
 	// enforce an execution timeout for the remote command
 	goCtx, cancel := context.WithTimeout(context.TODO(), ExecCommandTimeout)
@@ -75,12 +75,7 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 	})
 	stdout, stderr = buffOut.String(), buffErr.String()
 	if err != nil {
-		log.Error("%v", err)
-		log.Error("%v", req.URL())
-		log.Error("command: %s", command)
-		log.Error("stderr: %s", stderr)
-		log.Error("stdout: %s", stdout)
-		return stdout, stderr, err
+		return stdout, stderr, fmt.Errorf("failed to execute command %q in %s/%s: %w", command, ctx.GetNamespace(), ctx.GetPodName(), err)
 	}
-	return stdout, stderr, err
+	return stdout, stderr, nil
 }

--- a/internal/results/archiver.go
+++ b/internal/results/archiver.go
@@ -61,7 +61,7 @@ func CompressResultsArtifacts(outputDir string, filePaths []string) (string, err
 
 		tarHeader, err := getFileTarHeader(file)
 		if err != nil {
-			return "", err
+			return "", fmt.Errorf("failed to get tar header for %s: %w", file, err)
 		}
 
 		err = tarWriter.WriteHeader(tarHeader)

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -365,7 +365,7 @@ func getOpenshiftVersion(oClient clientconfigv1.ConfigV1Interface) (ver string, 
 			log.Warn("Unable to get ClusterOperator CR from openshift-apiserver. Running in a non-OCP cluster.")
 			return NonOpenshiftClusterVersion, nil
 		default:
-			return "", err
+			return "", fmt.Errorf("failed to get OpenShift version: %w", err)
 		}
 	}
 
@@ -410,7 +410,7 @@ func getPodsOwnedByCsv(csvName, operatorNamespace string, client *clientsholder.
 	// Get all pods from the target namespace
 	podsList, err := client.K8sClient.CoreV1().Pods(operatorNamespace).List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list pods in namespace %s: %w", operatorNamespace, err)
 	}
 
 	for index := range podsList.Items {

--- a/pkg/autodiscover/autodiscover_clusteroperators.go
+++ b/pkg/autodiscover/autodiscover_clusteroperators.go
@@ -3,6 +3,7 @@ package autodiscover
 
 import (
 	"context"
+	"fmt"
 
 	configv1 "github.com/openshift/api/config/v1"
 	clientconfigv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
@@ -14,7 +15,7 @@ import (
 func findClusterOperators(client clientconfigv1.ClusterOperatorInterface) ([]configv1.ClusterOperator, error) {
 	clusterOperators, err := client.List(context.TODO(), metav1.ListOptions{})
 	if err != nil && !k8serrors.IsNotFound(err) {
-		return nil, err
+		return nil, fmt.Errorf("failed to list cluster operators: %w", err)
 	}
 
 	if k8serrors.IsNotFound(err) {

--- a/pkg/autodiscover/autodiscover_nads.go
+++ b/pkg/autodiscover/autodiscover_nads.go
@@ -3,6 +3,7 @@ package autodiscover
 
 import (
 	"context"
+	"fmt"
 
 	nadClient "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
@@ -16,7 +17,7 @@ func getNetworkAttachmentDefinitions(client *clientsholder.ClientsHolder, namesp
 	for _, ns := range namespaces {
 		nad, err := client.CNCFNetworkingClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil && !kerrors.IsNotFound(err) {
-			return nil, err
+			return nil, fmt.Errorf("failed to list network attachment definitions in namespace %s: %w", ns, err)
 		}
 
 		// Append the list of networkAttachmentDefinitions to the nadList slice

--- a/pkg/autodiscover/autodiscover_networkpolicies.go
+++ b/pkg/autodiscover/autodiscover_networkpolicies.go
@@ -18,6 +18,7 @@ package autodiscover
 
 import (
 	"context"
+	"fmt"
 
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +28,7 @@ import (
 func getNetworkPolicies(oc networkingv1client.NetworkingV1Interface) ([]networkingv1.NetworkPolicy, error) {
 	nps, err := oc.NetworkPolicies("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list network policies: %w", err)
 	}
 	return nps.Items, nil
 }

--- a/pkg/autodiscover/autodiscover_pdbs.go
+++ b/pkg/autodiscover/autodiscover_pdbs.go
@@ -18,6 +18,7 @@ package autodiscover
 
 import (
 	"context"
+	"fmt"
 
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +30,7 @@ func getPodDisruptionBudgets(oc policyv1client.PolicyV1Interface, namespaces []s
 	for _, ns := range namespaces {
 		pdbs, err := oc.PodDisruptionBudgets(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("failed to list pod disruption budgets in namespace %s: %w", ns, err)
 		}
 		podDisruptionBudgets = append(podDisruptionBudgets, pdbs.Items...)
 	}

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -17,6 +17,7 @@ package autodiscover
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	appsv1 "k8s.io/api/apps/v1"
@@ -32,16 +33,14 @@ import (
 func FindDeploymentByNameByNamespace(appClient appv1client.AppsV1Interface, namespace, name string) (*appsv1.Deployment, error) {
 	dp, err := appClient.Deployments(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		log.Error("Cannot retrieve deployment in ns=%s name=%s", namespace, name)
-		return nil, err
+		return nil, fmt.Errorf("failed to get deployment %s/%s: %w", namespace, name, err)
 	}
 	return dp, nil
 }
 func FindStatefulsetByNameByNamespace(appClient appv1client.AppsV1Interface, namespace, name string) (*appsv1.StatefulSet, error) {
 	ss, err := appClient.StatefulSets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
-		log.Error("Cannot retrieve deployment in ns=%s name=%s", namespace, name)
-		return nil, err
+		return nil, fmt.Errorf("failed to get statefulset %s/%s: %w", namespace, name, err)
 	}
 	return ss, nil
 }
@@ -49,8 +48,7 @@ func FindStatefulsetByNameByNamespace(appClient appv1client.AppsV1Interface, nam
 func FindCrObjectByNameByNamespace(scalesGetter scale.ScalesGetter, ns, name string, groupResourceSchema schema.GroupResource) (*scalingv1.Scale, error) {
 	crScale, err := scalesGetter.Scales(ns).Get(context.TODO(), groupResourceSchema, name, metav1.GetOptions{})
 	if err != nil {
-		log.Error("Cannot retrieve deployment in ns=%s name=%s", ns, name)
-		return nil, err
+		return nil, fmt.Errorf("failed to get scale for %s/%s: %w", ns, name, err)
 	}
 	return crScale, nil
 }

--- a/pkg/autodiscover/autodiscover_pv.go
+++ b/pkg/autodiscover/autodiscover_pv.go
@@ -18,6 +18,7 @@ package autodiscover
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	corev1 "k8s.io/api/core/v1"
@@ -30,7 +31,7 @@ import (
 func getPersistentVolumes(oc corev1client.CoreV1Interface) ([]corev1.PersistentVolume, error) {
 	pvs, err := oc.PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list persistent volumes: %w", err)
 	}
 	return pvs.Items, nil
 }
@@ -38,7 +39,7 @@ func getPersistentVolumes(oc corev1client.CoreV1Interface) ([]corev1.PersistentV
 func getPersistentVolumeClaims(oc corev1client.CoreV1Interface) ([]corev1.PersistentVolumeClaim, error) {
 	pvcs, err := oc.PersistentVolumeClaims("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list persistent volume claims: %w", err)
 	}
 	return pvcs.Items, nil
 }
@@ -47,7 +48,7 @@ func getAllStorageClasses(client storagev1typed.StorageV1Interface) ([]storagev1
 	storageclasslist, err := client.StorageClasses().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		log.Error("Error when listing storage classes, err: %v", err)
-		return nil, err
+		return nil, fmt.Errorf("failed to list storage classes: %w", err)
 	}
 	return storageclasslist.Items, nil
 }

--- a/pkg/autodiscover/autodiscover_resources.go
+++ b/pkg/autodiscover/autodiscover_resources.go
@@ -18,6 +18,7 @@ package autodiscover
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +28,7 @@ import (
 func getResourceQuotas(oc corev1client.CoreV1Interface) ([]corev1.ResourceQuota, error) {
 	rql, err := oc.ResourceQuotas("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to list resource quotas: %w", err)
 	}
 	return rql.Items, nil
 }

--- a/pkg/autodiscover/autodiscover_service_accounts.go
+++ b/pkg/autodiscover/autodiscover_service_accounts.go
@@ -17,6 +17,7 @@ package autodiscover
 
 import (
 	"context"
+	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -27,7 +28,7 @@ func getServiceAccounts(oc corev1client.CoreV1Interface, namespaces []string) (s
 	for _, ns := range namespaces {
 		s, err := oc.ServiceAccounts(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			return servicesAccounts, err
+			return servicesAccounts, fmt.Errorf("failed to list service accounts in namespace %s: %w", ns, err)
 		}
 		for i := range s.Items {
 			servicesAccounts = append(servicesAccounts, &s.Items[i])

--- a/pkg/autodiscover/autodiscover_services.go
+++ b/pkg/autodiscover/autodiscover_services.go
@@ -17,6 +17,7 @@ package autodiscover
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/stringhelper"
 	corev1 "k8s.io/api/core/v1"
@@ -28,7 +29,7 @@ func getServices(oc corev1client.CoreV1Interface, namespaces, ignoreList []strin
 	for _, ns := range namespaces {
 		s, err := oc.Services(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
-			return allServices, err
+			return allServices, fmt.Errorf("failed to list services in namespace %s: %w", ns, err)
 		}
 		for i := range s.Items {
 			if stringhelper.StringInSlice(ignoreList, s.Items[i].Name, false) {

--- a/pkg/autodiscover/autodiscover_sriov.go
+++ b/pkg/autodiscover/autodiscover_sriov.go
@@ -3,6 +3,7 @@ package autodiscover
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +39,7 @@ func getSriovNetworks(client *clientsholder.ClientsHolder, namespaces []string) 
 	for _, ns := range namespaces {
 		snl, err := client.DynamicClient.Resource(SriovNetworkGVR).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil && !kerrors.IsNotFound(err) {
-			return nil, err
+			return nil, fmt.Errorf("failed to list SRIOV networks in namespace %s: %w", ns, err)
 		}
 
 		// Append the list of sriovNetworks to the sriovNetworks slice
@@ -60,7 +61,7 @@ func getSriovNetworkNodePolicies(client *clientsholder.ClientsHolder, namespaces
 	for _, ns := range namespaces {
 		snnp, err := client.DynamicClient.Resource(SriovNetworkNodePolicyGVR).Namespace(ns).List(context.TODO(), metav1.ListOptions{})
 		if err != nil && !kerrors.IsNotFound(err) {
-			return nil, err
+			return nil, fmt.Errorf("failed to list SRIOV network node policies in namespace %s: %w", ns, err)
 		}
 
 		// Append the list of sriovNetworkNodePolicies to the sriovNetworkNodePolicies slice

--- a/pkg/claimhelper/claimhelper.go
+++ b/pkg/claimhelper/claimhelper.go
@@ -285,8 +285,7 @@ func MarshalConfigurations(env *provider.TestEnvironment) (configurations []byte
 	}
 	configurations, err = j.Marshal(&config)
 	if err != nil {
-		log.Error("Error converting configurations to JSON: %v", err)
-		return configurations, err
+		return configurations, fmt.Errorf("failed to marshal configurations to JSON: %w", err)
 	}
 	return configurations, nil
 }
@@ -310,11 +309,11 @@ func UnmarshalClaim(claimFile []byte, claimRoot *claim.Root) {
 
 // ReadClaimFile writes the output payload to the claim file.  In the event of an error, this method fatally fails.
 func ReadClaimFile(claimFileName string) (data []byte, err error) {
+	log.Info("Reading claim file at path: %s", claimFileName)
 	data, err = os.ReadFile(claimFileName)
 	if err != nil {
-		log.Error("ReadFile failed with err: %v", err)
+		return nil, fmt.Errorf("failed to read claim file %s: %w", claimFileName, err)
 	}
-	log.Info("Reading claim file at path: %s", claimFileName)
 	return data, nil
 }
 
@@ -322,7 +321,6 @@ func ReadClaimFile(claimFileName string) (data []byte, err error) {
 func GetConfigurationFromClaimFile(claimFileName string) (env *provider.TestEnvironment, err error) {
 	data, err := ReadClaimFile(claimFileName)
 	if err != nil {
-		log.Error("ReadClaimFile failed with err: %v", err)
 		return env, err
 	}
 	var aRoot claim.Root
@@ -330,10 +328,13 @@ func GetConfigurationFromClaimFile(claimFileName string) (env *provider.TestEnvi
 	UnmarshalClaim(data, &aRoot)
 	configJSON, err := j.Marshal(aRoot.Claim.Configurations)
 	if err != nil {
-		return nil, fmt.Errorf("cannot convert config to json")
+		return nil, fmt.Errorf("failed to marshal claim configurations to JSON: %w", err)
 	}
 	err = j.Unmarshal(configJSON, &env)
-	return env, err
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshal config from claim file: %w", err)
+	}
+	return env, nil
 }
 
 // MarshalClaimOutput is a helper function to serialize a claim as JSON for output.  In the event of an error, this
@@ -388,7 +389,6 @@ func SanitizeClaimFile(claimFileName, labelsFilter string) (string, error) {
 	log.Info("Sanitizing claim file %s", claimFileName)
 	data, err := ReadClaimFile(claimFileName)
 	if err != nil {
-		log.Error("ReadClaimFile failed with err: %v", err)
 		return "", err
 	}
 	var aRoot claim.Root
@@ -398,8 +398,7 @@ func SanitizeClaimFile(claimFileName, labelsFilter string) (string, error) {
 	for testID := range aRoot.Claim.Results {
 		evaluator, err := labels.NewLabelsExprEvaluator(labelsFilter)
 		if err != nil {
-			log.Error("Failed to create labels expression evaluator: %v", err)
-			return "", err
+			return "", fmt.Errorf("failed to create labels expression evaluator for %q: %w", labelsFilter, err)
 		}
 
 		_, gatheredLabels := identifiers.GetTestIDAndLabels(*aRoot.Claim.Results[testID].TestID)

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -67,13 +67,13 @@ func createSendToCollectorPostRequest(endPoint, claimFilePath, executedBy, partn
 	// Add the claim file to the request
 	err := addClaimFileToPostRequest(w, claimFilePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to add claim file to post request: %w", err)
 	}
 
 	// Add the executed by, partner name and password fields to the request
 	err = addVarFieldsToPostRequest(w, executedBy, partnerName, password)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to add variable fields to post request: %w", err)
 	}
 
 	w.Close()

--- a/pkg/configuration/utils.go
+++ b/pkg/configuration/utils.go
@@ -17,6 +17,7 @@
 package configuration
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
@@ -40,12 +41,12 @@ func LoadConfiguration(filePath string) (TestConfiguration, error) {
 	log.Info("Loading config from file: %s", filePath)
 	contents, err := os.ReadFile(filePath)
 	if err != nil {
-		return configuration, err
+		return configuration, fmt.Errorf("failed to read config file %s: %w", filePath, err)
 	}
 
 	err = yaml.Unmarshal(contents, &configuration)
 	if err != nil {
-		return configuration, err
+		return configuration, fmt.Errorf("failed to parse config file %s: %w", filePath, err)
 	}
 
 	// Set default namespace for the probe daemonset pods, in case it was not set.

--- a/pkg/provider/deployments_test.go
+++ b/pkg/provider/deployments_test.go
@@ -67,7 +67,7 @@ func TestGetUpdatedDeployment(t *testing.T) {
 
 		if testCase.expectedErr != nil {
 			assert.NotNil(t, err)
-			assert.Equal(t, testCase.expectedErr.Error(), err.Error())
+			assert.ErrorContains(t, err, testCase.expectedErr.Error())
 		} else {
 			assert.Nil(t, err)
 			assert.NotNil(t, deployment)

--- a/pkg/provider/nodes.go
+++ b/pkg/provider/nodes.go
@@ -79,7 +79,7 @@ func (node *Node) IsRTKernel() bool {
 func (node *Node) GetRHCOSVersion() (string, error) {
 	versions, err := node.GetRHCOSVersions()
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get RHCOS versions for node: %w", err)
 	}
 	if len(versions) == 0 {
 		return operatingsystem.NotFoundStr, nil
@@ -102,7 +102,7 @@ func (node *Node) GetRHCOSVersions() ([]string, error) {
 	// Get all matching short versions from the long version string
 	shortVersions, err := operatingsystem.GetAllShortVersionsFromLong(longVersionSplit[0])
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get short versions from RHCOS version %s: %w", longVersionSplit[0], err)
 	}
 
 	return shortVersions, nil

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -209,11 +209,11 @@ func (p *Pod) CreatedByDeploymentConfig() (bool, error) {
 		if podOwner.Kind == replicationController {
 			replicationControllers, err := oc.K8sClient.CoreV1().ReplicationControllers(p.Namespace).Get(context.TODO(), podOwner.Name, metav1.GetOptions{})
 			if err != nil {
-				return false, err
+				return false, fmt.Errorf("failed to get replication controller %s/%s: %w", p.Namespace, podOwner.Name, err)
 			}
 			for _, rcOwner := range replicationControllers.GetOwnerReferences() {
 				if rcOwner.Name == podOwner.Name && rcOwner.Kind == deploymentConfig {
-					return true, err
+					return true, nil
 				}
 			}
 		}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -690,7 +690,7 @@ func getMachineConfig(mcName string, machineConfigs map[string]MachineConfig) (M
 
 	nodeMc, err := client.MachineCfg.MachineconfigurationV1().MachineConfigs().Get(context.TODO(), mcName, metav1.GetOptions{})
 	if err != nil {
-		return MachineConfig{}, err
+		return MachineConfig{}, fmt.Errorf("failed to get machine config %s: %w", mcName, err)
 	}
 
 	mc := MachineConfig{

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -679,7 +679,11 @@ func TestGetRHCOSVersion(t *testing.T) {
 		}
 
 		result, err := node.GetRHCOSVersion()
-		assert.Equal(t, tc.expectedErr, err)
+		if tc.expectedErr != nil {
+			assert.ErrorContains(t, err, tc.expectedErr.Error())
+		} else {
+			assert.NoError(t, err)
+		}
 		assert.Equal(t, tc.expectedOutput, result)
 	}
 }

--- a/pkg/provider/statefulsets_test.go
+++ b/pkg/provider/statefulsets_test.go
@@ -130,7 +130,11 @@ func TestGetUpdatedStatefulset(t *testing.T) {
 
 		// Run the function to be tested.
 		result, err := GetUpdatedStatefulset(client.AppsV1(), tc.testNamespace, "testPod")
-		assert.Equal(t, tc.funcErr, err)
+		if tc.funcErr != nil {
+			assert.ErrorContains(t, err, tc.funcErr.Error())
+		} else {
+			assert.NoError(t, err)
+		}
 		if err == nil {
 			assert.Equal(t, tc.testNamespace, result.Namespace)
 			assert.Equal(t, "testPod", result.Name)

--- a/pkg/scheduling/scheduling.go
+++ b/pkg/scheduling/scheduling.go
@@ -71,8 +71,7 @@ func parseSchedulingPolicyAndPriority(chrtCommandOutput string) (schedPolicy str
 		case strings.Contains(line, CurrentSchedulingPriority):
 			schedPriority, err = strconv.Atoi(lastToken)
 			if err != nil {
-				log.Error("Error obtained during strconv %v", err)
-				return schedPolicy, InvalidPriority, err
+				return schedPolicy, InvalidPriority, fmt.Errorf("failed to parse scheduling priority %q: %w", lastToken, err)
 			}
 		default:
 			return schedPolicy, InvalidPriority, fmt.Errorf("invalid: %s", line)

--- a/tests/lifecycle/podsets/podsets.go
+++ b/tests/lifecycle/podsets/podsets.go
@@ -96,7 +96,7 @@ func isDeploymentReady(name, namespace string) (bool, error) {
 
 	dep, err := provider.GetUpdatedDeployment(appsV1Api, namespace, name)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to get updated deployment %s/%s: %w", namespace, name, err)
 	}
 
 	return dep.IsDeploymentReady(), nil
@@ -107,7 +107,7 @@ func isStatefulSetReady(name, namespace string) (bool, error) {
 
 	sts, err := provider.GetUpdatedStatefulset(appsV1Api, namespace, name)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("failed to get updated statefulset %s/%s: %w", namespace, name, err)
 	}
 
 	return sts.IsStatefulSetReady(), nil

--- a/tests/networking/icmp/icmp.go
+++ b/tests/networking/icmp/icmp.go
@@ -240,7 +240,10 @@ var TestPing = func(sourceContainerID *provider.Container, targetContainerIP net
 		return results, fmt.Errorf("ping failed with stderr:%s err:%s", stderr, err)
 	}
 	results, err = parsePingResult(stdout, stderr)
-	return results, err
+	if err != nil {
+		return results, fmt.Errorf("failed to parse ping results: %w", err)
+	}
+	return results, nil
 }
 
 func parsePingResult(stdout, stderr string) (results PingResults, err error) {

--- a/tests/platform/operatingsystem/operatingsystem.go
+++ b/tests/platform/operatingsystem/operatingsystem.go
@@ -18,6 +18,7 @@ package operatingsystem
 
 import (
 	_ "embed"
+	"fmt"
 	"strings"
 )
 
@@ -60,7 +61,7 @@ func GetRHCOSMappedVersions(rhcosVersionMap string) (map[string]string, error) {
 func GetShortVersionFromLong(longVersion string) (string, error) {
 	versions, err := GetAllShortVersionsFromLong(longVersion)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to get short versions from long version %s: %w", longVersion, err)
 	}
 	if len(versions) == 0 {
 		return NotFoundStr, nil
@@ -74,7 +75,7 @@ func GetShortVersionFromLong(longVersion string) (string, error) {
 func GetAllShortVersionsFromLong(longVersion string) ([]string, error) {
 	capturedVersions, err := GetRHCOSMappedVersions(rhcosVersionMap)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to get RHCOS mapped versions: %w", err)
 	}
 
 	var matchingVersions []string


### PR DESCRIPTION
## Summary

Wrap ~50 bare error returns across 28 source files with contextual `fmt.Errorf` messages using `%w` for proper error chain preservation. Engineers investigating failures now see which specific operation failed instead of generic Kubernetes API errors.

## Key areas improved

| Area | Files | Wraps | Example |
|------|-------|-------|---------|
| Autodiscover (K8s API) | 11 | 18 | `"failed to list services in namespace X"` |
| CLI (claim/upload) | 4 | 10 | `"failed to open CSV file X"` |
| Provider | 4 | 5 | `"failed to get machine config X"` |
| Claimhelper | 1 | 5 | `"failed to read claim file X"` |
| Command execution | 1 | 2 | `"failed to execute command X in Y/Z"` |
| Configuration | 1 | 2 | `"failed to parse config file X"` |
| Other (archiver, scheduling, tests) | 6 | 6 | Various |

## Bug fix

Fixed `ReadClaimFile()` silently swallowing errors — it logged the error but returned `nil`, causing callers to proceed with empty data instead of failing.

## Test updates

Updated 3 test files to use `assert.ErrorContains` instead of exact error string equality, making tests resilient to error wrapping changes.

## Related to

- [redhat-best-practices-for-k8s/certsuite#3730](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3730) — `%w` error wrapping in certsuite (open)
- [openshift/tls-scanner#70](https://github.com/openshift/tls-scanner/pull/70) — `%w` error wrapping in tls-scanner (merged)
- [openshift-kni/commatrix#482](https://github.com/openshift-kni/commatrix/pull/482) — `%w` error wrapping in commatrix (merged)
- [crc-org/crc#5180](https://github.com/crc-org/crc/pull/5180) — `%w` error wrapping in crc (merged)
- [openshift-kni/lifecycle-agent#6319](https://github.com/openshift-kni/lifecycle-agent/pull/6319) — bare error wrapping in lifecycle-agent (open)
- [redhat-best-practices-for-k8s/certsuite#3627](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3627) — bare error wrapping in certsuite (merged)

## Test plan

- [x] `make lint` passes (0 issues)
- [x] `make test` passes
- [x] Local cluster test: 6/6 checks pass on cnfdt16