### PR TITLE
fix: replace panic with error log in getHelmList

### DIFF
--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -196,7 +196,8 @@ func getHelmList(restConfig *rest.Config, namespaces []string) map[string][]*rel
 
 		helmClient, err := helmclient.NewClientFromRestConf(opt)
 		if err != nil {
-			panic(err)
+			log.Error("Failed to create helm client for namespace %q, err: %v", ns, err)
+			continue
 		}
 		nsHelmchartreleases, _ := helmClient.ListDeployedReleases()
 		helmChartReleases[ns] = nsHelmchartreleases


### PR DESCRIPTION
## Summary

- Replace `panic(err)` with `log.Error` + `continue` in `getHelmList()` when `helmclient.NewClientFromRestConf` fails for a namespace
- Matches the error handling pattern already used by `findSubscriptions()` in the same file
- Prevents the entire test suite from crashing if the Helm client fails to initialize for a single namespace

## Test plan

- [ ] `go build ./...` passes
- [ ] `make lint` passes (golangci-lint reports 0 issues)
- [ ] Existing unit tests pass