### PR TITLE
Add missing probe daemonset skip functions and --require-probe flag

### DIFF
--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -54,6 +54,7 @@ func NewCommand() *cobra.Command {
 	runCmd.PersistentFlags().String("connect-api-proxy-url", "", "Proxy URL for Red Hat Connect API")
 	runCmd.PersistentFlags().String("connect-api-proxy-port", "", "Proxy port for Red Hat Connect API")
 	runCmd.PersistentFlags().Bool("cleanup-probe", true, "Delete the probe daemonset at the end of the test run")
+	runCmd.PersistentFlags().Bool("require-probe", false, "Abort the test run if the probe daemonset fails to deploy")
 
 	return runCmd
 }
@@ -89,6 +90,7 @@ func initTestParamsFromFlags(cmd *cobra.Command) error {
 	testParams.ConnectAPIProxyURL, _ = cmd.Flags().GetString("connect-api-proxy-url")
 	testParams.ConnectAPIProxyPort, _ = cmd.Flags().GetString("connect-api-proxy-port")
 	testParams.CleanupProbe, _ = cmd.Flags().GetBool("cleanup-probe")
+	testParams.RequireProbe, _ = cmd.Flags().GetBool("require-probe")
 	timeoutStr, _ := cmd.Flags().GetString("timeout")
 
 	// Check if the output directory exists and, if not, create it

--- a/pkg/checksdb/checksdb.go
+++ b/pkg/checksdb/checksdb.go
@@ -16,6 +16,7 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/labels"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/stringhelper"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/identifiers"
 )
 
@@ -98,6 +99,7 @@ func RunChecks(timeout time.Duration) (failedCtr int, err error) {
 	// Print the results in the CLI
 	cli.PrintResultsTable(getResultsSummary())
 	printFailedChecksLog()
+	printDaemonsetSkippedChecks()
 
 	if len(errs) > 0 {
 		log.Error("RunChecks errors: %v", errs)
@@ -200,6 +202,34 @@ func printFailedChecksLog() {
 			}
 		}
 	}
+}
+
+func printDaemonsetSkippedChecks() {
+	var skippedIDs []string
+	for _, group := range dbByGroup {
+		for _, check := range group.checks {
+			if check.Result == CheckResultSkipped && check.skipReason == testhelper.DaemonsetFailedToSpawnSkipReason {
+				skippedIDs = append(skippedIDs, check.ID)
+			}
+		}
+	}
+
+	if len(skippedIDs) == 0 {
+		return
+	}
+
+	header := "| " + cli.Yellow + "SKIPPED DUE TO PROBE DAEMONSET FAILURE" + cli.Reset + " |"
+	nbSymbols := utf8.RuneCountInString(header) - nbColorSymbols
+	fmt.Println(strings.Repeat("=", nbSymbols))
+	fmt.Println(header)
+	fmt.Println(strings.Repeat("=", nbSymbols))
+	fmt.Printf("The probe daemonset failed to deploy. %d test(s) were skipped:\n", len(skippedIDs))
+	for _, id := range skippedIDs {
+		fmt.Printf("  - %s\n", id)
+	}
+	fmt.Println()
+	fmt.Println("To abort on probe failure instead of skipping, use --require-probe")
+	fmt.Println(strings.Repeat("=", nbSymbols))
 }
 
 func GetResults() map[string]claim.Result {

--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -142,4 +142,6 @@ type TestParameters struct {
 	AllowNonRunning bool
 	// CleanupProbe determines whether to delete the probe daemonset at the end of the run
 	CleanupProbe bool
+	// RequireProbe aborts the test run if the probe daemonset fails to deploy
+	RequireProbe bool
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -273,9 +273,20 @@ func buildTestEnvironment() { //nolint:funlen,gocyclo
 
 	// Wait for the probe pods to be ready before the autodiscovery starts.
 	if err := deployDaemonSet(config.ProbeDaemonSetNamespace); err != nil {
-		log.Error("The TNF daemonset could not be deployed, err: %v", err)
-		// Because of this failure, we are only able to run a certain amount of tests that do not rely
-		// on the existence of the daemonset probe pods.
+		log.Error("The probe daemonset could not be deployed, err: %v", err)
+
+		testParams := configuration.GetTestParameters()
+		if testParams.RequireProbe {
+			log.Fatal("--require-probe is set: aborting because the probe daemonset failed to deploy")
+		}
+
+		log.Warn("Probe daemonset failed to deploy. The following test categories will be SKIPPED: " +
+			"Platform (SELinux, hugepages, boot params, sysctl, kernel taints, base image, hyperthreading), " +
+			"Networking (ICMP connectivity, port usage), " +
+			"Access Control (process count, SSH daemon detection), " +
+			"Performance (CPU scheduling policy). " +
+			"To abort on probe failure instead, use --require-probe")
+
 		env.DaemonsetFailedToSpawn = true
 	}
 

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -440,10 +440,12 @@ func GetNoServicesUnderTestSkipFn(env *provider.TestEnvironment) func() (bool, s
 	}
 }
 
+const DaemonsetFailedToSpawnSkipReason = "probe daemonset failed to spawn. please check the logs."
+
 func GetDaemonSetFailedToSpawnSkipFn(env *provider.TestEnvironment) func() (bool, string) {
 	return func() (bool, string) {
 		if env.DaemonsetFailedToSpawn {
-			return true, "probe daemonset failed to spawn. please check the logs."
+			return true, DaemonsetFailedToSpawnSkipReason
 		}
 
 		return false, ""

--- a/tests/performance/suite.go
+++ b/tests/performance/suite.go
@@ -79,7 +79,7 @@ var (
 	}
 )
 
-func LoadChecks() {
+func LoadChecks() { //nolint:funlen
 	log.Debug("Loading %s suite checks", common.PerformanceTestKey)
 
 	checksGroup := checksdb.NewChecksGroup(common.PerformanceTestKey).
@@ -93,28 +93,36 @@ func LoadChecks() {
 		}))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestRtAppNoExecProbes)).
-		WithSkipCheckFn(skipIfNoGuaranteedPodContainersWithExclusiveCPUs).
+		WithSkipCheckFn(
+			skipIfNoGuaranteedPodContainersWithExclusiveCPUs,
+			testhelper.GetDaemonSetFailedToSpawnSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testRtAppsNoExecProbes(c, &env)
 			return nil
 		}))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestSharedCPUPoolSchedulingPolicy)).
-		WithSkipCheckFn(skipIfNoNonGuaranteedPodContainersWithoutHostPID).
+		WithSkipCheckFn(
+			skipIfNoNonGuaranteedPodContainersWithoutHostPID,
+			testhelper.GetDaemonSetFailedToSpawnSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testSchedulingPolicyInCPUPool(c, &env, env.GetNonGuaranteedPodContainersWithoutHostPID(), scheduling.SharedCPUScheduling)
 			return nil
 		}))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestExclusiveCPUPoolSchedulingPolicy)).
-		WithSkipCheckFn(skipIfNoGuaranteedPodContainersWithExclusiveCPUsWithoutHostPID).
+		WithSkipCheckFn(
+			skipIfNoGuaranteedPodContainersWithExclusiveCPUsWithoutHostPID,
+			testhelper.GetDaemonSetFailedToSpawnSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testSchedulingPolicyInCPUPool(c, &env, env.GetGuaranteedPodContainersWithExclusiveCPUsWithoutHostPID(), scheduling.ExclusiveCPUScheduling)
 			return nil
 		}))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestIsolatedCPUPoolSchedulingPolicy)).
-		WithSkipCheckFn(skipIfNoGuaranteedPodContainersWithIsolatedCPUsWithoutHostPID).
+		WithSkipCheckFn(
+			skipIfNoGuaranteedPodContainersWithIsolatedCPUsWithoutHostPID,
+			testhelper.GetDaemonSetFailedToSpawnSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testSchedulingPolicyInCPUPool(c, &env, env.GetGuaranteedPodContainersWithIsolatedCPUsWithoutHostPID(), scheduling.ExclusiveCPUScheduling)
 			return nil

--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -58,7 +58,9 @@ func LoadChecks() {
 		WithBeforeEachFn(beforeEachFn)
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestHyperThreadEnable)).
-		WithSkipCheckFn(testhelper.GetNoBareMetalNodesSkipFn(&env)).
+		WithSkipCheckFn(
+			testhelper.GetNoBareMetalNodesSkipFn(&env),
+			testhelper.GetDaemonSetFailedToSpawnSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
 			testHyperThreadingEnabled(c, &env)
 			return nil


### PR DESCRIPTION
## Summary

- Adds `GetDaemonSetFailedToSpawnSkipFn` to 5 tests that depend on the probe daemonset but were missing it, preventing panics (TestHyperThreadEnable) and misleading failures (4 performance scheduling tests)
- Adds `--require-probe` CLI flag to abort the run if the probe daemonset fails to deploy, for users who want strict enforcement
- Adds a warning message listing impacted test categories when the daemonset fails
- Adds an end-of-run summary listing all tests skipped due to daemonset failure
- Exports `DaemonsetFailedToSpawnSkipReason` constant from testhelper for use by the end-of-run summary

## Test plan

- [ ] `make build` passes
- [ ] `make test` passes
- [ ] `make lint` passes
- [ ] Verify `--require-probe` flag appears in `./certsuite run --help`
- [ ] Verify probe-dependent tests are skipped (not panicked/failed) when daemonset is unavailable