### PR TITLE
Set go 1.26 with toolchain go1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/redhat-best-practices-for-k8s/certsuite
 
-go 1.26.4
+go 1.26
+
+toolchain go1.26.5
 
 require (
 	github.com/Masterminds/semver/v3 v3.5.0


### PR DESCRIPTION
## Summary
- Set `go` directive to `1.26` (minimum version floor)
- Set `toolchain` directive to `go1.26.5` (pinned build version)
- Ran `go mod tidy`

This standardizes the Go version strategy: the `go` directive stays at the minor version, while `toolchain` pins the exact patch release used for builds.