### PR TITLE
Fix log level fallback message to match actual behavior

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -61,7 +61,7 @@ func CloseGlobalLogFile() error {
 func SetupLogger(logWriter io.Writer, level string) {
 	logLevel, err := parseLevel(level)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Could not parse log level, err: %v. Defaulting to DEBUG.", err)
+		fmt.Fprintf(os.Stderr, "Could not parse log level, err: %v. Defaulting to INFO.", err)
 		globalLogLevel = slog.LevelInfo
 	} else {
 		globalLogLevel = logLevel


### PR DESCRIPTION
## Summary

- Fix misleading error message in internal/log/log.go: when the configured log level cannot be parsed, the message said "Defaulting to DEBUG" but the code actually sets slog.LevelInfo. Updated the message to say "Defaulting to INFO".

## Test plan

- [x] make test passes (0 failures)
- [x] golangci-lint passes (0 issues)