### PR TITLE
fix: keep nodes without MachineConfig on hosted control planes

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -18,6 +18,7 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"regexp"
 	"sync"
 	"time"
@@ -170,6 +171,9 @@ type MachineConfig struct {
 		} `json:"systemd"`
 	} `json:"config"`
 }
+
+// ErrNoMachineConfig is returned when a node has no MachineConfig (e.g. HyperShift).
+var ErrNoMachineConfig = errors.New("no MachineConfig available")
 
 type CniNetworkInterface struct {
 	Name       string                 `json:"name"`

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -740,16 +740,19 @@ func createNodes(nodes []corev1.Node) map[string]Node {
 			continue
 		}
 
-		// Get Node's machineConfig name
+		// Not all OCP clusters expose MachineConfig on nodes (e.g. hosted control planes).
+		// Keep the node without Mc — do not assume MCO.
 		mcName, exists := node.Annotations["machineconfiguration.openshift.io/currentConfig"]
 		if !exists {
-			log.Error("Failed to get machineConfig name for node %q", node.Name)
+			log.Warn("Failed to get machineConfig name for node %q; keeping node without MachineConfig", node.Name)
+			wrapperNodes[node.Name] = Node{Data: node}
 			continue
 		}
 		log.Info("Node %q - mc name %q", node.Name, mcName)
 		mc, err := getMachineConfig(mcName, machineConfigs)
 		if err != nil {
-			log.Error("Failed to get machineConfig %q, err: %v", mcName, err)
+			log.Warn("Failed to get machineConfig %q, err: %v; keeping node without MachineConfig", mcName, err)
+			wrapperNodes[node.Name] = Node{Data: node}
 			continue
 		}
 

--- a/tests/platform/bootparams/bootparams.go
+++ b/tests/platform/bootparams/bootparams.go
@@ -36,7 +36,10 @@ func TestBootParamsHelper(env *provider.TestEnvironment, cut *provider.Container
 	if probePod == nil {
 		return fmt.Errorf("probe pod for container %s not found on node %s", cut, cut.NodeName)
 	}
-	mcKernelArgumentsMap := GetMcKernelArguments(env, cut.NodeName)
+	mcKernelArgumentsMap, err := GetMcKernelArguments(env, cut.NodeName)
+	if err != nil {
+		return fmt.Errorf("error getting MachineConfig kernel arguments for node %s: %w", cut.NodeName, err)
+	}
 	currentKernelArgsMap, err := getCurrentKernelCmdlineArgs(env, cut.NodeName)
 	if err != nil {
 		return fmt.Errorf("error getting kernel cli arguments from container: %s, err=%w", cut, err)
@@ -66,9 +69,17 @@ func TestBootParamsHelper(env *provider.TestEnvironment, cut *provider.Container
 	return nil
 }
 
-func GetMcKernelArguments(env *provider.TestEnvironment, nodeName string) (aMap map[string]string) {
-	mcKernelArgumentsMap := arrayhelper.ArgListToMap(env.Nodes[nodeName].Mc.Spec.KernelArguments)
-	return mcKernelArgumentsMap
+// GetMcKernelArguments returns kernel arguments from the node's MachineConfig.
+// Mc is optional: do not assume every OCP node has MachineConfig.
+func GetMcKernelArguments(env *provider.TestEnvironment, nodeName string) (map[string]string, error) {
+	node, exists := env.Nodes[nodeName]
+	if !exists {
+		return nil, fmt.Errorf("node %q not found in environment", nodeName)
+	}
+	if node.Mc.MachineConfig == nil {
+		return nil, fmt.Errorf("node %q has no MachineConfig", nodeName)
+	}
+	return arrayhelper.ArgListToMap(node.Mc.Spec.KernelArguments), nil
 }
 
 func getGrubKernelArgs(env *provider.TestEnvironment, nodeName string) (aMap map[string]string, err error) {

--- a/tests/platform/bootparams/bootparams.go
+++ b/tests/platform/bootparams/bootparams.go
@@ -17,7 +17,6 @@
 package bootparams
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
@@ -28,7 +27,7 @@ import (
 )
 
 // ErrNoMachineConfig is returned when a node has no MachineConfig (e.g. HyperShift).
-var ErrNoMachineConfig = errors.New("no MachineConfig available")
+var ErrNoMachineConfig = provider.ErrNoMachineConfig
 
 const (
 	grubKernelArgsCommand = "cat /host/boot/loader/entries/$(ls /host/boot/loader/entries/ | sort | tail -n 1)"
@@ -81,7 +80,7 @@ func GetMcKernelArguments(env *provider.TestEnvironment, nodeName string) (map[s
 		return nil, fmt.Errorf("node %q not found in environment", nodeName)
 	}
 	if node.Mc.MachineConfig == nil {
-		return nil, fmt.Errorf("node %q: %w", nodeName, ErrNoMachineConfig)
+		return nil, fmt.Errorf("node %q: %w", nodeName, provider.ErrNoMachineConfig)
 	}
 	return arrayhelper.ArgListToMap(node.Mc.Spec.KernelArguments), nil
 }

--- a/tests/platform/bootparams/bootparams.go
+++ b/tests/platform/bootparams/bootparams.go
@@ -17,6 +17,7 @@
 package bootparams
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -25,6 +26,9 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/arrayhelper"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 )
+
+// ErrNoMachineConfig is returned when a node has no MachineConfig (e.g. HyperShift).
+var ErrNoMachineConfig = errors.New("no MachineConfig available")
 
 const (
 	grubKernelArgsCommand = "cat /host/boot/loader/entries/$(ls /host/boot/loader/entries/ | sort | tail -n 1)"
@@ -77,7 +81,7 @@ func GetMcKernelArguments(env *provider.TestEnvironment, nodeName string) (map[s
 		return nil, fmt.Errorf("node %q not found in environment", nodeName)
 	}
 	if node.Mc.MachineConfig == nil {
-		return nil, fmt.Errorf("node %q has no MachineConfig", nodeName)
+		return nil, fmt.Errorf("node %q: %w", nodeName, ErrNoMachineConfig)
 	}
 	return arrayhelper.ArgListToMap(node.Mc.Spec.KernelArguments), nil
 }

--- a/tests/platform/bootparams/bootparams_test.go
+++ b/tests/platform/bootparams/bootparams_test.go
@@ -22,6 +22,7 @@ import (
 	mcv1 "github.com/openshift/api/machineconfiguration/v1"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetMcKernelArguments_SingleKeyValue(t *testing.T) {
@@ -39,7 +40,8 @@ func TestGetMcKernelArguments_SingleKeyValue(t *testing.T) {
 		},
 	}
 
-	result := GetMcKernelArguments(env, "node1")
+	result, err := GetMcKernelArguments(env, "node1")
+	require.NoError(t, err)
 	assert.Equal(t, "true", result["nosmt"])
 }
 
@@ -58,7 +60,8 @@ func TestGetMcKernelArguments_MultipleArgs(t *testing.T) {
 		},
 	}
 
-	result := GetMcKernelArguments(env, "node1")
+	result, err := GetMcKernelArguments(env, "node1")
+	require.NoError(t, err)
 	assert.Len(t, result, 3)
 	assert.Equal(t, "true", result["nosmt"])
 	assert.Equal(t, "1G", result["hugepagesz"])
@@ -80,7 +83,8 @@ func TestGetMcKernelArguments_FlagWithoutValue(t *testing.T) {
 		},
 	}
 
-	result := GetMcKernelArguments(env, "node1")
+	result, err := GetMcKernelArguments(env, "node1")
+	require.NoError(t, err)
 	assert.Len(t, result, 1)
 	assert.Equal(t, "", result["nosmt"])
 }
@@ -100,6 +104,31 @@ func TestGetMcKernelArguments_EmptyArgs(t *testing.T) {
 		},
 	}
 
-	result := GetMcKernelArguments(env, "node1")
+	result, err := GetMcKernelArguments(env, "node1")
+	require.NoError(t, err)
 	assert.Empty(t, result)
+}
+
+func TestGetMcKernelArguments_MissingNode(t *testing.T) {
+	env := &provider.TestEnvironment{
+		Nodes: map[string]provider.Node{},
+	}
+
+	result, err := GetMcKernelArguments(env, "missing-node")
+	require.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestGetMcKernelArguments_NilMachineConfig(t *testing.T) {
+	env := &provider.TestEnvironment{
+		Nodes: map[string]provider.Node{
+			"node1": {
+				Mc: provider.MachineConfig{},
+			},
+		},
+	}
+
+	result, err := GetMcKernelArguments(env, "node1")
+	require.Error(t, err)
+	assert.Nil(t, result)
 }

--- a/tests/platform/bootparams/bootparams_test.go
+++ b/tests/platform/bootparams/bootparams_test.go
@@ -130,5 +130,6 @@ func TestGetMcKernelArguments_NilMachineConfig(t *testing.T) {
 
 	result, err := GetMcKernelArguments(env, "node1")
 	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNoMachineConfig)
 	assert.Nil(t, result)
 }

--- a/tests/platform/hugepages/hugepages.go
+++ b/tests/platform/hugepages/hugepages.go
@@ -129,6 +129,10 @@ func NewTester(node *provider.Node, probePod *corev1.Pod, commander clientsholde
 	}
 
 	log.Info("Parsing machineconfig's kernelArguments and systemd's hugepages units.")
+	// Mc is optional: do not assume every OCP node has MachineConfig (e.g. HyperShift).
+	if tester.node.Mc.MachineConfig == nil {
+		return nil, fmt.Errorf("node %q: %w", node.Data.Name, provider.ErrNoMachineConfig)
+	}
 	tester.mcSystemdHugepagesByNuma, err = getMcSystemdUnitsHugepagesConfig(&tester.node.Mc)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get MC systemd hugepages config, err: %w", err)
@@ -211,6 +215,10 @@ func (tester *Tester) TestNodeHugepagesWithMcSystemd() (bool, error) {
 // The total count of hugepages of the size defined in the kernelArguments must match the kernArgs' hugepages value.
 // For other sizes, the sum should be 0.
 func (tester *Tester) TestNodeHugepagesWithKernelArgs() (bool, error) {
+	// Mc is optional: do not assume every OCP node has MachineConfig (e.g. HyperShift).
+	if tester.node.Mc.MachineConfig == nil {
+		return false, provider.ErrNoMachineConfig
+	}
 	kernelArgsHpCountBySize, _, err := getMcHugepagesFromMcKernelArguments(&tester.node.Mc)
 	if err != nil {
 		return false, fmt.Errorf("failed to get kernelArguments hugepages config, err: %w", err)
@@ -289,6 +297,10 @@ func (tester *Tester) getNodeNumaHugePages() (hugepages hugepagesByNuma, err err
 
 // getMcSystemdUnitsHugepagesConfig gets the hugepages information from machineconfig's systemd units.
 func getMcSystemdUnitsHugepagesConfig(mc *provider.MachineConfig) (hugepages hugepagesByNuma, err error) {
+	if mc == nil || mc.MachineConfig == nil {
+		return nil, provider.ErrNoMachineConfig
+	}
+
 	const UnitContentsRegexMatchLen = 4
 	hugepages = hugepagesByNuma{}
 
@@ -336,6 +348,10 @@ func logMcKernelArgumentsHugepages(hugepagesPerSize map[int]int, defhugepagesz i
 
 // getMcHugepagesFromMcKernelArguments gets the hugepages params from machineconfig's kernelArguments
 func getMcHugepagesFromMcKernelArguments(mc *provider.MachineConfig) (hugepagesPerSize map[int]int, defhugepagesz int, err error) {
+	if mc == nil || mc.MachineConfig == nil {
+		return nil, 0, provider.ErrNoMachineConfig
+	}
+
 	defhugepagesz = RhelDefaultHugepagesz
 	hugepagesPerSize = map[int]int{}
 

--- a/tests/platform/hugepages/hugepages_test.go
+++ b/tests/platform/hugepages/hugepages_test.go
@@ -139,6 +139,36 @@ func Test_hugepagesFromKernelArgsFunc(t *testing.T) {
 	}
 }
 
+func TestGetMcHugepages_NilMachineConfig(t *testing.T) {
+	mc := provider.MachineConfig{}
+
+	_, _, err := getMcHugepagesFromMcKernelArguments(&mc)
+	assert.ErrorIs(t, err, provider.ErrNoMachineConfig)
+
+	_, err = getMcSystemdUnitsHugepagesConfig(&mc)
+	assert.ErrorIs(t, err, provider.ErrNoMachineConfig)
+}
+
+func TestNewTester_NilMachineConfig(t *testing.T) {
+	node := &provider.Node{
+		Data: &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node1"}},
+		Mc:   provider.MachineConfig{},
+	}
+	probePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns1"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "container1"}}},
+	}
+	client := &fakeK8sClient{
+		execCommandFunctionMocker: func() (string, string, error) {
+			return "/host/sys/devices/system/node/node0/hugepages/hugepages-2048kB/nr_hugepages count:0\n", "", nil
+		},
+	}
+
+	tester, err := NewTester(node, probePod, client)
+	assert.ErrorIs(t, err, provider.ErrNoMachineConfig)
+	assert.Nil(t, tester)
+}
+
 type fakeK8sClient struct {
 	execCommandFunctionMocker func() (stdout string, stderr string, err error)
 }

--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -434,9 +434,14 @@ func testHugepages(check *checksdb.Check, env *provider.TestEnvironment) {
 		}
 
 		hpTester, err := hugepages.NewTester(&node, probePod, clientsholder.GetClientsHolder())
+		if errors.Is(err, provider.ErrNoMachineConfig) {
+			check.LogInfo("Skipping node %q: %v", nodeName, err)
+			continue
+		}
 		if err != nil {
 			check.LogError("Unable to get node hugepages tester for node %q, err: %v", nodeName, err)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(nodeName, "Unable to get node hugepages tester", false))
+			continue
 		}
 
 		if err := hpTester.Run(); err != nil {

--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -502,7 +502,12 @@ func testSysctlConfigs(check *checksdb.Check, env *provider.TestEnvironment) {
 			continue
 		}
 
-		mcKernelArgumentsMap := bootparams.GetMcKernelArguments(env, cut.NodeName)
+		mcKernelArgumentsMap, err := bootparams.GetMcKernelArguments(env, cut.NodeName)
+		if err != nil {
+			check.LogError("Could not get MachineConfig kernel arguments for node %q, error: %v", cut.NodeName, err)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Could not get MachineConfig kernel arguments", false))
+			continue
+		}
 		validSettings := true
 		for key, sysctlConfigVal := range sysctlSettings {
 			if mcVal, ok := mcKernelArgumentsMap[key]; ok {

--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -17,6 +17,7 @@
 package platform
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -462,28 +463,20 @@ func testUnalteredBootParams(check *checksdb.Check, env *provider.TestEnvironmen
 		}
 		alreadyCheckedNodes[cut.NodeName] = true
 
-		node, exists := env.Nodes[cut.NodeName]
-		if !exists {
-			check.LogError("Node %q not found in environment", cut.NodeName)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Node not found in environment", false))
-			continue
-		}
-		// No MachineConfig to compare against (e.g. HyperShift) — skip, do not fail.
-		if node.Mc.MachineConfig == nil {
-			check.LogInfo("Skipping node %q: no MachineConfig", cut.NodeName)
-			continue
-		}
-
 		err := bootparams.TestBootParamsHelper(env, cut, check.GetLogger())
+		if errors.Is(err, bootparams.ErrNoMachineConfig) {
+			check.LogInfo("Skipping node %q: %v", cut.NodeName, err)
+			continue
+		}
 		if err != nil {
-			check.LogError("Node %q failed the boot params check", cut.NodeName)
+			check.LogError("Node %q failed the boot params check: %v", cut.NodeName, err)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Failed the boot params check", false).
 				AddField(testhelper.ProbePodName, env.ProbePods[cut.NodeName].Name))
-		} else {
-			check.LogInfo("Node %q passed the boot params check", cut.NodeName)
-			compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Passed the boot params check", true).
-				AddField(testhelper.ProbePodName, env.ProbePods[cut.NodeName].Name))
+			continue
 		}
+		check.LogInfo("Node %q passed the boot params check", cut.NodeName)
+		compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Passed the boot params check", true).
+			AddField(testhelper.ProbePodName, env.ProbePods[cut.NodeName].Name))
 	}
 
 	check.SetResult(compliantObjects, nonCompliantObjects)
@@ -514,21 +507,13 @@ func testSysctlConfigs(check *checksdb.Check, env *provider.TestEnvironment) {
 			continue
 		}
 
-		node, exists := env.Nodes[cut.NodeName]
-		if !exists {
-			check.LogError("Node %q not found in environment", cut.NodeName)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Node not found in environment", false))
-			continue
-		}
-		// No MachineConfig to compare against (e.g. HyperShift) — skip, do not fail.
-		if node.Mc.MachineConfig == nil {
-			check.LogInfo("Skipping node %q: no MachineConfig", cut.NodeName)
-			continue
-		}
-
 		mcKernelArgumentsMap, err := bootparams.GetMcKernelArguments(env, cut.NodeName)
+		if errors.Is(err, bootparams.ErrNoMachineConfig) {
+			check.LogInfo("Skipping sysctl check for node %q: %v", cut.NodeName, err)
+			continue
+		}
 		if err != nil {
-			check.LogError("Could not get MachineConfig kernel arguments for node %q, error: %v", cut.NodeName, err)
+			check.LogError("Could not get MachineConfig kernel arguments for node %q: %v", cut.NodeName, err)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Could not get MachineConfig kernel arguments", false))
 			continue
 		}

--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -462,6 +462,18 @@ func testUnalteredBootParams(check *checksdb.Check, env *provider.TestEnvironmen
 		}
 		alreadyCheckedNodes[cut.NodeName] = true
 
+		node, exists := env.Nodes[cut.NodeName]
+		if !exists {
+			check.LogError("Node %q not found in environment", cut.NodeName)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Node not found in environment", false))
+			continue
+		}
+		// No MachineConfig to compare against (e.g. HyperShift) — skip, do not fail.
+		if node.Mc.MachineConfig == nil {
+			check.LogInfo("Skipping node %q: no MachineConfig", cut.NodeName)
+			continue
+		}
+
 		err := bootparams.TestBootParamsHelper(env, cut, check.GetLogger())
 		if err != nil {
 			check.LogError("Node %q failed the boot params check", cut.NodeName)
@@ -499,6 +511,18 @@ func testSysctlConfigs(check *checksdb.Check, env *provider.TestEnvironment) {
 		if err != nil {
 			check.LogError("Could not get sysctl settings for node %q, error: %v", cut.NodeName, err)
 			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Could not get sysctl settings", false))
+			continue
+		}
+
+		node, exists := env.Nodes[cut.NodeName]
+		if !exists {
+			check.LogError("Node %q not found in environment", cut.NodeName)
+			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewNodeReportObject(cut.NodeName, "Node not found in environment", false))
+			continue
+		}
+		// No MachineConfig to compare against (e.g. HyperShift) — skip, do not fail.
+		if node.Mc.MachineConfig == nil {
+			check.LogInfo("Skipping node %q: no MachineConfig", cut.NodeName)
 			continue
 		}
 


### PR DESCRIPTION
### Why
Konflux EaaS run of certsuite v5.5.23 against ptp-operator on a HyperShift guest (OCP ~4.21) left `env.Nodes` empty even though three workers and healthy probe pods existed.
Guest nodes lacked `machineconfiguration.openshift.io/currentConfig`. `createNodes` treated the cluster as OCP, logged "Failed to get machineConfig name", and dropped every node. That emptied `claim.nodes.nodeSummary` while ProbePods / `nodesHwInfo` still listed the nodes.
Fallout included:
- panic in `platform-alteration-boot-params` (`GetMcKernelArguments`)
- fail in `platform-alteration-base-image` ("No mutex found for node")
- cascade skips for other platform checks
- lifecycle HA/scaling "not enough nodes" via empty `GetWorkerCount()`
HyperShift guests are OCP without usable guest MCO annotations; management-cluster MCO does not apply to guest workers.

certsuite assumed every OCP cluster exposes usable guest MachineConfig (MCO). HyperShift guests are still detected as OCP, but worker nodes often lack `machineconfiguration.openshift.io/currentConfig` (MCO lives on the management cluster / NodePool side, not on guest workers).

### What
- Keep nodes in `env.Nodes` when Mc annotation is missing or Mc fetch fails
- `GetMcKernelArguments` returns `ErrNoMachineConfig` instead of panicking when Mc is absent
- Boot-params / sysctl callers use `errors.Is(..., ErrNoMachineConfig)` → skip (do not fail)

Regular OCP with MCO is unchanged.