### PR TITLE
ci: add OCP 4.22 nightly tests and bump quick-ocp to v0.0.37

### DIFF
--- a/.github/workflows/qe-ocp-418-intrusive.yaml
+++ b/.github/workflows/qe-ocp-418-intrusive.yaml
@@ -110,7 +110,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@27aad2ca36800250d42316d2eefeea2d861ea507 # v0.0.35
+        uses: palmsoftware/quick-ocp@750f1c774eac0d563504fa63f3c70571bacb54b4 # v0.0.37
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-418.yaml
+++ b/.github/workflows/qe-ocp-418.yaml
@@ -111,7 +111,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@27aad2ca36800250d42316d2eefeea2d861ea507 # v0.0.35
+        uses: palmsoftware/quick-ocp@750f1c774eac0d563504fa63f3c70571bacb54b4 # v0.0.37
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-419-intrusive.yaml
+++ b/.github/workflows/qe-ocp-419-intrusive.yaml
@@ -110,7 +110,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@27aad2ca36800250d42316d2eefeea2d861ea507 # v0.0.35
+        uses: palmsoftware/quick-ocp@750f1c774eac0d563504fa63f3c70571bacb54b4 # v0.0.37
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-419.yaml
+++ b/.github/workflows/qe-ocp-419.yaml
@@ -111,7 +111,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@27aad2ca36800250d42316d2eefeea2d861ea507 # v0.0.35
+        uses: palmsoftware/quick-ocp@750f1c774eac0d563504fa63f3c70571bacb54b4 # v0.0.37
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-420-intrusive.yaml
+++ b/.github/workflows/qe-ocp-420-intrusive.yaml
@@ -110,7 +110,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@27aad2ca36800250d42316d2eefeea2d861ea507 # v0.0.35
+        uses: palmsoftware/quick-ocp@750f1c774eac0d563504fa63f3c70571bacb54b4 # v0.0.37
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-420.yaml
+++ b/.github/workflows/qe-ocp-420.yaml
@@ -111,7 +111,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@27aad2ca36800250d42316d2eefeea2d861ea507 # v0.0.35
+        uses: palmsoftware/quick-ocp@750f1c774eac0d563504fa63f3c70571bacb54b4 # v0.0.37
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-421-intrusive.yaml
+++ b/.github/workflows/qe-ocp-421-intrusive.yaml
@@ -110,7 +110,7 @@ jobs:
           exit 1
 
       - name: Deploy the OCP Cluster
-        uses: palmsoftware/quick-ocp@27aad2ca36800250d42316d2eefeea2d861ea507 # v0.0.35
+        uses: palmsoftware/quick-ocp@750f1c774eac0d563504fa63f3c70571bacb54b4 # v0.0.37
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true

--- a/.github/workflows/qe-ocp-422-intrusive.yaml
+++ b/.github/workflows/qe-ocp-422-intrusive.yaml
@@ -1,4 +1,4 @@
-name: QE OCP 4.21 Testing
+name: QE OCP 4.22 Intrusive Testing
 
 on:
   # pull_request:
@@ -43,14 +43,14 @@ jobs:
           tags: quay.io/redhat-best-practices-for-k8s/certsuite:localtest
           outputs: type=docker,dest=/tmp/testimage.tar
 
+      - name: Build the binary
+        run: make build-certsuite-tool
+
       - name: Store image as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: testimage
           path: /tmp/testimage.tar
-
-      - name: Build the binary
-        run: make build-certsuite-tool
 
       - name: Store binary as artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -58,18 +58,17 @@ jobs:
           name: certsuite-binary
           path: ./certsuite
 
-  qe-ocp-421-testing:
-    name: QE OCP 4.21 Tests (${{ matrix.suite }} - ${{ matrix.run-type }})
+  qe-ocp-422-intrusive-testing:
+    name: QE OCP 4.22 Tests (${{ matrix.suite }} - ${{ matrix.run-type }})
     runs-on: ubuntu-24.04
-    timeout-minutes: 240
+    timeout-minutes: 300
     needs: build-and-store
     if: needs.build-and-store.result == 'success'
     strategy:
       fail-fast: false
       matrix:
-        # Suites with -ocp suffix run only OCP-required tests
-        # 100% OCP-required suites don't need suffix but use it for consistency
-        suite: [affiliatedcertification-ocp, performance-ocp, platformalteration1-ocp, platformalteration2-ocp, platformalteration3-ocp, platformalteration4-ocp]
+        # Add more suites if more intrusive tests are added to the QE repo
+        suite: [lifecycle]
         # run-type: [binary, image]
         run-type: [binary]
     env:
@@ -115,7 +114,7 @@ jobs:
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
-          desiredOCPVersion: 4.21
+          desiredOCPVersion: 4.22
           waitForOperatorsReady: true
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
@@ -153,17 +152,17 @@ jobs:
         if: matrix.run-type == 'image'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
-          timeout_minutes: 120
+          timeout_minutes: 180
           max_attempts: 2
-          command: cd ${GITHUB_WORKSPACE}/certsuite-qe; FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE} CERTSUITE_IMAGE=${{env.TEST_CERTSUITE_IMAGE_NAME}} CERTSUITE_IMAGE_TAG=${{env.TEST_CERTSUITE_IMAGE_TAG}} JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true make test-features
+          command: cd ${GITHUB_WORKSPACE}/certsuite-qe; FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE} CERTSUITE_IMAGE=${{env.TEST_CERTSUITE_IMAGE_NAME}} CERTSUITE_IMAGE_TAG=${{env.TEST_CERTSUITE_IMAGE_TAG}} JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=false ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true make test-features
 
       - name: Run the tests (against binary)
         if: matrix.run-type == 'binary'
         uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4.0.0
         with:
-          timeout_minutes: 120
+          timeout_minutes: 180
           max_attempts: 2
-          command: cd ${GITHUB_WORKSPACE}/certsuite-qe; FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE} USE_BINARY=true JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=true ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true make test-features
+          command: cd ${GITHUB_WORKSPACE}/certsuite-qe; FEATURES=${{matrix.suite}} CERTSUITE_REPO_PATH=${GITHUB_WORKSPACE} USE_BINARY=true JOB_ID=${{github.run_id}} DISABLE_INTRUSIVE_TESTS=false ENABLE_PARALLEL=false ENABLE_FLAKY_RETRY=true make test-features
 
       - name: (if on main and upstream) Send chat msg to dev team if failed to run QE tests
         if: ${{ failure() && github.ref == 'refs/heads/main' && github.repository_owner == 'redhat-best-practices-for-k8s' }}
@@ -174,5 +173,5 @@ jobs:
           GITHUB_REPO: https://github.com/redhat-best-practices-for-k8s/certsuite
         run: |
           curl -X POST --data "{
-              \"text\": \"🚨⚠️  Failed to run non-intrusive OCP 4.21 QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
+              \"text\": \"🚨⚠️  Failed to run intrusive OCP 4.22 QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
           }" -H 'Content-type: application/json; charset=UTF-8' '${{ secrets.QE_NIGHTLY_WEBHOOK }}'

--- a/.github/workflows/qe-ocp-422.yaml
+++ b/.github/workflows/qe-ocp-422.yaml
@@ -1,4 +1,4 @@
-name: QE OCP 4.21 Testing
+name: QE OCP 4.22 Testing
 
 on:
   # pull_request:
@@ -58,8 +58,8 @@ jobs:
           name: certsuite-binary
           path: ./certsuite
 
-  qe-ocp-421-testing:
-    name: QE OCP 4.21 Tests (${{ matrix.suite }} - ${{ matrix.run-type }})
+  qe-ocp-422-testing:
+    name: QE OCP 4.22 Tests (${{ matrix.suite }} - ${{ matrix.run-type }})
     runs-on: ubuntu-24.04
     timeout-minutes: 240
     needs: build-and-store
@@ -115,7 +115,7 @@ jobs:
         with:
           ocpPullSecret: $OCP_PULL_SECRET
           bundleCache: true
-          desiredOCPVersion: 4.21
+          desiredOCPVersion: 4.22
           waitForOperatorsReady: true
         env:
           OCP_PULL_SECRET: ${{ secrets.CRC_PULL_SECRET }}
@@ -174,5 +174,5 @@ jobs:
           GITHUB_REPO: https://github.com/redhat-best-practices-for-k8s/certsuite
         run: |
           curl -X POST --data "{
-              \"text\": \"🚨⚠️  Failed to run non-intrusive OCP 4.21 QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
+              \"text\": \"🚨⚠️  Failed to run non-intrusive OCP 4.22 QE tests from commit \<$GITHUB_REPO/commit/$COMMIT_SHA|$COMMIT_SHA\>, job ID \<$GITHUB_REPO/actions/runs/$JOB_RUN_ID/attempts/$JOB_RUN_ATTEMPT|$JOB_RUN_ID\> \"
           }" -H 'Content-type: application/json; charset=UTF-8' '${{ secrets.QE_NIGHTLY_WEBHOOK }}'


### PR DESCRIPTION
## Summary

- Add OCP 4.22 nightly test workflows (non-intrusive and intrusive)
- Bump quick-ocp from v0.0.35 to [v0.0.37](https://github.com/palmsoftware/quick-ocp/releases/tag/v0.0.37) across all qe-ocp workflow files

quick-ocp v0.0.37 adds OCP 4.22 support ([CRC v2.62.0](https://github.com/crc-org/crc/releases/tag/v2.62.0)) and fixes oc tools download for new z-stream versions.

Ref: [CNFCERT-1440](https://redhat.atlassian.net/browse/CNFCERT-1440)