### PR TITLE
Fix YAML key case in example config to match Go struct tag

### DIFF
--- a/config/certsuite_config.yml
+++ b/config/certsuite_config.yml
@@ -23,7 +23,7 @@ acceptedKernelTaints:
 skipScalingTestDeployments:
   - name: deployment1
     namespace: tnf
-skipScalingTestStatefulsets:
+skipScalingTestStatefulSets:
   - name: statefulset1
     namespace: tnf
 skipHelmChartList:


### PR DESCRIPTION
## Summary

- Fix case mismatch in config/certsuite_config.yml: the example used `skipScalingTestStatefulsets` (lowercase 's') but the Go struct tag in pkg/configuration/configuration.go expects `skipScalingTestStatefulSets` (uppercase 'S'). YAML unmarshaling is case-sensitive, so this field silently failed to populate when using the example config.

## Test plan

- [x] Verified Go struct tag: `yaml:"skipScalingTestStatefulSets,omitempty"`
- [x] Updated example config key to match exactly