### PR TITLE
test: add missing unit tests and remove stale TODO markers

### DIFF
--- a/internal/log/custom_handler_test.go
+++ b/internal/log/custom_handler_test.go
@@ -1,1 +1,137 @@
 package log
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var testTime = time.Date(2025, 1, 15, 10, 30, 0, 0, time.UTC)
+
+func TestNewCustomHandlerDefaultLevel(t *testing.T) {
+	t.Parallel()
+	h := NewCustomHandler(&bytes.Buffer{}, nil)
+
+	require.NotNil(t, h)
+	assert.True(t, h.Enabled(context.Background(), slog.LevelInfo))
+	assert.False(t, h.Enabled(context.Background(), slog.LevelDebug))
+}
+
+func TestNewCustomHandlerWithOpts(t *testing.T) {
+	t.Parallel()
+	h := NewCustomHandler(&bytes.Buffer{}, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})
+
+	require.NotNil(t, h)
+	assert.True(t, h.Enabled(context.Background(), slog.LevelDebug))
+}
+
+func TestEnabled(t *testing.T) {
+	t.Parallel()
+	h := NewCustomHandler(&bytes.Buffer{}, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	})
+
+	tests := []struct {
+		name    string
+		level   slog.Level
+		enabled bool
+	}{
+		{"debug below threshold", slog.LevelDebug, false},
+		{"info below threshold", slog.LevelInfo, false},
+		{"warn at threshold", slog.LevelWarn, true},
+		{"error above threshold", slog.LevelError, true},
+		{"fatal above threshold", CustomLevelFatal, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.enabled, h.Enabled(context.Background(), tt.level))
+		})
+	}
+}
+
+func TestHandleWritesFormattedOutput(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	h := NewCustomHandler(&buf, nil)
+
+	r := slog.NewRecord(testTime, slog.LevelInfo, "hello world", 0)
+	err := h.Handle(context.Background(), r)
+
+	require.NoError(t, err)
+	output := buf.String()
+	assert.Contains(t, output, "INFO")
+	assert.Contains(t, output, "hello world")
+	assert.Contains(t, output, "\n")
+}
+
+func TestHandleWritesErrorLevel(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	h := NewCustomHandler(&buf, nil)
+
+	r := slog.NewRecord(testTime, slog.LevelError, "something failed", 0)
+	err := h.Handle(context.Background(), r)
+
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "ERROR")
+	assert.Contains(t, buf.String(), "something failed")
+}
+
+func TestWithAttrsReturnsNewHandler(t *testing.T) {
+	t.Parallel()
+	original := NewCustomHandler(&bytes.Buffer{}, nil)
+	modified := original.WithAttrs([]slog.Attr{
+		slog.String("key", "value"),
+	})
+
+	require.NotNil(t, modified)
+	assert.NotEqual(t, original, modified)
+
+	modifiedHandler, ok := modified.(*CustomHandler)
+	require.True(t, ok)
+	assert.NotEmpty(t, modifiedHandler.attrs)
+	assert.Empty(t, original.attrs)
+}
+
+func TestWithAttrsEmptyReturnsOriginal(t *testing.T) {
+	t.Parallel()
+	original := NewCustomHandler(&bytes.Buffer{}, nil)
+	same := original.WithAttrs(nil)
+
+	assert.Equal(t, original, same)
+}
+
+func TestWithGroupReturnsNil(t *testing.T) {
+	t.Parallel()
+	h := NewCustomHandler(&bytes.Buffer{}, nil)
+
+	assert.Nil(t, h.WithGroup("test"))
+}
+
+func TestHandleWithAttrs(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	h := NewCustomHandler(&buf, nil)
+	h2 := h.WithAttrs([]slog.Attr{
+		slog.String("request_id", "abc-123"),
+	})
+
+	handler, ok := h2.(*CustomHandler)
+	require.True(t, ok)
+
+	r := slog.NewRecord(testTime, slog.LevelInfo, "with attrs", 0)
+	err := handler.Handle(context.Background(), r)
+
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "abc-123")
+	assert.Contains(t, buf.String(), "with attrs")
+}

--- a/tests/lifecycle/scaling/scaling_helper_test.go
+++ b/tests/lifecycle/scaling/scaling_helper_test.go
@@ -20,9 +20,8 @@ func TestIsManaged(t *testing.T) {
 		args args
 		want bool
 	}{
-		// TODO: Add test cases.
 		{
-			name: "test1",
+			name: "found",
 			args: args{
 				podSetName: "test1",
 				managedPodSet: []configuration.ManagedDeploymentsStatefulsets{
@@ -34,13 +33,31 @@ func TestIsManaged(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "test2",
+			name: "not found",
 			args: args{
 				podSetName: "test1",
 				managedPodSet: []configuration.ManagedDeploymentsStatefulsets{
 					{
 						Name: "test2",
 					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "empty managed list",
+			args: args{
+				podSetName:    "test1",
+				managedPodSet: []configuration.ManagedDeploymentsStatefulsets{},
+			},
+			want: false,
+		},
+		{
+			name: "empty pod set name",
+			args: args{
+				podSetName: "",
+				managedPodSet: []configuration.ManagedDeploymentsStatefulsets{
+					{Name: "test1"},
 				},
 			},
 			want: false,

--- a/tests/networking/netcommons/netcommons_test.go
+++ b/tests/networking/netcommons/netcommons_test.go
@@ -62,7 +62,6 @@ func Test_getIPVersion(t *testing.T) {
 			want:    Undefined,
 			wantErr: true,
 		},
-		// TODO: Add test cases.
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -74,6 +73,25 @@ func Test_getIPVersion(t *testing.T) {
 			if got != tt.want {
 				t.Errorf("getIPVersion() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestIPVersionString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		version  IPVersion
+		expected string
+	}{
+		{IPv4, "IPv4"},
+		{IPv6, "IPv6"},
+		{IPv4v6, "IPv4v6"},
+		{Undefined, "undefined"},
+		{IPVersion(99), "undefined"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, tt.version.String())
 		})
 	}
 }

--- a/tests/networking/services/services_test.go
+++ b/tests/networking/services/services_test.go
@@ -35,7 +35,6 @@ func TestGetServiceIPVersion(t *testing.T) {
 		wantResult netcommons.IPVersion
 		wantErr    bool
 	}{
-		// TODO: Add test cases.
 		{
 			name:       "dual-stack-ok1",
 			args:       args{aService: createService([]string{"1.1.1.1", "fd00:10:96::d789"}, corev1.IPFamilyPolicyPreferDualStack)},
@@ -95,6 +94,22 @@ func createService(ips []string, aFp corev1.IPFamilyPolicy) (aService *corev1.Se
 	aService.Spec.ClusterIPs = ips
 	aService.Spec.IPFamilyPolicy = &aFp
 	return aService
+}
+
+func TestToString(t *testing.T) {
+	t.Parallel()
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-service",
+			Namespace: "my-ns",
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP:  "10.0.0.1",
+			ClusterIPs: []string{"10.0.0.1", "fd00::1"},
+		},
+	}
+	expected := "Service ns: my-ns, name: my-service ClusterIP:10.0.0.1 ClusterIPs: [10.0.0.1 fd00::1]"
+	assert.Equal(t, expected, ToString(svc))
 }
 
 func TestToStringSlice(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add 9 unit tests for the entirely-untested `internal/log/CustomHandler` slog implementation (Enabled, Handle, WithAttrs, WithGroup)
- Add `TestIPVersionString` covering all `IPVersion` constants plus out-of-range values
- Add `TestToString` for service formatting verification
- Add `IsManaged` edge cases (empty managed list, empty pod set name)
- Remove 3 stale `// TODO: Add test cases.` markers from auto-generated test scaffolding

### Coverage impact

| Package | Before | After |
|---------|--------|-------|
| `internal/log` | 0.0% | 30.4% |
| `tests/networking/netcommons` | 77.1% | 94.3% |

## Test plan

- [x] `go test ./internal/log/...` — 9 new tests pass
- [x] `go test ./tests/networking/netcommons/...` — all tests pass
- [x] `go test ./tests/networking/services/...` — all tests pass
- [x] `go test ./tests/lifecycle/scaling/...` — all tests pass (4 IsManaged cases)
- [x] `make test` — 79 packages pass, 0 failures
- [x] `golangci-lint` — 0 issues