### PR TITLE
Add OCP 4.22 to RHCOS version update script

### DIFF
--- a/script/rhcos_versions.sh
+++ b/script/rhcos_versions.sh
@@ -2,7 +2,7 @@
 
 set -o errexit -o pipefail
 
-CHANNELS=(4.21 4.20 4.19 4.18 4.16 4.15 4.14 4.13 4.12 4.11 4.10 4.9 4.8 4.7 4.6 4.5)
+CHANNELS=(4.22 4.21 4.20 4.19 4.18 4.16 4.15 4.14 4.13 4.12 4.11 4.10 4.9 4.8 4.7 4.6 4.5)
 CHANNEL_TYPES=(stable candidate)
 
 # Keep track of the number of failures we see from the 'oc adm' calls.


### PR DESCRIPTION
## Summary

Adds OCP 4.22 channel to the automated RHCOS version map update script.

## Problem

The OCP 4.22 nightly tests were failing because RHCOS version `9.8.20260605-0` (used by CRC 2.62.0 / OCP 4.22.1) was not in the version map.

The root cause: `script/rhcos_versions.sh` only includes channels up to 4.21, so it never fetches 4.22 versions.

## Solution

Updated `CHANNELS` array to include `4.22`.

## Next Steps

After merging this PR, run the RHCOS version update workflow to populate all OCP 4.22 versions into the map.