### PR TITLE
ci: remove depends-on-action from all workflows

### DIFF
--- a/.github/workflows/pre-main.yaml
+++ b/.github/workflows/pre-main.yaml
@@ -69,11 +69,6 @@ jobs:
       - name: Install yaml dependency
         uses: ./.github/actions/install-yaml-dep
 
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Install checkmake
         run: |
           curl --location --output $CM_BIN --silent $CM_URL_LINUX
@@ -151,11 +146,6 @@ jobs:
       - name: Install yaml dependency
         uses: ./.github/actions/install-yaml-dep
 
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Run Tests
         run: make test
         env:
@@ -229,11 +219,6 @@ jobs:
 
       - name: Install yaml dependency
         uses: ./.github/actions/install-yaml-dep
-
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Update the CNF containers, helm charts and operators DB.
       - name: Update the CNF DB
@@ -321,7 +306,6 @@ jobs:
         with:
           ref: ${{ github.sha }}
 
-      # needed by depends-on-action
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
@@ -331,11 +315,6 @@ jobs:
         uses: ./.github/actions/setup-partner-cluster
         with:
           make-command: 'install'
-
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build the `certsuite` image
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
@@ -535,16 +514,3 @@ jobs:
           slack_webhook: '${{ secrets.SLACK_ALERT_WEBHOOK_URL }}'
 
 
-  check-all-dependencies-are-merged:
-    name: Check all the PR dependencies are merged
-    runs-on: ubuntu-slim
-    steps:
-
-      - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Check all dependent Pull Requests are merged
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          check-unmerged-pr: true

--- a/.github/workflows/qe-hosted-arm.yml
+++ b/.github/workflows/qe-hosted-arm.yml
@@ -115,11 +115,6 @@ jobs:
           path: certsuite-qe
           ref: main
 
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Run the tests (against image)
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:

--- a/.github/workflows/qe-hosted.yml
+++ b/.github/workflows/qe-hosted.yml
@@ -215,11 +215,6 @@ jobs:
           path: certsuite-qe
           ref: main
 
-      - name: Extract dependent Pull Requests
-        uses: depends-on/depends-on-action@826c144163ac67bf08347590a5f81afd45da63ca # main
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Run the tests (against image)
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:


### PR DESCRIPTION
## Summary

- Remove all 8 usages of `depends-on/depends-on-action` across 3 workflow files
- Remove the `check-all-dependencies-are-merged` job that existed solely for this action

## Why

The `depends-on/depends-on-action` is pinned to a commit that uses Node.js 20. GitHub [deprecated Node.js 20 actions](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) and began forcing Node.js 24 on **June 16, 2026** (today). This causes the action to fail with HTTP 500 errors from the GitHub API, breaking smoke tests and QE tests on every PR.

The action has an [open issue (#69)](https://github.com/depends-on/depends-on-action/issues/69) to upgrade to Node.js 22+, but no fix has been released.

Jira: [CNFCERT-1424](https://redhat.atlassian.net/browse/CNFCERT-1424)

## Related PRs

- [certsuite-operator#317](https://github.com/redhat-best-practices-for-k8s/certsuite-operator/pull/317)
- [certsuite-operator-plugin#12](https://github.com/redhat-best-practices-for-k8s/certsuite-operator-plugin/pull/12)
- [certsuite-qe#1498](https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1498)
- [collector#705](https://github.com/redhat-best-practices-for-k8s/collector/pull/705)

## Files changed

- `.github/workflows/pre-main.yaml` — removed 5 action steps + 1 entire job
- `.github/workflows/qe-hosted.yml` — removed 1 action step
- `.github/workflows/qe-hosted-arm.yml` — removed 1 action step

## Test plan

- [x] `yamllint` passes on all 3 files (warnings only, same as before)
- [ ] CI runs without the depends-on-action step failures