### PR TITLE
build(deps): bump operator-sdk from v1.42.2 to v1.42.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ ENV \
 
 # Download operator-sdk binary
 ENV \
-	OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.42.2 \
+	OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v1.42.3 \
 	OSDK_BIN=/usr/local/osdk/bin
 
 RUN \


### PR DESCRIPTION
## Summary
- Bumps operator-sdk from v1.42.2 to v1.42.3 in the Dockerfile

## Release notes
https://github.com/operator-framework/operator-sdk/releases/tag/v1.42.3


Made with [Cursor](https://cursor.com)