### PR TITLE
fix: close file handles on all exit paths in archiver

### DIFF
--- a/internal/results/archiver.go
+++ b/internal/results/archiver.go
@@ -49,6 +49,7 @@ func CompressResultsArtifacts(outputDir string, filePaths []string) (string, err
 		return "", fmt.Errorf("failed creating tar.gz file %s in dir %s (filepath=%s): %v",
 			zipFileName, outputDir, zipFilePath, err)
 	}
+	defer zipFile.Close()
 
 	zipWriter := gzip.NewWriter(zipFile)
 	defer zipWriter.Close()
@@ -74,11 +75,11 @@ func CompressResultsArtifacts(outputDir string, filePaths []string) (string, err
 			return "", fmt.Errorf("failed to open file %s: %v", file, err)
 		}
 
-		if _, err = io.Copy(tarWriter, f); err != nil {
-			return "", fmt.Errorf("failed to tar file %s: %v", file, err)
-		}
-
+		_, err = io.Copy(tarWriter, f)
 		f.Close()
+		if err != nil {
+			return "", fmt.Errorf("failed to tar file %s: %w", file, err)
+		}
 	}
 
 	// Create fully qualified path to the zip file


### PR DESCRIPTION
## Summary

- Add `defer zipFile.Close()` for the tar.gz output file — previously the file handle leaked if any error occurred after creation
- Move `f.Close()` before the error check on `io.Copy` so source file handles are released even when the copy fails
- Use `%w` for error wrapping consistency with the rest of the function

## Test plan

- [ ] `go build ./...` passes
- [ ] `golangci-lint run ./internal/results/...` reports 0 issues
- [ ] Existing unit tests pass