### PR TITLE
fix: allow extension API server RBAC for OLM-managed operators

### DIFF
--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -43,8 +43,9 @@ import (
 )
 
 const (
-	nodePort              = "NodePort"
-	defaultServiceAccount = "default"
+	nodePort                  = "NodePort"
+	defaultServiceAccount     = "default"
+	clusterServiceVersionKind = "ClusterServiceVersion"
 )
 
 var (
@@ -602,38 +603,10 @@ func testPodRoleBindings(check *checksdb.Check, env *provider.TestEnvironment) {
 					continue
 				}
 				// If we make it to this point, the role binding and the pod are in different namespaces.
-				// We must check if the pod's service account is in the role binding's subjects.
-				found := false
-				for _, subject := range env.RoleBindings[rbIndex].Subjects {
-					// If the subject is a service account and the service account is in the same namespace as one of the CNF's namespaces, then continue, this is allowed
-					if subject.Kind == rbacv1.ServiceAccountKind &&
-						subject.Namespace == put.Namespace &&
-						subject.Name == put.Spec.ServiceAccountName &&
-						stringhelper.StringInSlice[string](env.Namespaces, env.RoleBindings[rbIndex].Namespace, false) {
-						continue
-					}
-
-					// Finally, if the subject is a service account and the service account is in the same namespace as the pod, then we have a failure
-					if subject.Kind == rbacv1.ServiceAccountKind &&
-						subject.Namespace == put.Namespace &&
-						subject.Name == put.Spec.ServiceAccountName {
-						check.LogError("Pod %q has the following role bindings that do not live in one of the CNF namespaces: %q", put, env.RoleBindings[rbIndex].Name)
-
-						// Add the pod to the non-compliant list
-						nonCompliantObjects = append(nonCompliantObjects,
-							testhelper.NewPodReportObject(put.Namespace, put.Name,
-								"The role bindings used by this pod do not live in one of the CNF namespaces", false).
-								AddField(testhelper.RoleBindingName, env.RoleBindings[rbIndex].Name).
-								AddField(testhelper.RoleBindingNamespace, env.RoleBindings[rbIndex].Namespace).
-								AddField(testhelper.ServiceAccountName, put.Spec.ServiceAccountName).
-								SetType(testhelper.PodRoleBinding))
-						found = true
-						podIsCompliant = false
-						break
-					}
-				}
-				// Break of out the loop if we found a role binding that is out of namespace
-				if found {
+				// Check if this represents a violation.
+				if violation := checkCrossNamespaceRoleBindingViolation(&env.RoleBindings[rbIndex], put, env.Namespaces, check); violation != nil {
+					nonCompliantObjects = append(nonCompliantObjects, violation)
+					podIsCompliant = false
 					break
 				}
 			}
@@ -678,6 +651,13 @@ func testPodClusterRoleBindings(check *checksdb.Check, env *provider.TestEnviron
 		if isOwnedByClusterWideOperator && result {
 			check.LogInfo("Pod %q is using a cluster role binding but is owned by a cluster-wide operator (Csv %q, namespace %q)", put, csvName, csvNamespace)
 			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is using a cluster role binding but owned by a cluster-wide operator", true))
+			continue
+		}
+		// Allow system:auth-delegator ClusterRoleBinding for OLM-managed pods (required for Kubernetes extension API server)
+		// See: https://kubernetes.io/docs/tasks/extend-kubernetes/setup-extension-api-server/
+		if result && roleRefName == "system:auth-delegator" && isOwnedByOLM(put) {
+			check.LogInfo("Pod %q is using system:auth-delegator cluster role binding but is owned by OLM (extension API server requirement)", put)
+			compliantObjects = append(compliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod is using system:auth-delegator cluster role binding but owned by OLM (extension API server requirement)", true))
 			continue
 		}
 		if result {
@@ -733,6 +713,76 @@ func ownedByClusterWideOperator(topOwners map[string]podhelper.TopOwner, env *pr
 		}
 	}
 	return "", "", false
+}
+
+// isOwnedByOLM checks if a pod is managed by OLM (Operator Lifecycle Manager).
+// It checks for OLM-specific labels and owner references that indicate the pod is managed by an operator.
+// Return:
+//   - bool: true if the pod has OLM labels or CSV owner references, otherwise false
+func isOwnedByOLM(put *provider.Pod) bool {
+	// Check for OLM-specific labels
+	if _, hasOLMOwner := put.Labels["olm.owner"]; hasOLMOwner {
+		return true
+	}
+	if _, hasOLMNamespace := put.Labels["olm.owner.namespace"]; hasOLMNamespace {
+		return true
+	}
+	if _, hasOLMKind := put.Labels["olm.owner.kind"]; hasOLMKind {
+		return true
+	}
+
+	// Check owner references for ClusterServiceVersion
+	for _, ownerRef := range put.OwnerReferences {
+		if ownerRef.Kind == clusterServiceVersionKind {
+			return true
+		}
+	}
+
+	return false
+}
+
+// isAllowedExtensionAPIServerRoleBinding checks if a RoleBinding is an allowed cross-namespace binding
+// for Kubernetes extension API servers. Returns true if the RoleBinding is the documented
+// extension-apiserver-authentication-reader in kube-system for an OLM-managed pod.
+// See: https://kubernetes.io/docs/tasks/extend-kubernetes/setup-extension-api-server/
+func isAllowedExtensionAPIServerRoleBinding(rb *rbacv1.RoleBinding, put *provider.Pod) bool {
+	return rb.Namespace == "kube-system" &&
+		rb.RoleRef.Name == "extension-apiserver-authentication-reader" &&
+		isOwnedByOLM(put)
+}
+
+// checkCrossNamespaceRoleBindingViolation checks if a cross-namespace RoleBinding represents a violation.
+// Returns a violation report object if the binding is not allowed, nil otherwise.
+func checkCrossNamespaceRoleBindingViolation(rb *rbacv1.RoleBinding, put *provider.Pod, cnfNamespaces []string, check *checksdb.Check) *testhelper.ReportObject {
+	for _, subject := range rb.Subjects {
+		// If the subject is a service account in a CNF namespace, this is allowed
+		if subject.Kind == rbacv1.ServiceAccountKind &&
+			subject.Namespace == put.Namespace &&
+			subject.Name == put.Spec.ServiceAccountName &&
+			stringhelper.StringInSlice[string](cnfNamespaces, rb.Namespace, false) {
+			continue
+		}
+
+		// Check if this is the pod's service account
+		if subject.Kind == rbacv1.ServiceAccountKind &&
+			subject.Namespace == put.Namespace &&
+			subject.Name == put.Spec.ServiceAccountName {
+			// Allow extension API server RoleBinding for OLM-managed pods
+			if isAllowedExtensionAPIServerRoleBinding(rb, put) {
+				check.LogInfo("Pod %q is using extension-apiserver-authentication-reader role binding in kube-system but is owned by OLM (extension API server requirement)", put)
+				return nil
+			}
+
+			check.LogError("Pod %q has the following role bindings that do not live in one of the CNF namespaces: %q", put, rb.Name)
+			return testhelper.NewPodReportObject(put.Namespace, put.Name,
+				"The role bindings used by this pod do not live in one of the CNF namespaces", false).
+				AddField(testhelper.RoleBindingName, rb.Name).
+				AddField(testhelper.RoleBindingNamespace, rb.Namespace).
+				AddField(testhelper.ServiceAccountName, put.Spec.ServiceAccountName).
+				SetType(testhelper.PodRoleBinding)
+		}
+	}
+	return nil
 }
 
 // testAutomountServiceToken checks if each pod uses the default service account name and if the token is explicitly set in the Pod's spec or if it is inherited from the associated ServiceAccount.

--- a/tests/accesscontrol/suite_test.go
+++ b/tests/accesscontrol/suite_test.go
@@ -19,8 +19,10 @@ package accesscontrol
 import (
 	"testing"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func Test_isContainerCapabilitySet(t *testing.T) {
@@ -121,6 +123,158 @@ func Test_isContainerCapabilitySet(t *testing.T) {
 			if got := isContainerCapabilitySet(tt.args.containerCapabilities, tt.args.capability); got != tt.want {
 				assert.Equal(t, tt.want, got)
 			}
+		})
+	}
+}
+
+func Test_isOwnedByOLM(t *testing.T) {
+	tests := []struct {
+		name string
+		pod  *provider.Pod
+		want bool
+	}{
+		{
+			name: "pod with olm.owner label",
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"olm.owner": "test-operator.v1.0.0",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod with olm.owner.namespace label",
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"olm.owner.namespace": "openshift-operators",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod with olm.owner.kind label",
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"olm.owner.kind": "ClusterServiceVersion",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod with ClusterServiceVersion owner reference",
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind:       "ClusterServiceVersion",
+								Name:       "test-operator.v1.0.0",
+								APIVersion: "operators.coreos.com/v1alpha1",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod with no OLM labels or owner references",
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"app": "my-app",
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pod with non-CSV owner reference",
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind:       "ReplicaSet",
+								Name:       "test-rs",
+								APIVersion: "apps/v1",
+							},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "pod with multiple OLM labels",
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"olm.owner":           "test-operator.v1.0.0",
+							"olm.owner.namespace": "openshift-operators",
+							"olm.owner.kind":      "ClusterServiceVersion",
+						},
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "pod with both OLM label and CSV owner reference",
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"olm.owner": "test-operator.v1.0.0",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								Kind:       "ClusterServiceVersion",
+								Name:       "test-operator.v1.0.0",
+								APIVersion: "operators.coreos.com/v1alpha1",
+							},
+						},
+					},
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isOwnedByOLM(tt.pod)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Updates `access-control-cluster-role-bindings` and `access-control-role-bindings` tests to allow Kubernetes extension API server bindings for OLM-managed pods.

## Problem
Operators like KMM-hub were being flagged as non-compliant for using:
- `system:auth-delegator` ClusterRoleBinding
- `extension-apiserver-authentication-reader` RoleBinding in kube-system

However, these bindings are officially required by Kubernetes for extension API servers as documented in the [Kubernetes documentation](https://kubernetes.io/docs/tasks/extend-kubernetes/setup-extension-api-server/) (bullets 12 & 13).

OLM automatically creates these bindings for any operator with webhooks. The previous exception logic only allowed them for cluster-wide operators, causing namespaced operators like KMM-hub to fail despite using the identical, documented pattern.

## Changes
1. Added `isOwnedByOLM()` helper function to detect OLM-managed pods via labels and owner references
2. Updated `testPodClusterRoleBindings()` to allow `system:auth-delegator` for OLM-managed pods
3. Updated `testPodRoleBindings()` to allow `extension-apiserver-authentication-reader` in kube-system for OLM-managed pods

## What This Does NOT Do
The tests still run and validate all RBAC bindings. This adds narrow, specific exceptions for:
- The exact role names documented by Kubernetes
- The exact namespace required (kube-system)
- Only for OLM-managed pods (not arbitrary workloads)

All other cross-namespace RoleBindings and RBAC anti-patterns are still caught as failures.

## Test Plan
- Built successfully with no compilation errors
- All unit tests pass
- Code follows repository formatting standards

Fixes #3523