### PR TITLE
fix: improve skip messages for 5 test cases

### DIFF
--- a/tests/lifecycle/suite.go
+++ b/tests/lifecycle/suite.go
@@ -409,6 +409,10 @@ func nameInStatefulSetSkipList(name, namespace string, list []configuration.Skip
 //nolint:dupl
 func testDeploymentScaling(env *provider.TestEnvironment, timeout time.Duration, check *checksdb.Check) {
 	defer env.SetNeedsRefresh()
+	if len(env.Deployments) == 0 {
+		check.SetResultSkipped("no deployments to check found")
+		return
+	}
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject
 	for _, deployment := range env.Deployments {
@@ -483,6 +487,10 @@ func testScaleCrd(env *provider.TestEnvironment, timeout time.Duration, check *c
 //nolint:dupl
 func testStatefulSetScaling(env *provider.TestEnvironment, timeout time.Duration, check *checksdb.Check) {
 	defer env.SetNeedsRefresh()
+	if len(env.StatefulSets) == 0 {
+		check.SetResultSkipped("no statefulsets to check found")
+		return
+	}
 	var compliantObjects []*testhelper.ReportObject
 	var nonCompliantObjects []*testhelper.ReportObject
 	for _, statefulSet := range env.StatefulSets {

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -235,7 +235,7 @@ func testNetworkConnectivity(env *provider.TestEnvironment, aIPVersion netcommon
 	netsUnderTest := icmp.BuildNetTestContext(env.Pods, aIPVersion, aType, check.GetLogger())
 	report, skip := icmp.RunNetworkingTests(netsUnderTest, defaultNumPings, aIPVersion, check.GetLogger())
 	if skip {
-		check.SetResultSkipped(fmt.Sprintf("There are no %q networks to test with at least 2 pods", aIPVersion))
+		check.SetResultSkipped(fmt.Sprintf("There are no %s %s networks to test with at least 2 pods. Ensure pods under test have the required network configuration.", aIPVersion, aType))
 		return
 	}
 	check.SetResult(report.CompliantObjectsOut, report.NonCompliantObjectsOut)

--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -566,11 +566,18 @@ func testNodeOperatingSystemStatus(check *checksdb.Check, env *provider.TestEnvi
 		// Control plane nodes must be RHCOS (also CentOS Stream starting in OCP 4.13)
 		// Per the release notes from OCP documentation:
 		// "You must use RHCOS machines for the control plane, and you can use either RHCOS or RHEL for compute machines."
-		if node.IsControlPlaneNode() && !node.IsRHCOS() && !node.IsCSCOS() {
-			check.LogError("Control plane node %q has been found to be running an incompatible operating system %q", nodeName, node.Data.Status.NodeInfo.OSImage)
-			failedControlPlaneNodes = append(failedControlPlaneNodes, nodeName)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(nodeName, "Control plane node has been found to be running an incompatible OS", false).AddField(testhelper.OSImage, node.Data.Status.NodeInfo.OSImage))
-			continue
+		if node.IsControlPlaneNode() {
+			if !node.IsRHCOS() && !node.IsCSCOS() {
+				check.LogError("Control plane node %q has been found to be running an incompatible operating system %q", nodeName, node.Data.Status.NodeInfo.OSImage)
+				failedControlPlaneNodes = append(failedControlPlaneNodes, nodeName)
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(nodeName, "Control plane node has been found to be running an incompatible OS", false).AddField(testhelper.OSImage, node.Data.Status.NodeInfo.OSImage))
+			} else {
+				check.LogInfo("Control plane node %q has been found to be running a compatible OS %q", nodeName, node.Data.Status.NodeInfo.OSImage)
+				compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(nodeName, "Control plane node has been found to be running a compatible OS", true).AddField(testhelper.OSImage, node.Data.Status.NodeInfo.OSImage))
+			}
+			if !node.IsWorkerNode() {
+				continue
+			}
 		}
 
 		// Worker nodes can either be RHEL or RHCOS
@@ -589,6 +596,7 @@ func testNodeOperatingSystemStatus(check *checksdb.Check, env *provider.TestEnvi
 
 				if len(shortVersions) == 0 {
 					check.LogInfo("Node %q has an RHCOS operating system that is not found in our internal database. Skipping as to not cause failures due to database mismatch.", nodeName)
+					compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(nodeName, "Worker node is running RHCOS but the version was not found in the internal database", true).AddField(testhelper.OSImage, node.Data.Status.NodeInfo.OSImage))
 					continue
 				}
 
@@ -633,6 +641,7 @@ func testNodeOperatingSystemStatus(check *checksdb.Check, env *provider.TestEnvi
 					OCP RC/GA version. Relaxing the conditions to check the OS as a result.
 					`
 				check.LogDebug(msg, nodeName, shortVersion)
+				compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(nodeName, "Worker node is running CentOS Stream CoreOS (not yet validated against OCP versions)", true).AddField(testhelper.OSImage, node.Data.Status.NodeInfo.OSImage))
 			} else if node.IsRHEL() {
 				// Get the short version from the node
 				shortVersion, err := node.GetRHELVersion()


### PR DESCRIPTION
## Summary
Improves skip messages for test cases that previously showed the generic "compliant and non-compliant objects lists are empty" message, making it clearer to partners why tests were skipped.

| Test Case | Before | After |
|-----------|--------|-------|
| `lifecycle-statefulset-scaling` | "compliant and non-compliant objects lists are empty" | "no statefulsets to check found" |
| `lifecycle-deployment-scaling` | "compliant and non-compliant objects lists are empty" | "no deployments to check found" |
| `networking-icmpv4-connectivity-multus` | `There are no "IPv4" networks to test...` | `There are no IPv4 Multus networks to test...` (includes interface type and remediation hint) |
| `networking-icmpv6-connectivity-multus` | `There are no "IPv6" networks to test...` | `There are no IPv6 Multus networks to test...` |
| `networking-icmpv6-connectivity` | `There are no "IPv6" networks to test...` | `There are no IPv6 Default networks to test...` |
| `platform-alteration-ocp-node-os-lifecycle` | "compliant and non-compliant objects lists are empty" | Now tracks compliant objects for control plane nodes, CSCOS workers, and RHCOS nodes with unknown DB versions |

## Test plan
- [ ] `make build` passes
- [ ] `make test` passes
- [ ] `make lint` passes (golangci-lint)