### PR TITLE
perf: compile label regex once at package init instead of in loop

### DIFF
--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -130,14 +130,13 @@ type labelObject struct {
 
 var data = DiscoveredTestData{}
 
-const labelRegex = `(\S*)\s*:\s*(\S*)`
 const labelRegexMatches = 3
+
+var labelRegexCompiled = regexp.MustCompile(`(\S*)\s*:\s*(\S*)`)
 
 func CreateLabels(labelStrings []string) (labelObjects []labelObject) {
 	for _, label := range labelStrings {
-		r := regexp.MustCompile(labelRegex)
-
-		values := r.FindStringSubmatch(label)
+		values := labelRegexCompiled.FindStringSubmatch(label)
 		if len(values) != labelRegexMatches {
 			log.Error("Failed to parse label %q. It will not be used!, ", label)
 			continue


### PR DESCRIPTION
## Summary

Optimizes regex compilation in the autodiscover package by moving `regexp.MustCompile()` from inside the `CreateLabels` loop to package-level initialization.

## Changes

- Converted `labelRegex` constant to compiled `labelRegexCompiled` variable
- Moved regex compilation from inside loop (N times) to package init (once)
- Eliminated redundant `regexp.MustCompile()` calls during label parsing

## Performance Impact

**Before:** Regex compiled N times (once per label string)  
**After:** Regex compiled once at package initialization

While the impact is low (only affects label parsing during autodiscovery), this follows Go best practices for regex compilation and eliminates wasteful recompilation.

## Testing

- ✅ All 39 autodiscover package tests pass
- ✅ golangci-lint reports 0 issues
- ✅ Package builds successfully