### PR TITLE
fix: add nil check for probe pod in hyperthreading detection

### DIFF
--- a/pkg/provider/nodes.go
+++ b/pkg/provider/nodes.go
@@ -142,10 +142,17 @@ const (
 func (node *Node) IsHyperThreadNode(env *TestEnvironment) (bool, error) {
 	o := clientsholder.GetClientsHolder()
 	nodeName := node.Data.Name
-	ctx := clientsholder.NewContext(env.ProbePods[nodeName].Namespace, env.ProbePods[nodeName].Name, env.ProbePods[nodeName].Spec.Containers[0].Name)
+
+	// Check if probe pod exists for this node
+	probePod, exists := env.ProbePods[nodeName]
+	if !exists || probePod == nil {
+		return false, fmt.Errorf("no probe pod found for node %s", nodeName)
+	}
+
+	ctx := clientsholder.NewContext(probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name)
 	cmdValue, errStr, err := o.ExecCommandContainer(ctx, isHyperThreadCommand)
 	if err != nil || errStr != "" {
-		return false, fmt.Errorf("cannot execute %s on probe pod %s, err=%v, stderr=%s", isHyperThreadCommand, env.ProbePods[nodeName], err, errStr)
+		return false, fmt.Errorf("cannot execute %s on probe pod %s, err=%v, stderr=%s", isHyperThreadCommand, probePod.Name, err, errStr)
 	}
 	re := regexp.MustCompile(`Thread\(s\) per core:\s+(\d+)`)
 	match := re.FindStringSubmatch(cmdValue)


### PR DESCRIPTION
## Summary

Fixes the nil pointer panic in the `platform-alteration-hyperthread-enable` test when probe pods are missing for nodes.

## Problem

The test was panicking with:
```
[ERROR] [parallel.go: 64] [platform-alteration-hyperthread-enable] Panic during parallel check execution: runtime error: invalid memory address or nil pointer dereference
```

This occurred because `env.ProbePods[nodeName]` was accessed without checking if the entry exists. On clusters where probe pods aren't deployed to all nodes, this causes repeated panics (once per node without a probe pod).

## Solution

Added a nil check before accessing the probe pod:
- Check if probe pod exists in the map
- Check if the pod itself is nil
- Return a descriptive error instead of panicking

## Impact

**Before:** Runtime panic (6 times on 6-node cluster)  
**After:** Returns error "no probe pod found for node X"

The test result is now reliable and logs are clean. The test properly reports nodes without probe pods as errors rather than crashing.

## Testing

- ✅ Package compiles successfully
- ✅ All 96 provider package tests pass
- ✅ golangci-lint reports 0 issues

Fixes #3732