### PR TITLE
Remove unreachable error check in DoAutoDiscover

### DIFF
--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -227,9 +227,6 @@ func DoAutoDiscover(config *configuration.TestConfiguration) DiscoveredTestData 
 
 	// Best effort mode autodiscovery for operand (running-only) pods.
 	pods, _ := FindPodsByLabels(oc.K8sClient.CoreV1(), nil, data.Namespaces)
-	if err != nil {
-		log.Fatal("Failed to get running pods, err: %v", err)
-	}
 
 	data.OperandPods, err = getOperandPodsFromTestCsvs(data.Csvs, pods)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Remove dead code in `pkg/autodiscover/autodiscover.go`: `FindPodsByLabels` returns `(runningPods, allPods []corev1.Pod)` with no error. The `_` discards `allPods`, not an error. The `if err != nil` block tested a stale `err` from the previous `getOperatorCsvPods` call, which was already handled above — making the block unreachable.

## Test plan

- [x] `make test` passes (0 failures)
- [x] `golangci-lint` passes (0 issues)