### PR TITLE
Update Go from 1.26.1 to 1.26.4

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,7 +147,7 @@ targetCrdFilters:
 ## Development Guidelines
 
 ### Go Version
-This repository uses Go 1.26.1. Ensure your local environment matches this version.
+This repository uses Go 1.26.4. Ensure your local environment matches this version.
 
 ### Testing and Mocks
 The codebase uses native Go structs for mocking interfaces in tests. Mock implementations are hand-written and located alongside the interfaces they mock (e.g., `internal/clientsholder/command_mock.go`). This approach avoids external dependencies and makes the code easier to understand and maintain.

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,8 +22,8 @@ RUN \
 ENV \
 	GO_DL_URL=https://golang.org/dl \
 	GOPATH=/root/go
-ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.26.1.linux-amd64.tar.gz
-ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.26.1.linux-arm64.tar.gz
+ENV GO_BIN_URL_x86_64=${GO_DL_URL}/go1.26.4.linux-amd64.tar.gz
+ENV GO_BIN_URL_aarch64=${GO_DL_URL}/go1.26.4.linux-arm64.tar.gz
 
 # Determine the CPU architecture and download the appropriate Go binary
 # We only build our binaries on x86_64 and aarch64 platforms, so it is not necessary
@@ -32,11 +32,11 @@ RUN \
 	if [ "$(uname -m)" = x86_64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_x86_64} --quiet \
 		&& rm -rf /usr/local/go \
-		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.26.1.linux-amd64.tar.gz; \
+		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.26.4.linux-amd64.tar.gz; \
 	elif [ "$(uname -m)" = aarch64 ]; then \
 		wget --directory-prefix=${TEMP_DIR} ${GO_BIN_URL_aarch64} --quiet \
 		&& rm -rf /usr/local/go \
-		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.26.1.linux-arm64.tar.gz; \
+		&& tar -C /usr/local -xzf ${TEMP_DIR}/go1.26.4.linux-arm64.tar.gz; \
 	else \
 		echo "CPU architecture is not supported." && exit 1; \
 	fi

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/redhat-best-practices-for-k8s/certsuite
 
-go 1.26.1
-
-toolchain go1.26.4
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
## Summary
- Update Go version from 1.26.1 to 1.26.4 across Dockerfile, go.mod, and AGENTS.md
- Remove redundant `toolchain` directive from go.mod since it now matches the `go` directive

## Test plan
- [ ] CI builds pass with the new Go version
- [ ] Container image builds successfully


Made with [Cursor](https://cursor.com)