### PR TITLE
fix: use %w instead of %v/%s in fmt.Errorf to preserve error chains

### DIFF
--- a/cmd/certsuite/check/image_cert_status/image_cert_status.go
+++ b/cmd/certsuite/check/image_cert_status/image_cert_status.go
@@ -39,7 +39,7 @@ func checkImageCertStatus(cmd *cobra.Command, _ []string) error {
 
 	validator, err := certdb.GetValidator(offlineDB)
 	if err != nil {
-		return fmt.Errorf("could not get a validator for container images, error: %v", err)
+		return fmt.Errorf("could not get a validator for container images, error: %w", err)
 	}
 
 	switch {

--- a/cmd/certsuite/check/results/results.go
+++ b/cmd/certsuite/check/results/results.go
@@ -50,7 +50,7 @@ func checkResults(cmd *cobra.Command, _ []string) error {
 	// Build a database with the test results from the log file
 	actualTestResults, err := getTestResultsDB(logFileName)
 	if err != nil {
-		return fmt.Errorf("could not get the test results DB, err: %v", err)
+		return fmt.Errorf("could not get the test results DB, err: %w", err)
 	}
 
 	// Generate a reference YAML template with the test results if required
@@ -61,7 +61,7 @@ func checkResults(cmd *cobra.Command, _ []string) error {
 	// Get the expected test results from the reference YAML template
 	expectedTestResults, err := getExpectedTestResults(templateFileName)
 	if err != nil {
-		return fmt.Errorf("could not get the expected test results, err: %v", err)
+		return fmt.Errorf("could not get the expected test results, err: %w", err)
 	}
 
 	// Match the results between the test results DB and the reference YAML template
@@ -95,7 +95,7 @@ func getTestResultsDB(logFileName string) (map[string]string, error) {
 
 	file, err := os.Open(logFileName)
 	if err != nil {
-		return nil, fmt.Errorf("could not open file %q, err: %v", logFileName, err)
+		return nil, fmt.Errorf("could not open file %q, err: %w", logFileName, err)
 	}
 	defer file.Close()
 
@@ -118,7 +118,7 @@ func getTestResultsDB(logFileName string) (map[string]string, error) {
 	}
 
 	if err := scanner.Err(); err != nil {
-		return nil, fmt.Errorf("error scanning file, err: %v", err)
+		return nil, fmt.Errorf("error scanning file, err: %w", err)
 	}
 
 	return resultsDB, nil
@@ -127,13 +127,13 @@ func getTestResultsDB(logFileName string) (map[string]string, error) {
 func getExpectedTestResults(templateFileName string) (map[string]string, error) {
 	templateFile, err := os.ReadFile(templateFileName)
 	if err != nil {
-		return nil, fmt.Errorf("could not open template file %q, err: %v", templateFileName, err)
+		return nil, fmt.Errorf("could not open template file %q, err: %w", templateFileName, err)
 	}
 
 	var expectedTestResultsList TestResults
 	err = yaml.Unmarshal(templateFile, &expectedTestResultsList)
 	if err != nil {
-		return nil, fmt.Errorf("could not parse the template YAML file, err: %v", err)
+		return nil, fmt.Errorf("could not parse the template YAML file, err: %w", err)
 	}
 
 	expectedTestResults := make(map[string]string)
@@ -190,12 +190,12 @@ func generateTemplateFile(resultsDB map[string]string) error {
 	yamlEncoder.SetIndent(twoSpaces)
 	err := yamlEncoder.Encode(&resultsTemplate)
 	if err != nil {
-		return fmt.Errorf("could not encode template yaml, err: %v", err)
+		return fmt.Errorf("could not encode template yaml, err: %w", err)
 	}
 
 	err = os.WriteFile(TestResultsTemplateFileName, yamlTemplate.Bytes(), TestResultsTemplateFilePermissions)
 	if err != nil {
-		return fmt.Errorf("could not write to file %q: %v", TestResultsTemplateFileName, err)
+		return fmt.Errorf("could not write to file %q: %w", TestResultsTemplateFileName, err)
 	}
 
 	return nil

--- a/cmd/certsuite/claim/compare/compare.go
+++ b/cmd/certsuite/claim/compare/compare.go
@@ -121,23 +121,23 @@ func claimCompareFilesfunc(claim1, claim2 string) error {
 	// readfiles
 	claimdata1, err := os.ReadFile(claim1)
 	if err != nil {
-		return fmt.Errorf("failed reading claim1 file: %v", err)
+		return fmt.Errorf("failed reading claim1 file: %w", err)
 	}
 
 	claimdata2, err := os.ReadFile(claim2)
 	if err != nil {
-		return fmt.Errorf("failed reading claim2 file: %v", err)
+		return fmt.Errorf("failed reading claim2 file: %w", err)
 	}
 
 	// unmarshal the files
 	claimFile1Data, err := unmarshalClaimFile(claimdata1)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal claim1 file: %v", err)
+		return fmt.Errorf("failed to unmarshal claim1 file: %w", err)
 	}
 
 	claimFile2Data, err := unmarshalClaimFile(claimdata2)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal claim2 file: %v", err)
+		return fmt.Errorf("failed to unmarshal claim2 file: %w", err)
 	}
 
 	// Compare claim versions.

--- a/cmd/certsuite/claim/show/csv/csv.go
+++ b/cmd/certsuite/claim/show/csv/csv.go
@@ -90,7 +90,7 @@ func dumpCsv(_ *cobra.Command, _ []string) error {
 	// Parse the claim file into the claim scheme.
 	claimScheme, err := claim.Parse(claimFilePathFlag)
 	if err != nil {
-		return fmt.Errorf("failed to parse claim file %s: %v", claimFilePathFlag, err)
+		return fmt.Errorf("failed to parse claim file %s: %w", claimFilePathFlag, err)
 	}
 
 	// Check claim format version
@@ -186,7 +186,7 @@ func loadCNFTypeMap(path string) (CNFTypeMap map[string]string, err error) { //n
 	// Open the CSV file
 	file, err := os.Open(path)
 	if err != nil {
-		return CNFTypeMap, fmt.Errorf("error opening text file: %s, err:%s", path, err)
+		return CNFTypeMap, fmt.Errorf("error opening text file: %s, err:%w", path, err)
 	}
 	defer file.Close()
 	// initialize map
@@ -195,7 +195,7 @@ func loadCNFTypeMap(path string) (CNFTypeMap map[string]string, err error) { //n
 	// read the file
 	data, err := io.ReadAll(file)
 	if err != nil {
-		return CNFTypeMap, fmt.Errorf("error reading JSON file: %s, err:%s", path, err)
+		return CNFTypeMap, fmt.Errorf("error reading JSON file: %s, err:%w", path, err)
 	}
 
 	err = json.Unmarshal(data, &CNFTypeMap)

--- a/cmd/certsuite/claim/show/failures/failures.go
+++ b/cmd/certsuite/claim/show/failures/failures.go
@@ -166,7 +166,7 @@ func getNonCompliantObjectsFromFailureReason(checkDetails string) ([]NonComplian
 
 	err := json.Unmarshal([]byte(checkDetails), &objects)
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode checkDetails %s: %v", checkDetails, err)
+		return nil, fmt.Errorf("failed to decode checkDetails %s: %w", checkDetails, err)
 	}
 
 	// Now let's create a list of our NonCompliantObject-type items.
@@ -286,7 +286,7 @@ func showFailures(_ *cobra.Command, _ []string) error {
 	// Parse the claim file into the claim scheme.
 	claimScheme, err := claim.Parse(claimFilePathFlag)
 	if err != nil {
-		return fmt.Errorf("failed to parse claim file %s: %v", claimFilePathFlag, err)
+		return fmt.Errorf("failed to parse claim file %s: %w", claimFilePathFlag, err)
 	}
 
 	// Check claim format version

--- a/cmd/certsuite/generate/feedback/feedback.go
+++ b/cmd/certsuite/generate/feedback/feedback.go
@@ -41,28 +41,28 @@ var (
 func runGenerateFeedbackJsFile(_ *cobra.Command, _ []string) error {
 	dat, err := os.ReadFile(feedbackJSONFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to read json feedback file: %v", err)
+		return fmt.Errorf("failed to read json feedback file: %w", err)
 	}
 	var obj map[string]interface{}
 	err = json.Unmarshal(dat, &obj)
 	if err != nil {
-		return fmt.Errorf("failed to unmarshal json feedback file %s: %v", feedbackJSONFilePath, err)
+		return fmt.Errorf("failed to unmarshal json feedback file %s: %w", feedbackJSONFilePath, err)
 	}
 
 	// Print the JSON content
 	jsonBytes, err := json.MarshalIndent(obj, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal feedback js content: %v", err)
+		return fmt.Errorf("failed to marshal feedback js content: %w", err)
 	}
 	feedbackJsFilePath := filepath.Join(feedbackOutputPath, "feedback.js")
 	file, err := os.Create(feedbackJsFilePath)
 	if err != nil {
-		return fmt.Errorf("failed to create javascript feedback file: %v", err)
+		return fmt.Errorf("failed to create javascript feedback file: %w", err)
 	}
 	feedbackjs := "feedback="
 	_, err = file.WriteString(feedbackjs + string(jsonBytes))
 	if err != nil {
-		return fmt.Errorf("failed to write javascript feedback file: %v", err)
+		return fmt.Errorf("failed to write javascript feedback file: %w", err)
 	}
 
 	fmt.Println(feedbackjs + string(jsonBytes))

--- a/cmd/certsuite/info/info.go
+++ b/cmd/certsuite/info/info.go
@@ -32,7 +32,7 @@ func showInfo(cmd *cobra.Command, _ []string) error {
 	// Get a list of matching test cases names
 	testIDs, err := getMatchingTestIDs(testCaseFlag)
 	if err != nil {
-		return fmt.Errorf("could not get the matching test case list, err: %v", err)
+		return fmt.Errorf("could not get the matching test case list, err: %w", err)
 	}
 
 	// Print the list and leave if only listing is required
@@ -123,12 +123,12 @@ func printTestList(testIDs []string) {
 
 func getMatchingTestIDs(labelExpr string) ([]string, error) {
 	if err := checksdb.InitLabelsExprEvaluator(labelExpr); err != nil {
-		return nil, fmt.Errorf("failed to initialize a test case label evaluator, err: %v", err)
+		return nil, fmt.Errorf("failed to initialize a test case label evaluator, err: %w", err)
 	}
 	certsuite.LoadInternalChecksDB()
 	testIDs, err := checksdb.FilterCheckIDs()
 	if err != nil {
-		return nil, fmt.Errorf("could not list test cases, err: %v", err)
+		return nil, fmt.Errorf("could not list test cases, err: %w", err)
 	}
 
 	return testIDs, nil

--- a/cmd/certsuite/pkg/claim/claim.go
+++ b/cmd/certsuite/pkg/claim/claim.go
@@ -90,12 +90,12 @@ type Schema struct {
 func CheckVersion(version string) error {
 	claimSemVersion, err := semver.NewVersion(version)
 	if err != nil {
-		return fmt.Errorf("claim file version %q is not valid: %v", version, err)
+		return fmt.Errorf("claim file version %q is not valid: %w", version, err)
 	}
 
 	supportedSemVersion, err := semver.NewVersion(supportedClaimFormatVersion)
 	if err != nil {
-		return fmt.Errorf("supported claim file version v%v is not valid: v%v", supportedClaimFormatVersion, err)
+		return fmt.Errorf("supported claim file version v%v is not valid: %w", supportedClaimFormatVersion, err)
 	}
 
 	if claimSemVersion.Compare(supportedSemVersion) != 0 {
@@ -109,13 +109,13 @@ func CheckVersion(version string) error {
 func Parse(filePath string) (*Schema, error) {
 	fileBytes, err := os.ReadFile(filePath)
 	if err != nil {
-		return nil, fmt.Errorf("failure reading file: %v", err)
+		return nil, fmt.Errorf("failure reading file: %w", err)
 	}
 
 	claimFile := Schema{}
 	err = json.Unmarshal(fileBytes, &claimFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal file: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal file: %w", err)
 	}
 
 	return &claimFile, nil

--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -128,10 +128,10 @@ func initTestParamsFromFlags(cmd *cobra.Command) error {
 		var dirPerm fs.FileMode = 0o755 // default permissions for a directory
 		err := os.MkdirAll(testParams.OutputDir, dirPerm)
 		if err != nil {
-			return fmt.Errorf("could not create directory %q, err: %v", testParams.OutputDir, err)
+			return fmt.Errorf("could not create directory %q, err: %w", testParams.OutputDir, err)
 		}
 	} else if err != nil {
-		return fmt.Errorf("could not check directory %q, err: %v", testParams.OutputDir, err)
+		return fmt.Errorf("could not check directory %q, err: %w", testParams.OutputDir, err)
 	}
 
 	// Process the timeout flag

--- a/cmd/certsuite/upload/results_spreadsheet/drive_utils.go
+++ b/cmd/certsuite/upload/results_spreadsheet/drive_utils.go
@@ -23,7 +23,7 @@ func createDriveFolder(srv *drive.Service, folderName, parentFolderID string) (*
 
 	files, err := call.Do()
 	if err != nil {
-		return nil, fmt.Errorf("unable to list files: %v", err)
+		return nil, fmt.Errorf("unable to list files: %w", err)
 	}
 
 	if len(files.Files) > 0 {
@@ -32,7 +32,7 @@ func createDriveFolder(srv *drive.Service, folderName, parentFolderID string) (*
 
 	createdFolder, err := srv.Files.Create(driveFolder).Do()
 	if err != nil {
-		return nil, fmt.Errorf("unable to create folder: %v", err)
+		return nil, fmt.Errorf("unable to create folder: %w", err)
 	}
 
 	return createdFolder, nil

--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet.go
@@ -78,12 +78,12 @@ func CreateSheetsAndDriveServices(credentials string) (sheetService *sheets.Serv
 
 	sheetSrv, err := sheets.NewService(ctx, option.WithAuthCredentialsFile(option.ServiceAccount, credentials))
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to retrieve Sheets service: %v", err)
+		return nil, nil, fmt.Errorf("unable to retrieve Sheets service: %w", err)
 	}
 
 	driveSrv, err := drive.NewService(ctx, option.WithAuthCredentialsFile(option.ServiceAccount, credentials))
 	if err != nil {
-		return nil, nil, fmt.Errorf("unable to retrieve Drive service: %v", err)
+		return nil, nil, fmt.Errorf("unable to retrieve Drive service: %w", err)
 	}
 
 	return sheetSrv, driveSrv, nil
@@ -206,7 +206,7 @@ func createConclusionsSheet(sheetsService *sheets.Service, driveService *drive.S
 	workloadsFolderName := "Results Per Workload"
 	workloadsResultsFolder, err := createDriveFolder(driveService, workloadsFolderName, mainResultsFolderID)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create workloads results folder: %v", err)
+		return nil, fmt.Errorf("unable to create workloads results folder: %w", err)
 	}
 
 	rawSheetHeaders := GetHeadersFromSheet(rawResultsSheet)
@@ -262,7 +262,7 @@ func createConclusionsSheet(sheetsService *sheets.Service, driveService *drive.S
 			case ResultsConclusionsCol:
 				workloadResultsSpreadsheet, err := createSingleWorkloadRawResultsSpreadSheet(sheetsService, driveService, workloadsResultsFolder, rawResultsSheet, workloadName)
 				if err != nil {
-					return nil, fmt.Errorf("error has occurred while creating %s results file: %v", workloadName, err)
+					return nil, fmt.Errorf("error has occurred while creating %s results file: %w", workloadName, err)
 				}
 
 				hyperlinkFormula := fmt.Sprintf("=HYPERLINK(%q, %q)", workloadResultsSpreadsheet.SpreadsheetUrl, "Results")
@@ -292,7 +292,7 @@ func createConclusionsSheet(sheetsService *sheets.Service, driveService *drive.S
 func createRawResultsSheet(fp string) (*sheets.Sheet, error) {
 	records, err := readCSV(fp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read csv file: %v", err)
+		return nil, fmt.Errorf("failed to read csv file: %w", err)
 	}
 
 	rows := prepareRecordsForSpreadSheet(records)

--- a/cmd/certsuite/upload/results_spreadsheet/sheet_utils.go
+++ b/cmd/certsuite/upload/results_spreadsheet/sheet_utils.go
@@ -73,7 +73,7 @@ func addBasicFilterToSpreadSheet(srv *sheets.Service, spreadsheet *sheets.Spread
 func addDescendingSortFilterToSheet(srv *sheets.Service, spreadsheet *sheets.Spreadsheet, sheetName, colName string) error {
 	sheetsValues, err := srv.Spreadsheets.Values.Get(spreadsheet.SpreadsheetId, sheetName).Do()
 	if err != nil {
-		return fmt.Errorf("unable to retrieve sheet %s values: %v", sheetName, err)
+		return fmt.Errorf("unable to retrieve sheet %s values: %w", sheetName, err)
 	}
 	headers := GetHeadersFromValueRange(sheetsValues)
 	indices, err := GetHeaderIndicesByColumnNames(headers, []string{colName})
@@ -83,7 +83,7 @@ func addDescendingSortFilterToSheet(srv *sheets.Service, spreadsheet *sheets.Spr
 
 	sheetID, err := GetSheetIDByName(spreadsheet, sheetName)
 	if err != nil {
-		return fmt.Errorf("unable to retrieve sheet %s id: %v", sheetName, err)
+		return fmt.Errorf("unable to retrieve sheet %s id: %w", sheetName, err)
 	}
 
 	requests := []*sheets.Request{
@@ -117,7 +117,7 @@ const booleanConditionTextEQ = "TEXT_EQ"
 func addFilterByFailedAndMandatoryToSheet(srv *sheets.Service, spreadsheet *sheets.Spreadsheet, sheetName string) error {
 	sheetsValues, err := srv.Spreadsheets.Values.Get(spreadsheet.SpreadsheetId, sheetName).Do()
 	if err != nil {
-		return fmt.Errorf("unable to retrieve sheet %s values: %v", sheetName, err)
+		return fmt.Errorf("unable to retrieve sheet %s values: %w", sheetName, err)
 	}
 	headers := GetHeadersFromValueRange(sheetsValues)
 	indices, err := GetHeaderIndicesByColumnNames(headers, []string{"State", "Mandatory/Optional"})
@@ -130,7 +130,7 @@ func addFilterByFailedAndMandatoryToSheet(srv *sheets.Service, spreadsheet *shee
 
 	sheetID, err := GetSheetIDByName(spreadsheet, sheetName)
 	if err != nil {
-		return fmt.Errorf("unable to retrieve sheet %s id: %v", sheetName, err)
+		return fmt.Errorf("unable to retrieve sheet %s id: %w", sheetName, err)
 	}
 
 	requests := []*sheets.Request{

--- a/internal/clientsholder/clientsholder.go
+++ b/internal/clientsholder/clientsholder.go
@@ -263,7 +263,7 @@ func getClusterRestConfig(filenames ...string) (*rest.Config, error) {
 		clientConfig := GetClientConfigFromRestConfig(restConfig)
 		clientsHolder.KubeConfig, err = createByteArrayKubeConfig(clientConfig)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create byte array from kube config reference: %v", err)
+			return nil, fmt.Errorf("failed to create byte array from kube config reference: %w", err)
 		}
 
 		// No error: we're inside a cluster.
@@ -300,7 +300,7 @@ func getClusterRestConfig(filenames ...string) (*rest.Config, error) {
 
 	restConfig, err = kubeconfig.ClientConfig()
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate rest config: %s", err)
+		return nil, fmt.Errorf("cannot instantiate rest config: %w", err)
 	}
 
 	return restConfig, nil
@@ -313,64 +313,64 @@ func newClientsHolder(filenames ...string) (*ClientsHolder, error) { //nolint:fu
 	var err error
 	clientsHolder.RestConfig, err = getClusterRestConfig(filenames...)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get rest.Config: %v", err)
+		return nil, fmt.Errorf("failed to get rest.Config: %w", err)
 	}
 	clientsHolder.RestConfig.Timeout = getClientTimeout()
 
 	clientsHolder.DynamicClient, err = dynamic.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate dynamic client (unstructured/dynamic): %s", err)
+		return nil, fmt.Errorf("cannot instantiate dynamic client (unstructured/dynamic): %w", err)
 	}
 	clientsHolder.APIExtClient, err = apiextv1.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate apiextv1: %s", err)
+		return nil, fmt.Errorf("cannot instantiate apiextv1: %w", err)
 	}
 	clientsHolder.OlmClient, err = olmClient.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate olm clientset: %s", err)
+		return nil, fmt.Errorf("cannot instantiate olm clientset: %w", err)
 	}
 	clientsHolder.OlmPkgClient, err = olmpkgclient.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate olm clientset: %s", err)
+		return nil, fmt.Errorf("cannot instantiate olm clientset: %w", err)
 	}
 	clientsHolder.K8sClient, err = kubernetes.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate k8sclient: %s", err)
+		return nil, fmt.Errorf("cannot instantiate k8sclient: %w", err)
 	}
 	// create the oc client
 	clientsHolder.OcpClient, err = clientconfigv1.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate ocClient: %s", err)
+		return nil, fmt.Errorf("cannot instantiate ocClient: %w", err)
 	}
 	clientsHolder.MachineCfg, err = ocpMachine.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate MachineCfg client: %s", err)
+		return nil, fmt.Errorf("cannot instantiate MachineCfg client: %w", err)
 	}
 	clientsHolder.K8sNetworkingClient, err = networkingv1.NewForConfig(clientsHolder.RestConfig)
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate k8s networking client: %s", err)
+		return nil, fmt.Errorf("cannot instantiate k8s networking client: %w", err)
 	}
 
 	discoveryClient, err := discovery.NewDiscoveryClientForConfig(clientsHolder.RestConfig)
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate discoveryClient: %s", err)
+		return nil, fmt.Errorf("cannot instantiate discoveryClient: %w", err)
 	}
 
 	clientsHolder.GroupResources, err = discoveryClient.ServerPreferredResources()
 	if err != nil {
-		return nil, fmt.Errorf("cannot get list of resources in cluster: %s", err)
+		return nil, fmt.Errorf("cannot get list of resources in cluster: %w", err)
 	}
 
 	resolver := scale.NewDiscoveryScaleKindResolver(discoveryClient)
 	gr, err := restmapper.GetAPIGroupResources(clientsHolder.K8sClient.Discovery())
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate GetAPIGroupResources: %s", err)
+		return nil, fmt.Errorf("cannot instantiate GetAPIGroupResources: %w", err)
 	}
 
 	mapper := restmapper.NewDiscoveryRESTMapper(gr)
 	clientsHolder.ScalingClient, err = scale.NewForConfig(clientsHolder.RestConfig, mapper, dynamic.LegacyAPIPathResolverFunc, resolver)
 	if err != nil {
-		return nil, fmt.Errorf("cannot instantiate ScalesGetter: %s", err)
+		return nil, fmt.Errorf("cannot instantiate ScalesGetter: %w", err)
 	}
 
 	clientsHolder.CNCFNetworkingClient, err = cncfNetworkAttachmentv1.NewForConfig(clientsHolder.RestConfig)

--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -76,7 +76,7 @@ func GetPidFromContainer(cut *provider.Container, ctx clientsholder.Context) (in
 	ch := clientsholder.GetClientsHolder()
 	outStr, errStr, err := ch.ExecCommandContainer(ctx, pidCmd)
 	if err != nil {
-		return 0, fmt.Errorf("cannot execute command: \" %s \"  on %s err:%s", pidCmd, cut, err)
+		return 0, fmt.Errorf("cannot execute command: \" %s \"  on %s err:%w", pidCmd, cut, err)
 	}
 	if errStr != "" {
 		return 0, fmt.Errorf("cmd: \" %s \" on %s returned %s", pidCmd, cut, errStr)
@@ -90,12 +90,12 @@ func GetContainerPidNamespace(testContainer *provider.Container, env *provider.T
 	// Get the container pid
 	ocpContext, err := GetNodeProbePodContext(testContainer.NodeName, env)
 	if err != nil {
-		return "", fmt.Errorf("failed to get probe pod's context for container %s: %v", testContainer, err)
+		return "", fmt.Errorf("failed to get probe pod's context for container %s: %w", testContainer, err)
 	}
 
 	pid, err := GetPidFromContainer(testContainer, ocpContext)
 	if err != nil {
-		return "", fmt.Errorf("unable to get container process id due to: %v", err)
+		return "", fmt.Errorf("unable to get container process id due to: %w", err)
 	}
 	log.Debug("Obtained process id for %s is %d", testContainer, pid)
 
@@ -111,7 +111,7 @@ func GetContainerPidNamespace(testContainer *provider.Container, env *provider.T
 func GetContainerProcesses(container *provider.Container, env *provider.TestEnvironment) ([]*Process, error) {
 	pidNs, err := GetContainerPidNamespace(container, env)
 	if err != nil {
-		return nil, fmt.Errorf("could not get the containers' pid namespace, err: %v", err)
+		return nil, fmt.Errorf("could not get the containers' pid namespace, err: %w", err)
 	}
 
 	return GetPidsFromPidNamespace(pidNs, container)
@@ -123,7 +123,7 @@ func ExecCommandContainerNSEnter(command string,
 	env := provider.GetTestEnvironment()
 	ctx, err := GetNodeProbePodContext(aContainer.NodeName, &env)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get probe pod's context for container %s: %v", aContainer, err)
+		return "", "", fmt.Errorf("failed to get probe pod's context for container %s: %w", aContainer, err)
 	}
 
 	ch := clientsholder.GetClientsHolder()
@@ -131,7 +131,7 @@ func ExecCommandContainerNSEnter(command string,
 	// Get the container PID to build the nsenter command
 	containerPid, err := GetPidFromContainer(aContainer, ctx)
 	if err != nil {
-		return "", "", fmt.Errorf("cannot get PID from: %s, err: %v", aContainer, err)
+		return "", "", fmt.Errorf("cannot get PID from: %s, err: %w", aContainer, err)
 	}
 
 	// Add the container PID and the specific command to run with nsenter
@@ -148,7 +148,7 @@ func ExecCommandContainerNSEnter(command string,
 		}
 	}
 	if err != nil {
-		return "", "", fmt.Errorf("cannot execute command: \" %s \"  on %s err:%s", command, aContainer, err)
+		return "", "", fmt.Errorf("cannot execute command: \" %s \"  on %s err:%w", command, aContainer, err)
 	}
 
 	return outStr, errStr, err
@@ -159,7 +159,7 @@ func GetPidsFromPidNamespace(pidNamespace string, container *provider.Container)
 	env := provider.GetTestEnvironment()
 	ctx, err := GetNodeProbePodContext(container.NodeName, &env)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get probe pod's context for container %s: %v", container, err)
+		return nil, fmt.Errorf("failed to get probe pod's context for container %s: %w", container, err)
 	}
 
 	stdout, stderr, err := clientsholder.GetClientsHolder().ExecCommandContainer(ctx, command)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -40,12 +40,12 @@ func CreateGlobalLogFile(outputDir, logLevel string) error {
 	logFilePath := outputDir + "/" + LogFileName
 	err := os.Remove(logFilePath)
 	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("could not delete old log file, err: %v", err)
+		return fmt.Errorf("could not delete old log file, err: %w", err)
 	}
 
 	logFile, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE, LogFilePermissions)
 	if err != nil {
-		return fmt.Errorf("could not open a new log file, err: %v", err)
+		return fmt.Errorf("could not open a new log file, err: %w", err)
 	}
 
 	SetupLogger(logFile, logLevel)

--- a/internal/results/archiver.go
+++ b/internal/results/archiver.go
@@ -27,12 +27,12 @@ func generateZipFileName() string {
 func getFileTarHeader(file string) (*tar.Header, error) {
 	info, err := os.Stat(file)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get file info from %s: %v", file, err)
+		return nil, fmt.Errorf("failed to get file info from %s: %w", file, err)
 	}
 
 	header, err := tar.FileInfoHeader(info, info.Name())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get file info header for %s: %v", file, err)
+		return nil, fmt.Errorf("failed to get file info header for %s: %w", file, err)
 	}
 
 	return header, nil
@@ -46,7 +46,7 @@ func CompressResultsArtifacts(outputDir string, filePaths []string) (string, err
 	log.Info("Compressing results artifacts into %s", zipFilePath)
 	zipFile, err := os.Create(zipFilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed creating tar.gz file %s in dir %s (filepath=%s): %v",
+		return "", fmt.Errorf("failed creating tar.gz file %s in dir %s (filepath=%s): %w",
 			zipFileName, outputDir, zipFilePath, err)
 	}
 	defer zipFile.Close()
@@ -67,12 +67,12 @@ func CompressResultsArtifacts(outputDir string, filePaths []string) (string, err
 
 		err = tarWriter.WriteHeader(tarHeader)
 		if err != nil {
-			return "", fmt.Errorf("failed to write tar header for %s: %v", file, err)
+			return "", fmt.Errorf("failed to write tar header for %s: %w", file, err)
 		}
 
 		f, err := os.Open(file)
 		if err != nil {
-			return "", fmt.Errorf("failed to open file %s: %v", file, err)
+			return "", fmt.Errorf("failed to open file %s: %w", file, err)
 		}
 
 		_, err = io.Copy(tarWriter, f)
@@ -85,7 +85,7 @@ func CompressResultsArtifacts(outputDir string, filePaths []string) (string, err
 	// Create fully qualified path to the zip file
 	zipFilePath, err = filepath.Abs(zipFilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to get absolute path for %s: %v", zipFilePath, err)
+		return "", fmt.Errorf("failed to get absolute path for %s: %w", zipFilePath, err)
 	}
 
 	// Return the entire path to the zip file

--- a/internal/results/html.go
+++ b/internal/results/html.go
@@ -22,7 +22,7 @@ func createClaimJSFile(claimFilePath, outputDir string) (filePath string, err er
 	// Read claim.json content.
 	claimContent, err := os.ReadFile(claimFilePath)
 	if err != nil {
-		return "", fmt.Errorf("failed to read claim file %s content in %s: %v", claimFilePath, outputDir, err)
+		return "", fmt.Errorf("failed to read claim file %s content in %s: %w", claimFilePath, outputDir, err)
 	}
 
 	// Add the content as the value for the js variable.
@@ -31,7 +31,7 @@ func createClaimJSFile(claimFilePath, outputDir string) (filePath string, err er
 	filePath = filepath.Join(outputDir, jsClaimVarFileName)
 	err = os.WriteFile(filePath, []byte(jsClaimContent), writeFilePerms)
 	if err != nil {
-		return "", fmt.Errorf("failed to write file %s: %v", filePath, err)
+		return "", fmt.Errorf("failed to write file %s: %w", filePath, err)
 	}
 
 	return filePath, nil
@@ -58,14 +58,14 @@ func CreateResultsWebFiles(outputDir, claimFileName string) (filePaths []string,
 	claimFilePath := filepath.Join(outputDir, claimFileName)
 	claimJSFilePath, err := createClaimJSFile(claimFilePath, outputDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create file %s: %v", jsClaimVarFileName, err)
+		return nil, fmt.Errorf("failed to create file %s: %w", jsClaimVarFileName, err)
 	}
 
 	filePaths = []string{claimJSFilePath}
 	for _, f := range staticFiles {
 		err := os.WriteFile(f.Path, f.Content, writeFilePerms)
 		if err != nil {
-			return nil, fmt.Errorf("failed to create file %s: %v", f.Path, err)
+			return nil, fmt.Errorf("failed to create file %s: %w", f.Path, err)
 		}
 
 		// Add this file path to the slice.

--- a/internal/results/rhconnect.go
+++ b/internal/results/rhconnect.go
@@ -24,12 +24,12 @@ const (
 func createFormField(w *multipart.Writer, field, value string) error {
 	fw, err := w.CreateFormField(field)
 	if err != nil {
-		return fmt.Errorf("failed to create form field: %v", err)
+		return fmt.Errorf("failed to create form field: %w", err)
 	}
 
 	_, err = fw.Write([]byte(value))
 	if err != nil {
-		return fmt.Errorf("failed to write field %s: %v", field, err)
+		return fmt.Errorf("failed to write field %s: %w", field, err)
 	}
 
 	return nil
@@ -71,7 +71,7 @@ func GetCertIDFromConnectAPI(apiKey, projectID, connectAPIBaseURL, proxyURL, pro
 	// Create a new request
 	req, err := http.NewRequest("POST", certIDURL, bytes.NewBuffer(projectIDJSONBytes))
 	if err != nil {
-		return "", fmt.Errorf("failed to create new request: %v", err)
+		return "", fmt.Errorf("failed to create new request: %w", err)
 	}
 
 	log.Debug("Request Body: %s", req.Body)
@@ -90,7 +90,7 @@ func GetCertIDFromConnectAPI(apiKey, projectID, connectAPIBaseURL, proxyURL, pro
 	setProxy(client, proxyURL, proxyPort)
 	res, err := sendRequest(req, client)
 	if err != nil {
-		return "", fmt.Errorf("failed to send post request to the endpoint: %v", err)
+		return "", fmt.Errorf("failed to send post request to the endpoint: %w", err)
 	}
 	defer res.Body.Close()
 
@@ -98,7 +98,7 @@ func GetCertIDFromConnectAPI(apiKey, projectID, connectAPIBaseURL, proxyURL, pro
 	var certIDResponse CertIDResponse
 	err = json.NewDecoder(res.Body).Decode(&certIDResponse)
 	if err != nil {
-		return "", fmt.Errorf("failed to decode response body: %v", err)
+		return "", fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	log.Info("Certification ID retrieved from the API: %d", certIDResponse.ID)
@@ -148,7 +148,7 @@ func SendResultsToConnectAPI(zipFile, apiKey, connectBaseURL, certID, proxyURL, 
 
 	fw, err := w.CreateFormFile("attachment", zipFile)
 	if err != nil {
-		return fmt.Errorf("failed to create form file: %v", err)
+		return fmt.Errorf("failed to create form file: %w", err)
 	}
 
 	if _, err = io.Copy(fw, claimFile); err != nil {
@@ -181,7 +181,7 @@ func SendResultsToConnectAPI(zipFile, apiKey, connectBaseURL, certID, proxyURL, 
 	// Create a new request
 	req, err := http.NewRequest("POST", connectAPIURL, &buffer)
 	if err != nil {
-		return fmt.Errorf("failed to create new request: %v", err)
+		return fmt.Errorf("failed to create new request: %w", err)
 	}
 
 	// Set the content type
@@ -195,7 +195,7 @@ func SendResultsToConnectAPI(zipFile, apiKey, connectBaseURL, certID, proxyURL, 
 	setProxy(client, proxyURL, proxyPort)
 	response, err := sendRequest(req, client)
 	if err != nil {
-		return fmt.Errorf("failed to send post request to the endpoint: %v", err)
+		return fmt.Errorf("failed to send post request to the endpoint: %w", err)
 	}
 	defer response.Body.Close()
 
@@ -203,7 +203,7 @@ func SendResultsToConnectAPI(zipFile, apiKey, connectBaseURL, certID, proxyURL, 
 	var uploadResult UploadResult
 	err = json.NewDecoder(response.Body).Decode(&uploadResult)
 	if err != nil {
-		return fmt.Errorf("failed to decode response body: %v", err)
+		return fmt.Errorf("failed to decode response body: %w", err)
 	}
 
 	log.Info("Download URL: %s", uploadResult.DownloadURL)
@@ -217,7 +217,7 @@ func sendRequest(req *http.Request, client *http.Client) (*http.Response, error)
 
 	res, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send post request: %v", err)
+		return nil, fmt.Errorf("failed to send post request: %w", err)
 	}
 
 	if res.StatusCode != http.StatusOK {

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -394,7 +394,7 @@ func getOperatorCsvPods(csvList []*olmv1Alpha.ClusterServiceVersion) (map[types.
 
 		pods, err := getPodsOwnedByCsv(csv.Name, strings.TrimSpace(ns), client)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get pods from ns %v: %v", ns, err)
+			return nil, fmt.Errorf("failed to get pods from ns %v: %w", ns, err)
 		}
 
 		csvToPodsMapping[types.NamespacedName{Name: csv.Name, Namespace: csv.Namespace}] = pods
@@ -415,7 +415,7 @@ func getPodsOwnedByCsv(csvName, operatorNamespace string, client *clientsholder.
 		pod := podsList.Items[index]
 		topOwners, err := podhelper.GetPodTopOwner(pod.Namespace, pod.OwnerReferences)
 		if err != nil {
-			return nil, fmt.Errorf("could not get top owners of Pod %s (in namespace %s), err=%v", pod.Name, pod.Namespace, err)
+			return nil, fmt.Errorf("could not get top owners of Pod %s (in namespace %s), err=%w", pod.Name, pod.Namespace, err)
 		}
 
 		// check if owner matches with the csv

--- a/pkg/autodiscover/autodiscover_crds.go
+++ b/pkg/autodiscover/autodiscover_crds.go
@@ -36,7 +36,7 @@ func getClusterCrdNames() ([]*apiextv1.CustomResourceDefinition, error) {
 	oc := clientsholder.GetClientsHolder()
 	crds, err := oc.APIExtClient.ApiextensionsV1().CustomResourceDefinitions().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("unable to get cluster CRDs, err: %v", err)
+		return nil, fmt.Errorf("unable to get cluster CRDs, err: %w", err)
 	}
 
 	var crdList []*apiextv1.CustomResourceDefinition

--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -132,7 +132,7 @@ func findOperatorsByLabels(olmClient v1alpha1.OperatorsV1alpha1Interface, labels
 func getAllNamespaces(oc corev1client.CoreV1Interface) (allNs []string, err error) {
 	nsList, err := oc.Namespaces().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return allNs, fmt.Errorf("error getting all namespaces, err: %v", err)
+		return allNs, fmt.Errorf("error getting all namespaces, err: %w", err)
 	}
 	for index := range nsList.Items {
 		allNs = append(allNs, nsList.Items[index].Name)
@@ -145,7 +145,7 @@ func getAllOperators(olmClient v1alpha1.OperatorsV1alpha1Interface) ([]*olmv1Alp
 
 	csvList, err := olmClient.ClusterServiceVersions("").List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
-		return nil, fmt.Errorf("error when listing CSVs in all namespaces, err: %v", err)
+		return nil, fmt.Errorf("error when listing CSVs in all namespaces, err: %w", err)
 	}
 	for i := range csvList.Items {
 		csvs = append(csvs, &csvList.Items[i])
@@ -280,7 +280,7 @@ func getOperandPodsFromTestCsvs(testCsvs []*olmv1Alpha.ClusterServiceVersion, po
 		pod := &pods[i]
 		owners, err := podhelper.GetPodTopOwner(pod.Namespace, pod.OwnerReferences)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get top owners of pod %v/%v: %v", pod.Namespace, pod.Name, err)
+			return nil, fmt.Errorf("failed to get top owners of pod %v/%v: %w", pod.Namespace, pod.Name, err)
 		}
 
 		for _, owner := range owners {

--- a/pkg/checksdb/check.go
+++ b/pkg/checksdb/check.go
@@ -257,7 +257,7 @@ func (check *Check) Run() error {
 	}
 
 	if check.Error != nil {
-		return fmt.Errorf("unable to run due to a previously existing error: %v", check.Error)
+		return fmt.Errorf("unable to run due to a previously existing error: %w", check.Error)
 	}
 
 	cli.PrintCheckRunning(check.ID)
@@ -270,17 +270,17 @@ func (check *Check) Run() error {
 	check.LogInfo("Running check (labels: %v)", check.Labels)
 	if check.BeforeCheckFn != nil {
 		if err := check.BeforeCheckFn(check); err != nil {
-			return fmt.Errorf("check %s failed in before check function: %v", check.ID, err)
+			return fmt.Errorf("check %s failed in before check function: %w", check.ID, err)
 		}
 	}
 
 	if err := check.CheckFn(check); err != nil {
-		return fmt.Errorf("check %s failed in check function: %v", check.ID, err)
+		return fmt.Errorf("check %s failed in check function: %w", check.ID, err)
 	}
 
 	if check.AfterCheckFn != nil {
 		if err := check.AfterCheckFn(check); err != nil {
-			return fmt.Errorf("check %s failed in after check function: %v", check.ID, err)
+			return fmt.Errorf("check %s failed in after check function: %w", check.ID, err)
 		}
 	}
 

--- a/pkg/checksdb/checksdb.go
+++ b/pkg/checksdb/checksdb.go
@@ -285,7 +285,7 @@ func InitLabelsExprEvaluator(labelsFilter string) error {
 
 	eval, err := labels.NewLabelsExprEvaluator(labelsFilter)
 	if err != nil {
-		return fmt.Errorf("could not create a label evaluator, err: %v", err)
+		return fmt.Errorf("could not create a label evaluator, err: %w", err)
 	}
 
 	labelsExprEvaluator = eval

--- a/pkg/claimhelper/claimhelper.go
+++ b/pkg/claimhelper/claimhelper.go
@@ -120,7 +120,7 @@ func NewClaimBuilder(env *provider.TestEnvironment) (*ClaimBuilder, error) {
 	log.Debug("Creating claim file builder.")
 	configurations, err := MarshalConfigurations(env)
 	if err != nil {
-		return nil, fmt.Errorf("configuration node missing because of: %v", err)
+		return nil, fmt.Errorf("configuration node missing because of: %w", err)
 	}
 
 	claimConfigurations := map[string]interface{}{}

--- a/pkg/diagnostics/diagnostics.go
+++ b/pkg/diagnostics/diagnostics.go
@@ -121,7 +121,7 @@ func getHWJsonOutput(probePod *corev1.Pod, o clientsholder.Command, cmd string) 
 	}
 	err = json.Unmarshal([]byte(outStr), &out)
 	if err != nil {
-		return out, fmt.Errorf("could not decode json file because of: %s", err)
+		return out, fmt.Errorf("could not decode json file because of: %w", err)
 	}
 	return out, nil
 }

--- a/pkg/labels/labels.go
+++ b/pkg/labels/labels.go
@@ -24,7 +24,7 @@ func NewLabelsExprEvaluator(labelsExpr string) (LabelsExprEvaluator, error) {
 
 	node, err := parser.ParseExpr(goLikeExpr)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse labels expression %s: %v", labelsExpr, err)
+		return nil, fmt.Errorf("failed to parse labels expression %s: %w", labelsExpr, err)
 	}
 
 	return labelsExprParser{

--- a/pkg/podhelper/podhelper.go
+++ b/pkg/podhelper/podhelper.go
@@ -30,7 +30,7 @@ func GetPodTopOwner(podNamespace string, podOwnerReferences []metav1.OwnerRefere
 		podNamespace,
 		podOwnerReferences)
 	if err != nil {
-		return topOwners, fmt.Errorf("could not get top owners, err: %v", err)
+		return topOwners, fmt.Errorf("could not get top owners, err: %w", err)
 	}
 	return topOwners, nil
 }
@@ -40,12 +40,12 @@ func followOwnerReferences(resourceList []*metav1.APIResourceList, dynamicClient
 	for _, ownerRef := range ownerRefs {
 		apiResource, err := searchAPIResource(ownerRef.Kind, ownerRef.APIVersion, resourceList)
 		if err != nil {
-			return fmt.Errorf("error searching APIResource for owner reference %v: %v", ownerRef, err)
+			return fmt.Errorf("error searching APIResource for owner reference %v: %w", ownerRef, err)
 		}
 
 		gv, err := schema.ParseGroupVersion(ownerRef.APIVersion)
 		if err != nil {
-			return fmt.Errorf("failed to parse apiVersion %q: %v", ownerRef.APIVersion, err)
+			return fmt.Errorf("failed to parse apiVersion %q: %w", ownerRef.APIVersion, err)
 		}
 
 		gvr := schema.GroupVersionResource{
@@ -63,7 +63,7 @@ func followOwnerReferences(resourceList []*metav1.APIResourceList, dynamicClient
 		// spawned and removed after completion.
 		resource, err := dynamicClient.Resource(gvr).Namespace(namespace).Get(context.TODO(), ownerRef.Name, metav1.GetOptions{})
 		if err != nil && !k8serrors.IsNotFound(err) {
-			return fmt.Errorf("could not get object indicated by owner references %+v (gvr=%+v): %v", ownerRef, gvr, err)
+			return fmt.Errorf("could not get object indicated by owner references %+v (gvr=%+v): %w", ownerRef, gvr, err)
 		}
 
 		// Get owner references of the unstructured object

--- a/pkg/provider/filters.go
+++ b/pkg/provider/filters.go
@@ -143,7 +143,7 @@ func (env *TestEnvironment) GetPodsUsingSRIOV() ([]*Pod, error) {
 	for _, p := range env.Pods {
 		usesSRIOV, err := p.IsUsingSRIOV()
 		if err != nil {
-			return nil, fmt.Errorf("failed to check sriov usage for pod %s: %v", p, err)
+			return nil, fmt.Errorf("failed to check sriov usage for pod %s: %w", p, err)
 		}
 
 		if usesSRIOV {

--- a/pkg/provider/nodes.go
+++ b/pkg/provider/nodes.go
@@ -145,7 +145,7 @@ func (node *Node) IsHyperThreadNode(env *TestEnvironment) (bool, error) {
 	ctx := clientsholder.NewContext(env.ProbePods[nodeName].Namespace, env.ProbePods[nodeName].Name, env.ProbePods[nodeName].Spec.Containers[0].Name)
 	cmdValue, errStr, err := o.ExecCommandContainer(ctx, isHyperThreadCommand)
 	if err != nil || errStr != "" {
-		return false, fmt.Errorf("cannot execute %s on probe pod %s, err=%s, stderr=%s", isHyperThreadCommand, env.ProbePods[nodeName], err, errStr)
+		return false, fmt.Errorf("cannot execute %s on probe pod %s, err=%v, stderr=%s", isHyperThreadCommand, env.ProbePods[nodeName], err, errStr)
 	}
 	re := regexp.MustCompile(`Thread\(s\) per core:\s+(\d+)`)
 	match := re.FindStringSubmatch(cmdValue)

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -316,7 +316,7 @@ func isNetworkAttachmentDefinitionSRIOVConfigMTUSet(nadConfig string) (bool, err
 
 	cniConfig := CNIConfig{}
 	if err := json.Unmarshal([]byte(nadConfig), &cniConfig); err != nil {
-		return false, fmt.Errorf("failed to unmarshal cni config %s: %v", nadConfig, err)
+		return false, fmt.Errorf("failed to unmarshal cni config %s: %w", nadConfig, err)
 	}
 
 	if cniConfig.Plugins == nil {
@@ -379,7 +379,7 @@ func isNetworkAttachmentDefinitionConfigTypeSRIOV(nadConfig string) (bool, error
 
 	cniConfig := CNIConfig{}
 	if err := json.Unmarshal([]byte(nadConfig), &cniConfig); err != nil {
-		return false, fmt.Errorf("failed to unmarshal cni config %s: %v", nadConfig, err)
+		return false, fmt.Errorf("failed to unmarshal cni config %s: %w", nadConfig, err)
 	}
 
 	// If type is found, it's a single plugin CNI config.
@@ -428,12 +428,12 @@ func (p *Pod) IsUsingSRIOV() (bool, error) {
 		log.Debug("%s: Reviewing network-attachment definition %q", p, networkName)
 		nad, err := oc.CNCFNetworkingClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(p.Namespace).Get(context.TODO(), networkName, metav1.GetOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to get NetworkAttachment %s: %v", networkName, err)
+			return false, fmt.Errorf("failed to get NetworkAttachment %s: %w", networkName, err)
 		}
 
 		isSRIOV, err := isNetworkAttachmentDefinitionConfigTypeSRIOV(nad.Spec.Config)
 		if err != nil {
-			return false, fmt.Errorf("failed to know if network-attachment %s is sriov: %v", networkName, err)
+			return false, fmt.Errorf("failed to know if network-attachment %s is sriov: %w", networkName, err)
 		}
 
 		log.Debug("%s: NAD config: %s", p, nad.Spec.Config)
@@ -468,7 +468,7 @@ func (p *Pod) IsUsingSRIOVWithMTU() (bool, error) {
 		nad, err := oc.CNCFNetworkingClient.K8sCniCncfIoV1().NetworkAttachmentDefinitions(
 			p.Namespace).Get(context.TODO(), networkName, metav1.GetOptions{})
 		if err != nil {
-			return false, fmt.Errorf("failed to get NetworkAttachment %s: %v", networkName, err)
+			return false, fmt.Errorf("failed to get NetworkAttachment %s: %w", networkName, err)
 		}
 
 		// If the network-status annotation is not set, let's check the SriovNetwork/SriovNetworkNodePolicy CRs

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -231,11 +231,11 @@ func deployDaemonSet(namespace string) error {
 		corev1.PullIfNotPresent,
 	)
 	if err != nil {
-		return fmt.Errorf("could not deploy certsuite daemonset, err=%v", err)
+		return fmt.Errorf("could not deploy certsuite daemonset, err=%w", err)
 	}
 	err = k8sPrivilegedDs.WaitDaemonsetReady(namespace, DaemonSetName, probePodsTimeout)
 	if err != nil {
-		return fmt.Errorf("timed out waiting for certsuite daemonset, err=%v", err)
+		return fmt.Errorf("timed out waiting for certsuite daemonset, err=%w", err)
 	}
 
 	return nil
@@ -248,13 +248,13 @@ func CleanupProbeDaemonset(namespace string) error {
 	log.Info("Cleaning up probe daemonset %q in namespace %q", DaemonSetName, namespace)
 	err := k8sPrivilegedDs.DeleteDaemonSet(DaemonSetName, namespace)
 	if err != nil {
-		return fmt.Errorf("failed to delete probe daemonset %q in namespace %q: %v", DaemonSetName, namespace, err)
+		return fmt.Errorf("failed to delete probe daemonset %q in namespace %q: %w", DaemonSetName, namespace, err)
 	}
 
 	log.Info("Cleaning up namespace %q", namespace)
 	err = k8sPrivilegedDs.DeleteNamespaceIfPresent(namespace)
 	if err != nil {
-		return fmt.Errorf("failed to delete namespace %q: %v", namespace, err)
+		return fmt.Errorf("failed to delete namespace %q: %w", namespace, err)
 	}
 
 	log.Info("Probe daemonset cleanup completed")
@@ -599,7 +599,7 @@ func GetPodIPsPerNet(annotation string) (ips map[string]CniNetworkInterface, err
 	var cniInfo []CniNetworkInterface
 	err = json.Unmarshal([]byte(annotation), &cniInfo)
 	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal network-status annotation, err: %v", err)
+		return nil, fmt.Errorf("could not unmarshal network-status annotation, err: %w", err)
 	}
 	// If this is the default interface, skip it as it is tested separately
 	// Otherwise add all non default interfaces
@@ -620,7 +620,7 @@ func GetPciPerPod(annotation string) (pciAddr []string, err error) {
 	var cniInfo []CniNetworkInterface
 	err = json.Unmarshal([]byte(annotation), &cniInfo)
 	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal network-status annotation, err: %v", err)
+		return nil, fmt.Errorf("could not unmarshal network-status annotation, err: %w", err)
 	}
 	for _, cniInterface := range cniInfo {
 		if cniInterface.DeviceInfo.PCI.PciAddress != "" {
@@ -719,7 +719,7 @@ func getMachineConfig(mcName string, machineConfigs map[string]MachineConfig) (M
 
 	err = json.Unmarshal(nodeMc.Spec.Config.Raw, &mc.Config)
 	if err != nil {
-		return MachineConfig{}, fmt.Errorf("failed to unmarshal mc's Config field, err: %v", err)
+		return MachineConfig{}, fmt.Errorf("failed to unmarshal mc's Config field, err: %w", err)
 	}
 
 	return mc, nil

--- a/pkg/scheduling/scheduling.go
+++ b/pkg/scheduling/scheduling.go
@@ -132,7 +132,7 @@ func GetProcessCPUScheduling(pid int, testContainer *provider.Container) (schedu
 	env := provider.GetTestEnvironment()
 	ctx, err := crclient.GetNodeProbePodContext(testContainer.NodeName, &env)
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to get probe pod's context for container %s: %v", testContainer, err)
+		return "", 0, fmt.Errorf("failed to get probe pod's context for container %s: %w", testContainer, err)
 	}
 
 	ch := clientsholder.GetClientsHolder()
@@ -145,7 +145,7 @@ func GetProcessCPUScheduling(pid int, testContainer *provider.Container) (schedu
 
 	schedulePolicy, schedulePriority, err = parseSchedulingPolicyAndPriority(stdout)
 	if err != nil {
-		return schedulePolicy, InvalidPriority, fmt.Errorf("error getting the scheduling policy and priority for %v : %v", testContainer, err)
+		return schedulePolicy, InvalidPriority, fmt.Errorf("error getting the scheduling policy and priority for %v : %w", testContainer, err)
 	}
 	log.Info("pid %d in %v has the cpu scheduling policy %s, scheduling priority %d", pid, testContainer, schedulePolicy, schedulePriority)
 

--- a/pkg/testhelper/testhelper.go
+++ b/pkg/testhelper/testhelper.go
@@ -712,7 +712,7 @@ func ResultObjectsToString(compliantObject, nonCompliantObject []*ReportObject) 
 
 	bytes, err := json.Marshal(reason)
 	if err != nil {
-		return "", fmt.Errorf("could not marshall FailureReasonOut object: %v", err)
+		return "", fmt.Errorf("could not marshall FailureReasonOut object: %w", err)
 	}
 
 	return string(bytes), nil

--- a/tests/accesscontrol/namespace/namespace.go
+++ b/tests/accesscontrol/namespace/namespace.go
@@ -38,7 +38,7 @@ func TestCrsNamespaces(crds []*apiextv1.CustomResourceDefinition, configNamespac
 	for _, crd := range crds {
 		crNamespaces, err := getCrsPerNamespaces(crd)
 		if err != nil {
-			return invalidCrs, fmt.Errorf("failed to get CRs for CRD %s - Error: %v", crd.Name, err)
+			return invalidCrs, fmt.Errorf("failed to get CRs for CRD %s - Error: %w", crd.Name, err)
 		}
 		for namespace, crNames := range crNamespaces {
 			if !stringhelper.StringInSlice(configNamespaces, namespace, false) {

--- a/tests/accesscontrol/pidshelper.go
+++ b/tests/accesscontrol/pidshelper.go
@@ -35,7 +35,7 @@ func getNbOfProcessesInPidNamespace(ctx clientsholder.Context, targetPid int, ch
 
 	outStr, errStr, err := ch.ExecCommandContainer(ctx, cmd)
 	if err != nil {
-		return 0, fmt.Errorf("can not execute command: \" %s \", err:%s", cmd, err)
+		return 0, fmt.Errorf("can not execute command: \" %s \", err:%w", cmd, err)
 	}
 	if errStr != "" {
 		return 0, fmt.Errorf("cmd: \" %s \" returned %s", cmd, errStr)

--- a/tests/accesscontrol/pidshelper_test.go
+++ b/tests/accesscontrol/pidshelper_test.go
@@ -91,7 +91,11 @@ func TestGetNbOfProcessesInPidNamespace(t *testing.T) {
 
 		// assertions
 		assert.Equal(t, tc.expectedResult, result)
-		assert.Equal(t, tc.expectedErr, err)
+		if tc.expectedErr != nil {
+			assert.EqualError(t, err, tc.expectedErr.Error())
+		} else {
+			assert.NoError(t, err)
+		}
 		assert.Equal(t, tc.expectedExecFuncCalls, ch.CallCount())
 	}
 }

--- a/tests/certification/suite.go
+++ b/tests/certification/suite.go
@@ -50,7 +50,7 @@ var (
 		var err error
 		validator, err = certdb.GetValidator(env.GetOfflineDBPath())
 		if err != nil {
-			return fmt.Errorf("cannot access the certification DB, err: %v", err)
+			return fmt.Errorf("cannot access the certification DB, err: %w", err)
 		}
 
 		return nil

--- a/tests/lifecycle/podrecreation/podrecreation.go
+++ b/tests/lifecycle/podrecreation/podrecreation.go
@@ -120,7 +120,7 @@ func deletePod(pod *corev1.Pod, mode string, wg *sync.WaitGroup) error {
 		FieldSelector: "metadata.name=" + pod.Name + ",metadata.namespace=" + pod.Namespace,
 	})
 	if err != nil {
-		return fmt.Errorf("waitPodDeleted ns=%s pod=%s, err=%s", pod.Namespace, pod.Name, err)
+		return fmt.Errorf("waitPodDeleted ns=%s pod=%s, err=%w", pod.Namespace, pod.Name, err)
 	}
 	// Actually deleting pod
 	err = clients.K8sClient.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{

--- a/tests/networking/icmp/icmp.go
+++ b/tests/networking/icmp/icmp.go
@@ -237,7 +237,7 @@ var TestPing = func(sourceContainerID *provider.Container, targetContainerIP net
 	stdout, stderr, err := crclient.ExecCommandContainerNSEnter(command, sourceContainerID)
 	if err != nil || stderr != "" {
 		results.outcome = testhelper.ERROR
-		return results, fmt.Errorf("ping failed with stderr:%s err:%s", stderr, err)
+		return results, fmt.Errorf("ping failed with stderr:%s err:%v", stderr, err)
 	}
 	results, err = parsePingResult(stdout, stderr)
 	if err != nil {

--- a/tests/networking/netutil/netutil.go
+++ b/tests/networking/netutil/netutil.go
@@ -58,7 +58,7 @@ func parseListeningPorts(cmdOut string) (map[PortInfo]bool, error) {
 
 		port, err := strconv.ParseInt(s[len(s)-1], 10, 32)
 		if err != nil {
-			return nil, fmt.Errorf("string to int conversion error, err: %v", err)
+			return nil, fmt.Errorf("string to int conversion error, err: %w", err)
 		}
 		protocol := strings.ToUpper(fields[indexProtocol])
 		portInfo := PortInfo{int32(port), protocol}

--- a/tests/networking/services/services.go
+++ b/tests/networking/services/services.go
@@ -53,7 +53,7 @@ func GetServiceIPVersion(aService *corev1.Service) (result netcommons.IPVersion,
 
 	res, err := isClusterIPsDualStack(aService.Spec.ClusterIPs)
 	if err != nil {
-		err = fmt.Errorf("%s, err:%s", ToString(aService), err)
+		err = fmt.Errorf("%s, err:%w", ToString(aService), err)
 		return result, err
 	}
 	if res {
@@ -87,7 +87,7 @@ func isClusterIPsDualStack(ips []string) (result bool, err error) {
 	for _, ip := range ips {
 		ipver, err := netcommons.GetIPVersion(ip)
 		if err != nil {
-			return result, fmt.Errorf("cannot get aService ClusterIPs (%s)  version - err: %v", ip, err)
+			return result, fmt.Errorf("cannot get aService ClusterIPs (%s)  version - err: %w", ip, err)
 		}
 		switch ipver {
 		case netcommons.IPv4:

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -139,7 +139,7 @@ func LoadChecks() {
 		WithCheckFn(func(c *checksdb.Check) error {
 			sriovPods, err := env.GetPodsUsingSRIOV()
 			if err != nil {
-				return fmt.Errorf("failure getting pods using SRIOV: %v", err)
+				return fmt.Errorf("failure getting pods using SRIOV: %w", err)
 			}
 			testRestartOnRebootLabelOnPodsUsingSriov(c, sriovPods)
 			return nil
@@ -152,7 +152,7 @@ func LoadChecks() {
 		WithCheckFn(func(c *checksdb.Check) error {
 			sriovPods, err := env.GetPodsUsingSRIOV()
 			if err != nil {
-				return fmt.Errorf("failure getting pods using SRIOV: %v", err)
+				return fmt.Errorf("failure getting pods using SRIOV: %w", err)
 			}
 			testNetworkAttachmentDefinitionSRIOVUsingMTU(c, sriovPods)
 			return nil

--- a/tests/observability/pdb/pdb.go
+++ b/tests/observability/pdb/pdb.go
@@ -95,7 +95,7 @@ func intOrStringToValue(intOrStr *intstr.IntOrString, replicas int32) (int, erro
 		// Convert percentage to absolute value: "60%" with 5 replicas → 0.60 * 5 = 3
 		v, err := percentageToFloat(intOrStr.StrVal)
 		if err != nil {
-			return 0, fmt.Errorf("invalid value %q: %v", intOrStr.StrVal, err)
+			return 0, fmt.Errorf("invalid value %q: %w", intOrStr.StrVal, err)
 		}
 		return int(math.RoundToEven(v * float64(replicas))), nil
 	}
@@ -173,7 +173,7 @@ func CheckPDBIsZoneAware(pdb *policyv1.PodDisruptionBudget, replicas *int32, num
 		var err error
 		minAvailableValue, err = intOrStringToValue(pdb.Spec.MinAvailable, replicaCount)
 		if err != nil {
-			result.ZoneCheckError = fmt.Errorf("failed to parse minAvailable: %v", err)
+			result.ZoneCheckError = fmt.Errorf("failed to parse minAvailable: %w", err)
 			return result
 		}
 		result.MinAvailableValue = minAvailableValue
@@ -183,7 +183,7 @@ func CheckPDBIsZoneAware(pdb *policyv1.PodDisruptionBudget, replicas *int32, num
 		var err error
 		maxUnavailableValue, err = intOrStringToValue(pdb.Spec.MaxUnavailable, replicaCount)
 		if err != nil {
-			result.ZoneCheckError = fmt.Errorf("failed to parse maxUnavailable: %v", err)
+			result.ZoneCheckError = fmt.Errorf("failed to parse maxUnavailable: %w", err)
 			return result
 		}
 		result.MaxUnavailableValue = maxUnavailableValue

--- a/tests/observability/pdb/pdb_test.go
+++ b/tests/observability/pdb/pdb_test.go
@@ -208,7 +208,11 @@ func TestIntOrStringToValue(t *testing.T) {
 	for index, tc := range testCases {
 		result, err := intOrStringToValue(&testCases[index].intOrString, tc.testReplicas)
 		assert.Equal(t, tc.expectedInt, result)
-		assert.Equal(t, tc.expectedErr, err)
+		if tc.expectedErr != nil {
+			assert.EqualError(t, err, tc.expectedErr.Error())
+		} else {
+			assert.NoError(t, err)
+		}
 	}
 }
 

--- a/tests/observability/suite.go
+++ b/tests/observability/suite.go
@@ -104,7 +104,7 @@ func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 
 	podLogsReaderCloser, err := req.Stream(context.TODO())
 	if err != nil {
-		return false, fmt.Errorf("unable to get log streamer, err: %v", err)
+		return false, fmt.Errorf("unable to get log streamer, err: %w", err)
 	}
 
 	defer podLogsReaderCloser.Close()
@@ -112,7 +112,7 @@ func containerHasLoggingOutput(cut *provider.Container) (bool, error) {
 	buf := new(bytes.Buffer)
 	_, err = io.Copy(buf, podLogsReaderCloser)
 	if err != nil {
-		return false, fmt.Errorf("unable to get log data, err: %v", err)
+		return false, fmt.Errorf("unable to get log data, err: %w", err)
 	}
 
 	return buf.String() != "", nil

--- a/tests/platform/bootparams/bootparams.go
+++ b/tests/platform/bootparams/bootparams.go
@@ -39,11 +39,11 @@ func TestBootParamsHelper(env *provider.TestEnvironment, cut *provider.Container
 	mcKernelArgumentsMap := GetMcKernelArguments(env, cut.NodeName)
 	currentKernelArgsMap, err := getCurrentKernelCmdlineArgs(env, cut.NodeName)
 	if err != nil {
-		return fmt.Errorf("error getting kernel cli arguments from container: %s, err=%s", cut, err)
+		return fmt.Errorf("error getting kernel cli arguments from container: %s, err=%w", cut, err)
 	}
 	grubKernelConfigMap, err := getGrubKernelArgs(env, cut.NodeName)
 	if err != nil {
-		return fmt.Errorf("error getting grub  kernel arguments for node: %s, err=%s", cut.NodeName, err)
+		return fmt.Errorf("error getting grub  kernel arguments for node: %s, err=%w", cut.NodeName, err)
 	}
 	for key, mcVal := range mcKernelArgumentsMap {
 		if currentVal, ok := currentKernelArgsMap[key]; ok {
@@ -76,7 +76,7 @@ func getGrubKernelArgs(env *provider.TestEnvironment, nodeName string) (aMap map
 	ctx := clientsholder.NewContext(env.ProbePods[nodeName].Namespace, env.ProbePods[nodeName].Name, env.ProbePods[nodeName].Spec.Containers[0].Name)
 	bootConfig, errStr, err := o.ExecCommandContainer(ctx, grubKernelArgsCommand)
 	if err != nil || errStr != "" {
-		return aMap, fmt.Errorf("cannot execute %s on probe pod %s, err=%s, stderr=%s", grubKernelArgsCommand, env.ProbePods[nodeName], err, errStr)
+		return aMap, fmt.Errorf("cannot execute %s on probe pod %s, err=%v, stderr=%s", grubKernelArgsCommand, env.ProbePods[nodeName], err, errStr)
 	}
 
 	splitBootConfig := strings.Split(bootConfig, "\n")
@@ -97,7 +97,7 @@ func getCurrentKernelCmdlineArgs(env *provider.TestEnvironment, nodeName string)
 	ctx := clientsholder.NewContext(env.ProbePods[nodeName].Namespace, env.ProbePods[nodeName].Name, env.ProbePods[nodeName].Spec.Containers[0].Name)
 	currentKernelCmdlineArgs, errStr, err := o.ExecCommandContainer(ctx, kernelArgscommand)
 	if err != nil || errStr != "" {
-		return aMap, fmt.Errorf("cannot execute %s on probe pod container %s, err=%s, stderr=%s", grubKernelArgsCommand, env.ProbePods[nodeName].Name, err, errStr)
+		return aMap, fmt.Errorf("cannot execute %s on probe pod container %s, err=%v, stderr=%s", grubKernelArgsCommand, env.ProbePods[nodeName].Name, err, errStr)
 	}
 	currentSplitKernelCmdlineArgs := strings.Split(strings.TrimSuffix(currentKernelCmdlineArgs, "\n"), " ")
 	return arrayhelper.ArgListToMap(currentSplitKernelCmdlineArgs), nil

--- a/tests/platform/cnffsdiff/fsdiff.go
+++ b/tests/platform/cnffsdiff/fsdiff.go
@@ -18,7 +18,6 @@ package cnffsdiff
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -221,7 +220,7 @@ func (f *FsDiff) GetResults() int {
 func (f *FsDiff) execCommandContainer(cmd, errorStr string) error {
 	output, outerr, err := f.clientHolder.ExecCommandContainer(f.ctxt, cmd)
 	if err != nil || output != "" || outerr != "" {
-		return errors.New(errorStr + fmt.Sprintf(" Stderr: %s, Stdout: %s, Err: %v", output, outerr, err))
+		return fmt.Errorf("%s Stderr: %s, Stdout: %s, Err: %v", errorStr, output, outerr, err)
 	}
 
 	return nil
@@ -251,7 +250,7 @@ func (f *FsDiff) installCustomPodman() error {
 	// We need to create the destination folder first.
 	f.check.LogInfo("Creating temp folder %s", nodeTmpMountFolder)
 	if err := f.createNodeFolder(); err != nil {
-		return err
+		return fmt.Errorf("failed to create temp folder %s: %w", nodeTmpMountFolder, err)
 	}
 
 	// Mount podman from partner probe pod into /host/tmp/...
@@ -259,7 +258,7 @@ func (f *FsDiff) installCustomPodman() error {
 	if mountErr := f.mountProbePodmanFolder(); mountErr != nil {
 		// We need to delete the temp folder previously created as mount point.
 		if deleteErr := f.deleteNodeFolder(); deleteErr != nil {
-			return fmt.Errorf("failed to mount folder %s: %s, failed to delete %s: %s",
+			return fmt.Errorf("failed to mount folder %s: %w, failed to delete %s: %w",
 				partnerPodmanFolder, mountErr, nodeTmpMountFolder, deleteErr)
 		}
 

--- a/tests/platform/cnffsdiff/fsdiff_test.go
+++ b/tests/platform/cnffsdiff/fsdiff_test.go
@@ -153,7 +153,7 @@ func TestRunTestMountFolderErrors(t *testing.T) {
 			mockedClientshHolder: &ClientHoldersMountCustomPodmanMock{
 				createFolderErr: fmt.Errorf("custom error"),
 			},
-			expectedError: "failed or unexpected output when creating folder /host/tmp/tnf-podman. Stderr: , Stdout: , Err: custom error",
+			expectedError: "failed to create temp folder /host/tmp/tnf-podman: failed or unexpected output when creating folder /host/tmp/tnf-podman. Stderr: , Stdout: , Err: custom error",
 		},
 		{
 			mockedClientshHolder: &ClientHoldersMountCustomPodmanMock{
@@ -161,7 +161,7 @@ func TestRunTestMountFolderErrors(t *testing.T) {
 				createFolderStderr: "custom stderr",
 				createFolderErr:    nil,
 			},
-			expectedError: "failed or unexpected output when creating folder /host/tmp/tnf-podman. Stderr: custom stdout, Stdout: custom stderr, Err: <nil>",
+			expectedError: "failed to create temp folder /host/tmp/tnf-podman: failed or unexpected output when creating folder /host/tmp/tnf-podman. Stderr: custom stdout, Stdout: custom stderr, Err: <nil>",
 		},
 
 		// Errors mounting the podman folder.

--- a/tests/platform/hugepages/hugepages.go
+++ b/tests/platform/hugepages/hugepages.go
@@ -125,13 +125,13 @@ func NewTester(node *provider.Node, probePod *corev1.Pod, commander clientsholde
 	var err error
 	tester.nodeHugepagesByNuma, err = tester.getNodeNumaHugePages()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get node hugepages, err: %v", err)
+		return nil, fmt.Errorf("unable to get node hugepages, err: %w", err)
 	}
 
 	log.Info("Parsing machineconfig's kernelArguments and systemd's hugepages units.")
 	tester.mcSystemdHugepagesByNuma, err = getMcSystemdUnitsHugepagesConfig(&tester.node.Mc)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get MC systemd hugepages config, err: %v", err)
+		return nil, fmt.Errorf("failed to get MC systemd hugepages config, err: %w", err)
 	}
 
 	return tester, nil
@@ -145,12 +145,12 @@ func (tester *Tester) Run() error {
 	if tester.HasMcSystemdHugepagesUnits() {
 		log.Info("Comparing MachineConfig Systemd hugepages info against node values.")
 		if pass, err := tester.TestNodeHugepagesWithMcSystemd(); !pass {
-			return fmt.Errorf("failed to compare machineConfig systemd's unit hugepages config with node values, err: %v", err)
+			return fmt.Errorf("failed to compare machineConfig systemd's unit hugepages config with node values, err: %w", err)
 		}
 	} else {
 		log.Info("Comparing MC KernelArguments hugepages info against node values.")
 		if pass, err := tester.TestNodeHugepagesWithKernelArgs(); !pass {
-			return fmt.Errorf("failed to compare machineConfig KernelArguments with node ones, err: %v", err)
+			return fmt.Errorf("failed to compare machineConfig KernelArguments with node ones, err: %w", err)
 		}
 	}
 	return nil

--- a/tests/platform/hugepages/hugepages_test.go
+++ b/tests/platform/hugepages/hugepages_test.go
@@ -2,7 +2,6 @@
 package hugepages
 
 import (
-	"errors"
 	"testing"
 
 	mcv1 "github.com/openshift/api/machineconfiguration/v1"
@@ -481,7 +480,7 @@ func TestNegativeMachineConfigSystemdHugepages(t *testing.T) {
 			&client,
 		)
 
-		assert.Equal(t, errors.New(tc.expectedErrorMsg), hpTester.Run())
+		assert.EqualError(t, hpTester.Run(), tc.expectedErrorMsg)
 	}
 }
 
@@ -726,6 +725,6 @@ func TestNegativeMachineConfigKernelArgsHugepages(t *testing.T) {
 			&client,
 		)
 
-		assert.Equal(t, errors.New(tc.expectedErrorMsg), hpTester.Run())
+		assert.EqualError(t, hpTester.Run(), tc.expectedErrorMsg)
 	}
 }

--- a/tests/platform/sysctlconfig/sysctlconfig.go
+++ b/tests/platform/sysctlconfig/sysctlconfig.go
@@ -56,7 +56,7 @@ func GetSysctlSettings(env *provider.TestEnvironment, nodeName string) (map[stri
 
 	outStr, errStr, err := o.ExecCommandContainer(ctx, sysctlCommand)
 	if err != nil || errStr != "" {
-		return nil, fmt.Errorf("failed to execute command %s in probe pod %s, err=%s, stderr=%s", sysctlCommand,
+		return nil, fmt.Errorf("failed to execute command %s in probe pod %s, err=%v, stderr=%s", sysctlCommand,
 			env.ProbePods[nodeName], err, errStr)
 	}
 


### PR DESCRIPTION
## Summary

- Replace `%v` and `%s` with `%w` in 199 `fmt.Errorf` call sites across 50 files where the argument is an `error` value
- Preserves error chains so callers can use [`errors.Is()`](https://pkg.go.dev/errors#Is) and [`errors.As()`](https://pkg.go.dev/errors#As) to inspect wrapped errors ([Go blog: Working with Errors in Go 1.13](https://go.dev/blog/go1.13-errors))
- Update 3 test files that compared errors by type (`assert.Equal(t, errors.New(...))`) to use `assert.EqualError` instead

## How is this different than prior attempts?

This repo has had two prior error-handling PRs that addressed a **different** problem:

| PR | What it fixed | Scope |
|----|--------------|-------|
| [#3627](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3627) | Bare `return err` — added context where there was none | 13 files, ~13 wraps |
| [#3633](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3633) | Bare `return err` — same, larger sweep | 28 files, ~50 wraps |
| **This PR** | Existing `fmt.Errorf` calls that already had context but used `%v`/`%s` instead of `%w` | 51 files, 199 verb changes |

The prior PRs added wrapping where **none existed** (bare `return err`). This PR fixes wrapping that **was already there** but used the wrong format verb, silently converting errors to strings and breaking `errors.Is()`/`errors.As()` chains.

## Details

Using `%v` or `%s` in [`fmt.Errorf`](https://pkg.go.dev/fmt#Errorf) converts the error to a plain string, silently breaking the error chain. This prevents `errors.Is()` and `errors.As()` from matching wrapped errors, making error handling unreliable.

Lines where the format verb corresponds to a non-error argument (strings, slices, status codes) or where `err` may be nil due to compound conditions (`err != nil || stderr != ""`) are intentionally left as `%v`.

## Related to

- [openshift/tls-scanner#70](https://github.com/openshift/tls-scanner/pull/70) — `%w` error wrapping in tls-scanner (merged)
- [openshift-kni/commatrix#482](https://github.com/openshift-kni/commatrix/pull/482) — `%w` error wrapping in commatrix (merged)
- [crc-org/crc#5180](https://github.com/crc-org/crc/pull/5180) — `%w` error wrapping in crc (merged)
- [openshift-kni/lifecycle-agent#6319](https://github.com/openshift-kni/lifecycle-agent/pull/6319) — bare error wrapping in lifecycle-agent (open)
- [redhat-best-practices-for-k8s/certsuite#3633](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3633) — bare error wrapping in certsuite (merged)
- [redhat-best-practices-for-k8s/certsuite#3627](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3627) — bare error wrapping in certsuite (merged)

## Test plan

- [x] `make build` passes
- [x] `make test` passes (all packages)
- [x] `golangci-lint run ./...` reports 0 issues
- [x] Verified all 55 remaining `%v`/`%s` calls are legitimate non-error uses