### PR TITLE
ci: skip Quay image pushes during Quay.io outages

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -33,6 +33,19 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
+  check-quay-status:
+    name: Check Quay.io availability
+    runs-on: ubuntu-24.04
+    outputs:
+      quay-available: ${{ steps.status.outputs.degraded-count == '0' }}
+    steps:
+      - name: Check Red Hat Status (Quay.io)
+        id: status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            Quay.io
+
   lint:
     name: Run Linters and Vet
     runs-on: ubuntu-24.04
@@ -418,9 +431,9 @@ jobs:
   # Only run this job if the previous jobs are successful that build the ARM and x86 images.
   create-manifest-multiarch-legacy:
     name: Create manifest list for multi-arch image (legacy)
-    needs: [unit-tests, smoke-tests-container]
+    needs: [unit-tests, smoke-tests-container, check-quay-status]
     runs-on: ubuntu-24.04
-    if: github.event_name != 'pull_request' && needs.smoke-tests-container.result == 'success' && needs.unit-tests.result == 'success'
+    if: github.event_name != 'pull_request' && needs.smoke-tests-container.result == 'success' && needs.unit-tests.result == 'success' && needs.check-quay-status.outputs.quay-available != 'false'
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -471,9 +484,9 @@ jobs:
   # Only run this job if the previous jobs are successful that build the ARM and x86 images.
   create-manifest-multiarch:
     name: Create manifest list for multi-arch image
-    needs: [unit-tests, smoke-tests-container]
+    needs: [unit-tests, smoke-tests-container, check-quay-status]
     runs-on: ubuntu-24.04
-    if: github.event_name != 'pull_request' && needs.smoke-tests-container.result == 'success' && needs.unit-tests.result == 'success'
+    if: github.event_name != 'pull_request' && needs.smoke-tests-container.result == 'success' && needs.unit-tests.result == 'success' && needs.check-quay-status.outputs.quay-available != 'false'
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/tnf-image.yaml
+++ b/.github/workflows/tnf-image.yaml
@@ -34,8 +34,22 @@ env:
   PROBE_IMAGE_SRC_URL: 'https://github.com/${PROBE_IMAGE_REPO}'
 
 jobs:
+  check-quay-status:
+    name: Check Quay.io availability
+    runs-on: ubuntu-24.04
+    outputs:
+      quay-available: ${{ steps.status.outputs.degraded-count == '0' }}
+    steps:
+      - name: Check Red Hat Status (Quay.io)
+        id: status
+        uses: palmsoftware/redhat-status@v0
+        with:
+          components: |
+            Quay.io
+
   test-and-push-tnf-image-main:
-    if: github.repository_owner == 'redhat-best-practices-for-k8s'
+    needs: [check-quay-status]
+    if: github.repository_owner == 'redhat-best-practices-for-k8s' && needs.check-quay-status.outputs.quay-available != 'false'
     name: 'Test and push the `certsuite` image'
     runs-on: ubuntu-24.04
     env:
@@ -158,6 +172,8 @@ jobs:
           slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
 
   test-and-push-tnf-image-legacy:
+    needs: [check-quay-status]
+    if: needs.check-quay-status.outputs.quay-available != 'false'
     name: 'Test and push the `cnf-certification-test` image (legacy)'
     runs-on: ubuntu-24.04
     env:


### PR DESCRIPTION
## Summary

- Adds a `check-quay-status` job to `tnf-image.yaml` and `pre-main.yaml` that queries [status.redhat.com](https://status.redhat.com) for Quay.io component health before attempting image pushes
- When Quay.io is degraded, push jobs are cleanly skipped (grey "Skipped" in the Actions UI) with no Slack failure alert
- Uses fail-open logic (`!= 'false'`) so a broken status check or unreachable status API never blocks pushes — only a confirmed Quay.io outage skips the push

## Affected Workflows

| Workflow | Push Jobs Gated |
|----------|----------------|
| `tnf-image.yaml` | `test-and-push-tnf-image-main`, `test-and-push-tnf-image-legacy` |
| `pre-main.yaml` | `create-manifest-multiarch-legacy`, `create-manifest-multiarch` |

## How It Works

1. A lightweight `check-quay-status` job runs [palmsoftware/redhat-status](https://github.com/palmsoftware/redhat-status) filtered to the `Quay.io` component group
2. The job outputs `quay-available` based on the `degraded-count` (Quay-specific, not global Red Hat status)
3. Push jobs check `needs.check-quay-status.outputs.quay-available != 'false'` — proceeds unless Quay is *known* degraded
4. Non-push jobs (lint, tests, smoke tests) are completely unaffected

## Test Plan

- [ ] Verify `check-quay-status` job runs and shows Quay.io summary in the Actions step output
- [ ] Verify push jobs still run normally when Quay is healthy
- [ ] Verify non-push jobs (lint, unit-tests, smoke-tests) are unaffected