### PR TITLE
Bug fix for parallel checks: add per-node mutex to prevent probe pod exhaustion

### DIFF
--- a/pkg/checksdb/parallel_test.go
+++ b/pkg/checksdb/parallel_test.go
@@ -1,8 +1,11 @@
 package checksdb
 
 import (
+	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
 	"github.com/stretchr/testify/assert"
@@ -93,4 +96,87 @@ func TestForEachParallelRespectsLimit(t *testing.T) {
 	})
 
 	assert.LessOrEqual(t, int(maxActive.Load()), 5)
+}
+
+// TestForEachParallelPerNodeMutex verifies the per-node mutex pattern used by
+// probe-pod-heavy tests. Items are assigned to "nodes"; a per-node mutex
+// serializes execution within each node while allowing cross-node parallelism.
+// The test asserts that per-node concurrency never exceeds 1, while total
+// concurrency across nodes does exceed 1 (proving parallelism isn't lost).
+func TestForEachParallelPerNodeMutex(t *testing.T) {
+	type item struct {
+		name string
+		node string
+	}
+
+	// 3 nodes, 10 items per node = 30 items total.
+	nodes := []string{"node-a", "node-b", "node-c"}
+	var items []item
+	for _, node := range nodes {
+		for i := range 10 {
+			items = append(items, item{name: fmt.Sprintf("%s-pod-%d", node, i), node: node})
+		}
+	}
+
+	// Build per-node mutex map (same pattern as production code).
+	mutexPerNode := make(map[string]*sync.Mutex, len(nodes))
+	for _, node := range nodes {
+		mutexPerNode[node] = &sync.Mutex{}
+	}
+
+	// Track per-node and total concurrency.
+	perNodeActive := make(map[string]*atomic.Int32, len(nodes))
+	perNodeMaxActive := make(map[string]*atomic.Int32, len(nodes))
+	for _, node := range nodes {
+		perNodeActive[node] = &atomic.Int32{}
+		perNodeMaxActive[node] = &atomic.Int32{}
+	}
+	var totalMaxActive atomic.Int32
+	var totalActive atomic.Int32
+
+	check := NewCheck("test-per-node-mutex", []string{"test"})
+
+	ForEachParallel(check, items, len(nodes), func(c *Check, it item, r *ParallelResult) {
+		if nodeMutex, ok := mutexPerNode[it.node]; ok {
+			nodeMutex.Lock()
+			defer nodeMutex.Unlock()
+		}
+
+		// Record per-node concurrency.
+		nodeCount := perNodeActive[it.node].Add(1)
+		for {
+			old := perNodeMaxActive[it.node].Load()
+			if nodeCount <= old || perNodeMaxActive[it.node].CompareAndSwap(old, nodeCount) {
+				break
+			}
+		}
+
+		// Record total concurrency.
+		totalCount := totalActive.Add(1)
+		for {
+			old := totalMaxActive.Load()
+			if totalCount <= old || totalMaxActive.CompareAndSwap(old, totalCount) {
+				break
+			}
+		}
+
+		// Simulate probe pod work so goroutines overlap.
+		time.Sleep(5 * time.Millisecond)
+
+		r.AddCompliantObject(testhelper.NewPodReportObject("ns", it.name, "ok", true))
+		perNodeActive[it.node].Add(-1)
+		totalActive.Add(-1)
+	})
+
+	// Per-node concurrency must never exceed 1.
+	for _, node := range nodes {
+		assert.Equal(t, int32(1), perNodeMaxActive[node].Load(),
+			"node %s had concurrent execution — per-node mutex failed", node)
+	}
+
+	// Total concurrency should exceed 1, proving cross-node parallelism works.
+	assert.Greater(t, int(totalMaxActive.Load()), 1,
+		"cross-node parallelism was not achieved")
+
+	assert.Equal(t, "passed", check.Result.String())
 }

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -19,6 +19,7 @@ package provider
 import (
 	"context"
 	"regexp"
+	"sync"
 	"time"
 
 	"fmt"
@@ -627,6 +628,14 @@ func GetPciPerPod(annotation string) (pciAddr []string, err error) {
 		}
 	}
 	return pciAddr, nil
+}
+
+func (env *TestEnvironment) NewPerNodeMutexMap() map[string]*sync.Mutex {
+	m := make(map[string]*sync.Mutex, len(env.Nodes))
+	for _, node := range env.Nodes {
+		m[node.Data.Name] = &sync.Mutex{}
+	}
+	return m
 }
 
 func (env *TestEnvironment) SetNeedsRefresh() {

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -764,7 +764,9 @@ func testAutomountServiceToken(check *checksdb.Check, env *provider.TestEnvironm
 }
 
 func testOneProcessPerContainer(check *checksdb.Check, env *provider.TestEnvironment) {
-	checksdb.ForEachParallel(check, env.Containers, 0, func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
+	mutexPerNode := env.NewPerNodeMutexMap()
+
+	checksdb.ForEachParallel(check, env.Containers, len(env.ProbePods), func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Container %q", cut)
 		if cut.IsIstioProxy() {
 			check.LogInfo("Skipping \"istio-proxy\" container")
@@ -776,6 +778,12 @@ func testOneProcessPerContainer(check *checksdb.Check, env *provider.TestEnviron
 			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Debug pod not found for node", false))
 			return
 		}
+
+		if nodeMutex, ok := mutexPerNode[cut.NodeName]; ok {
+			nodeMutex.Lock()
+			defer nodeMutex.Unlock()
+		}
+
 		ocpContext := clientsholder.NewContext(probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name)
 		pid, err := crclient.GetPidFromContainer(cut, ocpContext)
 		if err != nil {
@@ -897,9 +905,16 @@ const (
 )
 
 func testNoSSHDaemonsAllowed(check *checksdb.Check, env *provider.TestEnvironment) {
-	checksdb.ForEachParallel(check, env.Pods, 0, func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
+	mutexPerNode := env.NewPerNodeMutexMap()
+
+	checksdb.ForEachParallel(check, env.Pods, len(env.ProbePods), func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Pod %q", put)
 		cut := put.Containers[0]
+
+		if nodeMutex, ok := mutexPerNode[put.Spec.NodeName]; ok {
+			nodeMutex.Lock()
+			defer nodeMutex.Unlock()
+		}
 
 		port, err := netutil.GetSSHDaemonPort(cut)
 		if err != nil {

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -159,14 +159,22 @@ func LoadChecks() {
 		}))
 }
 
+//nolint:funlen
 func testUndeclaredContainerPortsUsage(check *checksdb.Check, env *provider.TestEnvironment) {
-	checksdb.ForEachParallel(check, env.Pods, 0, func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
+	mutexPerNode := env.NewPerNodeMutexMap()
+
+	checksdb.ForEachParallel(check, env.Pods, len(env.ProbePods), func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
 		declaredPorts := make(map[netutil.PortInfo]bool)
 		for _, cut := range put.Containers {
 			check.LogInfo("Testing Container %q", cut)
 			for _, port := range cut.Ports {
 				declaredPorts[netutil.PortInfo{PortNumber: port.ContainerPort, Protocol: string(port.Protocol)}] = true
 			}
+		}
+
+		if nodeMutex, ok := mutexPerNode[put.Spec.NodeName]; ok {
+			nodeMutex.Lock()
+			defer nodeMutex.Unlock()
 		}
 
 		firstPodContainer := put.Containers[0]
@@ -257,7 +265,9 @@ func testPartnerSpecificTCPPorts(check *checksdb.Check, env *provider.TestEnviro
 
 //nolint:funlen
 func testReservedPortsUsageParallel(check *checksdb.Check, env *provider.TestEnvironment, portsToTest map[int32]bool, portsOrigin string) {
-	checksdb.ForEachParallel(check, env.Pods, 0, func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
+	mutexPerNode := env.NewPerNodeMutexMap()
+
+	checksdb.ForEachParallel(check, env.Pods, len(env.ProbePods), func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Pod %q", put)
 
 		nonCompliantPortFound := false
@@ -281,6 +291,11 @@ func testReservedPortsUsageParallel(check *checksdb.Check, env *provider.TestEnv
 							AddField(testhelper.PortProtocol, string(port.Protocol)))
 				}
 			}
+		}
+
+		if nodeMutex, ok := mutexPerNode[put.Spec.NodeName]; ok {
+			nodeMutex.Lock()
+			defer nodeMutex.Unlock()
 		}
 
 		firstContainer := put.Containers[0]

--- a/tests/performance/suite.go
+++ b/tests/performance/suite.go
@@ -259,8 +259,15 @@ func testExclusiveCPUPool(check *checksdb.Check, env *provider.TestEnvironment) 
 
 func testSchedulingPolicyInCPUPool(check *checksdb.Check, env *provider.TestEnvironment,
 	podContainers []*provider.Container, schedulingType string) {
-	checksdb.ForEachParallel(check, podContainers, 0, func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
+	mutexPerNode := env.NewPerNodeMutexMap()
+
+	checksdb.ForEachParallel(check, podContainers, len(env.ProbePods), func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Container %q", cut)
+
+		if nodeMutex, ok := mutexPerNode[cut.NodeName]; ok {
+			nodeMutex.Lock()
+			defer nodeMutex.Unlock()
+		}
 
 		pidNamespace, err := crclient.GetContainerPidNamespace(cut, env)
 		if err != nil {
@@ -311,13 +318,20 @@ func getExecProbesCmds(c *provider.Container) map[string]bool {
 }
 
 func testRtAppsNoExecProbes(check *checksdb.Check, env *provider.TestEnvironment) {
+	mutexPerNode := env.NewPerNodeMutexMap()
+
 	cuts := env.GetNonGuaranteedPodContainersWithoutHostPID()
-	checksdb.ForEachParallel(check, cuts, 0, func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
+	checksdb.ForEachParallel(check, cuts, len(env.ProbePods), func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Container %q", cut)
 		if !cut.HasExecProbes() {
 			check.LogInfo("Container %q does not define exec probes", cut)
 			result.AddCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container does not define exec probes", true))
 			return
+		}
+
+		if nodeMutex, ok := mutexPerNode[cut.NodeName]; ok {
+			nodeMutex.Lock()
+			defer nodeMutex.Unlock()
 		}
 
 		processes, err := crclient.GetContainerProcesses(cut, env)

--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 
 	clientsholder "github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
@@ -229,10 +228,7 @@ func testContainersFsDiff(check *checksdb.Check, env *provider.TestEnvironment) 
 
 	// We also need a per-node map of mutexes to limit the concurrency per node on ocp < 4.13
 	// This avoids conflicts while mounting/unmounting and deleting the podman temp folder on the node.
-	mutexPerNode := make(map[string]*sync.Mutex)
-	for _, node := range env.Nodes {
-		mutexPerNode[node.Data.Name] = &sync.Mutex{}
-	}
+	mutexPerNode := env.NewPerNodeMutexMap()
 
 	checksdb.ForEachParallel(check, env.Containers, len(env.ProbePods), func(check *checksdb.Check, cut *provider.Container, result *checksdb.ParallelResult) {
 		check.LogInfo("Testing Container %q (node %q)", cut, cut.NodeName)


### PR DESCRIPTION
## Summary

PR #3611 introduced parallel execution of test checks (ForEachParallel, default concurrency of 10 workers). When multiple pods on the same node are tested concurrently, all commands route through the same probe pod, overwhelming it with concurrent SPDY exec requests. This causes:

- context deadline exceeded errors (30s timeout hit)
- Exit code 137 (OOM kills on probe pods)
- "container not found" errors (probe pod connection loss)

This was already fixed for platform-alteration-base-image in #3671. This PR applies the same per-node mutex pattern to the remaining 6 vulnerable test functions:

- testOneProcessPerContainer (accesscontrol)
- testNoSSHDaemonsAllowed (accesscontrol)
- testUndeclaredContainerPortsUsage (networking)
- testReservedPortsUsageParallel (networking)
- testSchedulingPolicyInCPUPool (performance)
- testRtAppsNoExecProbes (performance)

Each function now serializes probe pod operations per-node while preserving cross-node parallelism. The concurrency limit is changed from the default (10) to len(env.ProbePods) to match available nodes.

Also:
- Extracts the repeated mutex map creation into TestEnvironment.NewPerNodeMutexMap() (used by all 7 functions including the base-image test from #3671)
- Adds a unit test (TestForEachParallelPerNodeMutex) verifying that the per-node mutex pattern prevents concurrent same-node execution while preserving cross-node parallelism

## Test plan

- [x] golangci-lint passes with 0 issues
- [x] make test passes (all 85 packages)
- [x] New unit test passes with -race detector enabled
- [ ] Verify on a multi-node cluster with 20+ pods (e.g. CSDB environment) that access-control-ssh-daemons passes without timeout errors
