### PR TITLE
test: add unit tests for pure functions across 16 packages

### DIFF
--- a/cmd/certsuite/check/results/results_test.go
+++ b/cmd/certsuite/check/results/results_test.go
@@ -1,0 +1,218 @@
+package results
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestGetTestResultsDB(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		fileContent    string
+		createFile     bool
+		expectedDB     map[string]string
+		expectedErrMsg string
+	}{
+		{
+			name:       "matching log lines",
+			createFile: true,
+			fileContent: `some preamble log line
+2024-01-01T00:00:00Z [test-case-1] Recording result "PASSED"
+another line
+2024-01-01T00:00:01Z [test-case-2] Recording result "FAILED"
+2024-01-01T00:00:02Z [test-case-3] Recording result "SKIPPED"
+`,
+			expectedDB: map[string]string{
+				"test-case-1": "PASSED",
+				"test-case-2": "FAILED",
+				"test-case-3": "SKIPPED",
+			},
+		},
+		{
+			name:        "no matches",
+			createFile:  true,
+			fileContent: "this is a log line without any results\nanother line\n",
+			expectedDB:  map[string]string{},
+		},
+		{
+			name:        "empty file",
+			createFile:  true,
+			fileContent: "",
+			expectedDB:  map[string]string{},
+		},
+		{
+			name:           "file not found",
+			createFile:     false,
+			expectedErrMsg: "could not open file",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var filePath string
+			if tc.createFile {
+				tmpFile, err := os.CreateTemp(t.TempDir(), "log-*.txt")
+				require.NoError(t, err)
+				_, err = tmpFile.WriteString(tc.fileContent)
+				require.NoError(t, err)
+				tmpFile.Close()
+				filePath = tmpFile.Name()
+			} else {
+				filePath = filepath.Join(t.TempDir(), "nonexistent.log")
+			}
+
+			db, err := getTestResultsDB(filePath)
+			if tc.expectedErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedDB, db)
+			}
+		})
+	}
+}
+
+func TestGetExpectedTestResults(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		fileContent    string
+		createFile     bool
+		expectedResult map[string]string
+		expectedErrMsg string
+	}{
+		{
+			name:       "valid YAML with pass fail skip",
+			createFile: true,
+			fileContent: `testCases:
+  pass:
+    - test-a
+    - test-b
+  fail:
+    - test-c
+  skip:
+    - test-d
+`,
+			expectedResult: map[string]string{
+				"test-a": "PASSED",
+				"test-b": "PASSED",
+				"test-c": "FAILED",
+				"test-d": "SKIPPED",
+			},
+		},
+		{
+			name:       "empty lists",
+			createFile: true,
+			fileContent: `testCases:
+  pass: []
+  fail: []
+  skip: []
+`,
+			expectedResult: map[string]string{},
+		},
+		{
+			name:           "file not found",
+			createFile:     false,
+			expectedErrMsg: "could not open template file",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var filePath string
+			if tc.createFile {
+				tmpFile, err := os.CreateTemp(t.TempDir(), "template-*.yaml")
+				require.NoError(t, err)
+				_, err = tmpFile.WriteString(tc.fileContent)
+				require.NoError(t, err)
+				tmpFile.Close()
+				filePath = tmpFile.Name()
+			} else {
+				filePath = filepath.Join(t.TempDir(), "nonexistent.yaml")
+			}
+
+			result, err := getExpectedTestResults(filePath)
+			if tc.expectedErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestGenerateTemplateFile(t *testing.T) {
+	testCases := []struct {
+		name      string
+		resultsDB map[string]string
+	}{
+		{
+			name: "map with pass fail skip results",
+			resultsDB: map[string]string{
+				"test-pass": "PASSED",
+				"test-fail": "FAILED",
+				"test-skip": "SKIPPED",
+			},
+		},
+		{
+			name:      "empty map",
+			resultsDB: map[string]string{},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			origDir, err := os.Getwd()
+			require.NoError(t, err)
+			tmpDir := t.TempDir()
+			err = os.Chdir(tmpDir)
+			require.NoError(t, err)
+			defer func() {
+				require.NoError(t, os.Chdir(origDir))
+			}()
+
+			err = generateTemplateFile(tc.resultsDB)
+			require.NoError(t, err)
+
+			outputPath := filepath.Join(tmpDir, TestResultsTemplateFileName)
+			data, err := os.ReadFile(outputPath)
+			require.NoError(t, err)
+
+			var parsed TestResults
+			err = yaml.Unmarshal(data, &parsed)
+			require.NoError(t, err)
+
+			passCount := 0
+			failCount := 0
+			skipCount := 0
+			for _, v := range tc.resultsDB {
+				switch v {
+				case resultPass:
+					passCount++
+				case resultFail:
+					failCount++
+				case resultSkip:
+					skipCount++
+				}
+			}
+			assert.Len(t, parsed.Pass, passCount)
+			assert.Len(t, parsed.Fail, failCount)
+			assert.Len(t, parsed.Skip, skipCount)
+		})
+	}
+}

--- a/cmd/certsuite/claim/show/csv/csv_test.go
+++ b/cmd/certsuite/claim/show/csv/csv_test.go
@@ -1,0 +1,24 @@
+package csv
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildCatalogByID(t *testing.T) {
+	catalogMap := buildCatalogByID()
+	assert.NotNil(t, catalogMap)
+
+	t.Run("catalog map is populated from identifiers.Catalog", func(t *testing.T) {
+		assert.GreaterOrEqual(t, len(catalogMap), 1)
+	})
+
+	t.Run("entries are keyed by ID string", func(t *testing.T) {
+		for id, desc := range catalogMap {
+			assert.NotEmpty(t, id)
+			assert.NotEmpty(t, desc.Identifier.Id)
+			assert.Equal(t, id, desc.Identifier.Id)
+		}
+	})
+}

--- a/cmd/certsuite/generate/config/config_test.go
+++ b/cmd/certsuite/generate/config/config_test.go
@@ -1,0 +1,224 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/configuration"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadCRDfilters(t *testing.T) {
+	testCases := []struct {
+		name            string
+		answers         []string
+		expectedFilters []configuration.CrdFilter
+	}{
+		{
+			name:    "valid scalable true",
+			answers: []string{"myname/true"},
+			expectedFilters: []configuration.CrdFilter{
+				{NameSuffix: "myname", Scalable: true},
+			},
+		},
+		{
+			name:    "valid scalable false",
+			answers: []string{"myname/false"},
+			expectedFilters: []configuration.CrdFilter{
+				{NameSuffix: "myname", Scalable: false},
+			},
+		},
+		{
+			name:    "multiple entries",
+			answers: []string{"name1/true", "name2/false"},
+			expectedFilters: []configuration.CrdFilter{
+				{NameSuffix: "name1", Scalable: true},
+				{NameSuffix: "name2", Scalable: false},
+			},
+		},
+		{
+			name:            "invalid bool value",
+			answers:         []string{"myname/notabool"},
+			expectedFilters: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			certsuiteConfig = configuration.TestConfiguration{}
+			loadCRDfilters(tc.answers)
+			assert.Equal(t, tc.expectedFilters, certsuiteConfig.CrdFilters)
+		})
+	}
+}
+
+func TestLoadNonScalableDeployments(t *testing.T) {
+	testCases := []struct {
+		name       string
+		answers    []string
+		expectedDS []configuration.SkipScalingTestDeploymentsInfo
+	}{
+		{
+			name:    "valid name/namespace",
+			answers: []string{"myname/mynamespace"},
+			expectedDS: []configuration.SkipScalingTestDeploymentsInfo{
+				{Name: "myname", Namespace: "mynamespace"},
+			},
+		},
+		{
+			name:    "multiple entries",
+			answers: []string{"deploy1/ns1", "deploy2/ns2"},
+			expectedDS: []configuration.SkipScalingTestDeploymentsInfo{
+				{Name: "deploy1", Namespace: "ns1"},
+				{Name: "deploy2", Namespace: "ns2"},
+			},
+		},
+		{
+			name:       "missing separator",
+			answers:    []string{"nameonly"},
+			expectedDS: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			certsuiteConfig = configuration.TestConfiguration{}
+			loadNonScalableDeployments(tc.answers)
+			assert.Equal(t, tc.expectedDS, certsuiteConfig.SkipScalingTestDeployments)
+		})
+	}
+}
+
+func TestLoadNonScalableStatefulSets(t *testing.T) {
+	testCases := []struct {
+		name       string
+		answers    []string
+		expectedSS []configuration.SkipScalingTestStatefulSetsInfo
+	}{
+		{
+			name:    "valid name/namespace",
+			answers: []string{"mysts/mynamespace"},
+			expectedSS: []configuration.SkipScalingTestStatefulSetsInfo{
+				{Name: "mysts", Namespace: "mynamespace"},
+			},
+		},
+		{
+			name:    "multiple entries",
+			answers: []string{"sts1/ns1", "sts2/ns2"},
+			expectedSS: []configuration.SkipScalingTestStatefulSetsInfo{
+				{Name: "sts1", Namespace: "ns1"},
+				{Name: "sts2", Namespace: "ns2"},
+			},
+		},
+		{
+			name:       "missing separator",
+			answers:    []string{"nameonly"},
+			expectedSS: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			certsuiteConfig = configuration.TestConfiguration{}
+			loadNonScalableStatefulSets(tc.answers)
+			assert.Equal(t, tc.expectedSS, certsuiteConfig.SkipScalingTestStatefulSets)
+		})
+	}
+}
+
+func TestLoadNamespaces(t *testing.T) {
+	testCases := []struct {
+		name               string
+		answers            []string
+		expectedNamespaces []configuration.Namespace
+	}{
+		{
+			name:               "empty slice",
+			answers:            []string{},
+			expectedNamespaces: nil,
+		},
+		{
+			name:    "single entry",
+			answers: []string{"ns1"},
+			expectedNamespaces: []configuration.Namespace{
+				{Name: "ns1"},
+			},
+		},
+		{
+			name:    "multiple entries",
+			answers: []string{"ns1", "ns2", "ns3"},
+			expectedNamespaces: []configuration.Namespace{
+				{Name: "ns1"},
+				{Name: "ns2"},
+				{Name: "ns3"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			certsuiteConfig = configuration.TestConfiguration{}
+			loadNamespaces(tc.answers)
+			assert.Equal(t, tc.expectedNamespaces, certsuiteConfig.TargetNameSpaces)
+		})
+	}
+}
+
+func TestLoadManagedDeployments(t *testing.T) {
+	testCases := []struct {
+		name     string
+		answers  []string
+		expected []configuration.ManagedDeploymentsStatefulsets
+	}{
+		{
+			name:     "empty slice",
+			answers:  []string{},
+			expected: nil,
+		},
+		{
+			name:    "multiple entries",
+			answers: []string{"deploy1", "deploy2"},
+			expected: []configuration.ManagedDeploymentsStatefulsets{
+				{Name: "deploy1"},
+				{Name: "deploy2"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			certsuiteConfig = configuration.TestConfiguration{}
+			loadManagedDeployments(tc.answers)
+			assert.Equal(t, tc.expected, certsuiteConfig.ManagedDeployments)
+		})
+	}
+}
+
+func TestLoadManagedStatefulSets(t *testing.T) {
+	testCases := []struct {
+		name     string
+		answers  []string
+		expected []configuration.ManagedDeploymentsStatefulsets
+	}{
+		{
+			name:     "empty slice",
+			answers:  []string{},
+			expected: nil,
+		},
+		{
+			name:    "multiple entries",
+			answers: []string{"sts1", "sts2"},
+			expected: []configuration.ManagedDeploymentsStatefulsets{
+				{Name: "sts1"},
+				{Name: "sts2"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			certsuiteConfig = configuration.TestConfiguration{}
+			loadManagedStatefulSets(tc.answers)
+			assert.Equal(t, tc.expected, certsuiteConfig.ManagedStatefulsets)
+		})
+	}
+}

--- a/cmd/certsuite/info/info_test.go
+++ b/cmd/certsuite/info/info_test.go
@@ -1,0 +1,64 @@
+package info
+
+import (
+	"testing"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite-claim/pkg/claim"
+	"github.com/redhat-best-practices-for-k8s/certsuite/tests/identifiers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetTestDescriptionsFromTestIDs(t *testing.T) {
+	t.Parallel()
+
+	var knownID string
+	for id := range identifiers.Catalog {
+		knownID = id.Id
+		break
+	}
+
+	testCases := []struct {
+		name     string
+		testIDs  []string
+		validate func(t *testing.T, results []claim.TestCaseDescription)
+	}{
+		{
+			name:    "empty input",
+			testIDs: []string{},
+			validate: func(t *testing.T, results []claim.TestCaseDescription) {
+				assert.Nil(t, results)
+			},
+		},
+		{
+			name:    "IDs not in catalog",
+			testIDs: []string{"nonexistent-test-id-12345", "another-fake-id"},
+			validate: func(t *testing.T, results []claim.TestCaseDescription) {
+				assert.Nil(t, results)
+			},
+		},
+		{
+			name:    "valid ID from catalog",
+			testIDs: []string{knownID},
+			validate: func(t *testing.T, results []claim.TestCaseDescription) {
+				assert.Len(t, results, 1)
+				assert.Equal(t, knownID, results[0].Identifier.Id)
+			},
+		},
+		{
+			name:    "mix of valid and invalid IDs",
+			testIDs: []string{knownID, "nonexistent-test-id"},
+			validate: func(t *testing.T, results []claim.TestCaseDescription) {
+				assert.Len(t, results, 1)
+				assert.Equal(t, knownID, results[0].Identifier.Id)
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			results := getTestDescriptionsFromTestIDs(tc.testIDs)
+			tc.validate(t, results)
+		})
+	}
+}

--- a/cmd/certsuite/pkg/claim/claim_test.go
+++ b/cmd/certsuite/pkg/claim/claim_test.go
@@ -2,10 +2,88 @@
 package claim
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		fileContent    string
+		createFile     bool
+		expectedErrMsg string
+	}{
+		{
+			name:       "valid claim JSON",
+			createFile: true,
+			fileContent: `{
+				"claim": {
+					"configurations": {
+						"Config": null,
+						"AbnormalEvents": [],
+						"testOperators": []
+					},
+					"nodes": {
+						"nodeSummary": null,
+						"cniPlugins": null,
+						"nodesHwInfo": null,
+						"csiDriver": null
+					},
+					"results": {},
+					"versions": {
+						"claimFormat": "v0.5.0",
+						"certSuite": ""
+					}
+				}
+			}`,
+		},
+		{
+			name:           "invalid JSON",
+			createFile:     true,
+			fileContent:    `{not valid json`,
+			expectedErrMsg: "failed to unmarshal file",
+		},
+		{
+			name:           "file not found",
+			createFile:     false,
+			expectedErrMsg: "failure reading file",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var filePath string
+			if tc.createFile {
+				tmpFile, err := os.CreateTemp(t.TempDir(), "claim-*.json")
+				require.NoError(t, err)
+				_, err = tmpFile.WriteString(tc.fileContent)
+				require.NoError(t, err)
+				tmpFile.Close()
+				filePath = tmpFile.Name()
+			} else {
+				filePath = filepath.Join(t.TempDir(), "nonexistent.json")
+			}
+
+			schema, err := Parse(filePath)
+			if tc.expectedErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+				assert.Nil(t, schema)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, schema)
+			}
+		})
+	}
+}
 
 func TestIsClaimFormatVersionSupported(t *testing.T) {
 	testCases := []struct {

--- a/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet_test.go
+++ b/cmd/certsuite/upload/results_spreadsheet/results_spreadsheet_test.go
@@ -1,0 +1,164 @@
+package resultsspreadsheet
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/sheets/v4"
+)
+
+func TestPrepareRecordsForSpreadSheet(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		records  [][]string
+		validate func(t *testing.T, rows []*sheets.RowData)
+	}{
+		{
+			name:    "empty input",
+			records: [][]string{},
+			validate: func(t *testing.T, rows []*sheets.RowData) {
+				assert.Nil(t, rows)
+			},
+		},
+		{
+			name:    "normal records",
+			records: [][]string{{"hello", "world"}, {"foo", "bar"}},
+			validate: func(t *testing.T, rows []*sheets.RowData) {
+				require.Len(t, rows, 2)
+				require.Len(t, rows[0].Values, 2)
+				assert.Equal(t, "hello", *rows[0].Values[0].UserEnteredValue.StringValue)
+				assert.Equal(t, "world", *rows[0].Values[1].UserEnteredValue.StringValue)
+			},
+		},
+		{
+			name:    "cell content exceeding 50000 chars gets truncated",
+			records: [][]string{{strings.Repeat("x", 60000)}},
+			validate: func(t *testing.T, rows []*sheets.RowData) {
+				require.Len(t, rows, 1)
+				val := *rows[0].Values[0].UserEnteredValue.StringValue
+				assert.LessOrEqual(t, len(val), cellContentLimit)
+			},
+		},
+		{
+			name:    "empty cells processed without panic",
+			records: [][]string{{""}},
+			validate: func(t *testing.T, rows []*sheets.RowData) {
+				require.Len(t, rows, 1)
+				assert.NotNil(t, rows[0].Values[0].UserEnteredValue.StringValue)
+			},
+		},
+		{
+			name:    "newlines replaced",
+			records: [][]string{{"line1\nline2"}, {"line1\r\nline2"}},
+			validate: func(t *testing.T, rows []*sheets.RowData) {
+				require.Len(t, rows, 2)
+				assert.NotContains(t, *rows[0].Values[0].UserEnteredValue.StringValue, "\n")
+				assert.NotContains(t, *rows[1].Values[0].UserEnteredValue.StringValue, "\r\n")
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			rows := prepareRecordsForSpreadSheet(tc.records)
+			tc.validate(t, rows)
+		})
+	}
+}
+
+func TestGetHeaderIndicesByColumnNames(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		headers        []string
+		columnNames    []string
+		expectedResult []int
+		expectedErrMsg string
+	}{
+		{
+			name:           "all columns found",
+			headers:        []string{"Name", "Age", "City"},
+			columnNames:    []string{"Age", "City"},
+			expectedResult: []int{1, 2},
+		},
+		{
+			name:           "missing column returns error",
+			headers:        []string{"Name", "Age"},
+			columnNames:    []string{"Missing"},
+			expectedErrMsg: "column Missing doesn't exist in given headers list",
+		},
+		{
+			name:           "empty headers",
+			headers:        []string{},
+			columnNames:    []string{"Name"},
+			expectedErrMsg: "column Name doesn't exist in given headers list",
+		},
+		{
+			name:           "single column found",
+			headers:        []string{"A", "B", "C"},
+			columnNames:    []string{"A"},
+			expectedResult: []int{0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := GetHeaderIndicesByColumnNames(tc.headers, tc.columnNames)
+			if tc.expectedErrMsg != "" {
+				assert.Error(t, err)
+				assert.Equal(t, tc.expectedErrMsg, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedResult, result)
+			}
+		})
+	}
+}
+
+func TestExtractFolderIDFromURL(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		url            string
+		expectedID     string
+		expectedErrMsg string
+	}{
+		{
+			name:       "valid Google Drive folder URL",
+			url:        "https://drive.google.com/drive/folders/1AbCdEfGhIjKlMnOp",
+			expectedID: "1AbCdEfGhIjKlMnOp",
+		},
+		{
+			name:       "URL with trailing slash",
+			url:        "https://drive.google.com/drive/folders/1AbCdEfGhIjKlMnOp/",
+			expectedID: "",
+		},
+		{
+			name:       "simple path",
+			url:        "https://example.com/folderid123",
+			expectedID: "folderid123",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			id, err := extractFolderIDFromURL(tc.url)
+			if tc.expectedErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedID, id)
+			}
+		})
+	}
+}

--- a/internal/clientsholder/clientsholder_test.go
+++ b/internal/clientsholder/clientsholder_test.go
@@ -15,3 +15,163 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package clientsholder
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+func TestNewContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		namespace string
+		pod       string
+		container string
+	}{
+		{
+			name:      "valid inputs",
+			namespace: "test-ns",
+			pod:       "test-pod",
+			container: "test-container",
+		},
+		{
+			name:      "empty strings",
+			namespace: "",
+			pod:       "",
+			container: "",
+		},
+		{
+			name:      "namespace only",
+			namespace: "my-namespace",
+			pod:       "",
+			container: "",
+		},
+		{
+			name:      "special characters",
+			namespace: "ns-with-dashes",
+			pod:       "pod.with.dots",
+			container: "container_with_underscores",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := NewContext(tt.namespace, tt.pod, tt.container)
+			assert.Equal(t, tt.namespace, ctx.GetNamespace())
+			assert.Equal(t, tt.pod, ctx.GetPodName())
+			assert.Equal(t, tt.container, ctx.GetContainerName())
+		})
+	}
+}
+
+func TestGetClientTimeout(t *testing.T) {
+	tests := []struct {
+		name     string
+		envVal   string
+		setEnv   bool
+		expected time.Duration
+	}{
+		{
+			name:     "env var unset returns default",
+			setEnv:   false,
+			expected: DefaultTimeout,
+		},
+		{
+			name:     "valid duration 30s",
+			envVal:   "30s",
+			setEnv:   true,
+			expected: 30 * time.Second,
+		},
+		{
+			name:     "valid duration 2m",
+			envVal:   "2m",
+			setEnv:   true,
+			expected: 2 * time.Minute,
+		},
+		{
+			name:     "invalid duration falls back to default",
+			envVal:   "not-a-duration",
+			setEnv:   true,
+			expected: DefaultTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setEnv {
+				t.Setenv(clientTimeoutEnvVar, tt.envVal)
+			}
+			result := getClientTimeout()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetClientConfigFromRestConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		restConfig *rest.Config
+		wantHost   string
+		wantToken  string
+		wantCAFile string
+	}{
+		{
+			name: "config with host and token",
+			restConfig: &rest.Config{
+				Host:        "https://api.example.com:6443",
+				BearerToken: "my-token-123",
+			},
+			wantHost:  "https://api.example.com:6443",
+			wantToken: "my-token-123",
+		},
+		{
+			name: "config with cert data",
+			restConfig: &rest.Config{
+				Host: "https://api.cluster.local:6443",
+				TLSClientConfig: rest.TLSClientConfig{
+					CAFile: "/var/run/secrets/ca.crt",
+				},
+			},
+			wantHost:   "https://api.cluster.local:6443",
+			wantCAFile: "/var/run/secrets/ca.crt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			config := GetClientConfigFromRestConfig(tt.restConfig)
+
+			require.NotNil(t, config)
+			assert.Equal(t, "Config", config.Kind)
+			assert.Equal(t, "v1", config.APIVersion)
+			assert.Equal(t, defaultContext, config.CurrentContext)
+
+			cluster, ok := config.Clusters[defaultCluster]
+			require.True(t, ok)
+			assert.Equal(t, tt.wantHost, cluster.Server)
+
+			if tt.wantCAFile != "" {
+				assert.Equal(t, tt.wantCAFile, cluster.CertificateAuthority)
+			}
+
+			authInfo, ok := config.AuthInfos[defaultUser]
+			require.True(t, ok)
+			assert.Equal(t, tt.wantToken, authInfo.Token)
+
+			ctx, ok := config.Contexts[defaultContext]
+			require.True(t, ok)
+			assert.Equal(t, defaultCluster, ctx.Cluster)
+			assert.Equal(t, defaultUser, ctx.AuthInfo)
+		})
+	}
+}

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,1 +1,84 @@
 package log
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		input     string
+		expected  slog.Level
+		expectErr bool
+	}{
+		{
+			name:     "debug level",
+			input:    "debug",
+			expected: slog.LevelDebug,
+		},
+		{
+			name:     "info level",
+			input:    "info",
+			expected: slog.LevelInfo,
+		},
+		{
+			name:     "warn level",
+			input:    "warn",
+			expected: slog.LevelWarn,
+		},
+		{
+			name:     "warning level",
+			input:    "warning",
+			expected: slog.LevelWarn,
+		},
+		{
+			name:     "error level",
+			input:    "error",
+			expected: slog.LevelError,
+		},
+		{
+			name:     "fatal level",
+			input:    "fatal",
+			expected: CustomLevelFatal,
+		},
+		{
+			name:     "uppercase DEBUG",
+			input:    "DEBUG",
+			expected: slog.LevelDebug,
+		},
+		{
+			name:     "mixed case Info",
+			input:    "Info",
+			expected: slog.LevelInfo,
+		},
+		{
+			name:      "invalid level",
+			input:     "verbose",
+			expectErr: true,
+		},
+		{
+			name:      "empty string",
+			input:     "",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			level, err := parseLevel(tt.input)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, level)
+		})
+	}
+}

--- a/internal/results/rhconnect_test.go
+++ b/internal/results/rhconnect_test.go
@@ -1,2 +1,111 @@
 // Copyright (C) 2023-2026 Red Hat, Inc.
 package results
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateFormField(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		fieldName  string
+		fieldValue string
+	}{
+		{
+			name:       "valid field creation",
+			fieldName:  "type",
+			fieldValue: "RhocpBestPracticeTestResult",
+		},
+		{
+			name:       "field with numeric value",
+			fieldName:  "certId",
+			fieldValue: "12345",
+		},
+		{
+			name:       "empty value",
+			fieldName:  "description",
+			fieldValue: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var buf bytes.Buffer
+			writer := multipart.NewWriter(&buf)
+
+			err := createFormField(writer, tt.fieldName, tt.fieldValue)
+			require.NoError(t, err)
+
+			err = writer.Close()
+			require.NoError(t, err)
+
+			reader := multipart.NewReader(&buf, writer.Boundary())
+			form, err := reader.ReadForm(1 << 20)
+			require.NoError(t, err)
+
+			values, ok := form.Value[tt.fieldName]
+			require.True(t, ok)
+			require.Len(t, values, 1)
+			assert.Equal(t, tt.fieldValue, values[0])
+		})
+	}
+}
+
+func TestSetProxy(t *testing.T) {
+	tests := []struct {
+		name        string
+		proxyURL    string
+		proxyPort   string
+		expectProxy bool
+	}{
+		{
+			name:        "valid proxy URL and port",
+			proxyURL:    "http://proxy.example.com",
+			proxyPort:   "8080",
+			expectProxy: true,
+		},
+		{
+			name:        "empty URL skips proxy",
+			proxyURL:    "",
+			proxyPort:   "8080",
+			expectProxy: false,
+		},
+		{
+			name:        "empty port skips proxy",
+			proxyURL:    "http://proxy.example.com",
+			proxyPort:   "",
+			expectProxy: false,
+		},
+		{
+			name:        "both empty skips proxy",
+			proxyURL:    "",
+			proxyPort:   "",
+			expectProxy: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &http.Client{}
+			setProxy(client, tt.proxyURL, tt.proxyPort)
+
+			if tt.expectProxy {
+				require.NotNil(t, client.Transport)
+				transport, ok := client.Transport.(*http.Transport)
+				require.True(t, ok)
+				assert.NotNil(t, transport.Proxy)
+			} else {
+				assert.Nil(t, client.Transport)
+			}
+		})
+	}
+}

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -43,9 +43,11 @@ import (
 )
 
 const (
-	nodePort                  = "NodePort"
-	defaultServiceAccount     = "default"
-	clusterServiceVersionKind = "ClusterServiceVersion"
+	nodePort                                    = "NodePort"
+	defaultServiceAccount                       = "default"
+	clusterServiceVersionKind                   = "ClusterServiceVersion"
+	extensionAPIServerNamespace                 = "kube-system"
+	extensionAPIServerAuthReaderRoleBindingName = "extension-apiserver-authentication-reader"
 )
 
 var (
@@ -746,8 +748,8 @@ func isOwnedByOLM(put *provider.Pod) bool {
 // extension-apiserver-authentication-reader in kube-system for an OLM-managed pod.
 // See: https://kubernetes.io/docs/tasks/extend-kubernetes/setup-extension-api-server/
 func isAllowedExtensionAPIServerRoleBinding(rb *rbacv1.RoleBinding, put *provider.Pod) bool {
-	return rb.Namespace == "kube-system" &&
-		rb.RoleRef.Name == "extension-apiserver-authentication-reader" &&
+	return rb.Namespace == extensionAPIServerNamespace &&
+		rb.RoleRef.Name == extensionAPIServerAuthReaderRoleBindingName &&
 		isOwnedByOLM(put)
 }
 

--- a/tests/accesscontrol/suite_test.go
+++ b/tests/accesscontrol/suite_test.go
@@ -17,11 +17,16 @@
 package accesscontrol
 
 import (
+	"io"
 	"testing"
 
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -275,6 +280,401 @@ func Test_isOwnedByOLM(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := isOwnedByOLM(tt.pod)
 			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_checkForbiddenCapability(t *testing.T) {
+	log.SetupLogger(io.Discard, "INFO")
+
+	tests := []struct {
+		name                  string
+		containers            []*provider.Container
+		capability            string
+		wantCompliantCount    int
+		wantNonCompliantCount int
+	}{
+		{
+			name:                  "no containers",
+			containers:            []*provider.Container{},
+			capability:            "SYS_ADMIN",
+			wantCompliantCount:    0,
+			wantNonCompliantCount: 0,
+		},
+		{
+			name: "container with nil SecurityContext",
+			containers: []*provider.Container{
+				{
+					Container: &corev1.Container{
+						Name:            "test-container",
+						SecurityContext: nil,
+					},
+					Namespace: "test-ns",
+					Podname:   "test-pod",
+				},
+			},
+			capability:            "SYS_ADMIN",
+			wantCompliantCount:    1,
+			wantNonCompliantCount: 0,
+		},
+		{
+			name: "container with nil Capabilities",
+			containers: []*provider.Container{
+				{
+					Container: &corev1.Container{
+						Name: "test-container",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: nil,
+						},
+					},
+					Namespace: "test-ns",
+					Podname:   "test-pod",
+				},
+			},
+			capability:            "NET_ADMIN",
+			wantCompliantCount:    1,
+			wantNonCompliantCount: 0,
+		},
+		{
+			name: "container with forbidden capability",
+			containers: []*provider.Container{
+				{
+					Container: &corev1.Container{
+						Name: "test-container",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"SYS_ADMIN"},
+							},
+						},
+					},
+					Namespace: "test-ns",
+					Podname:   "test-pod",
+				},
+			},
+			capability:            "SYS_ADMIN",
+			wantCompliantCount:    0,
+			wantNonCompliantCount: 1,
+		},
+		{
+			name: "compliant container without forbidden capability",
+			containers: []*provider.Container{
+				{
+					Container: &corev1.Container{
+						Name: "test-container",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"NET_RAW"},
+							},
+						},
+					},
+					Namespace: "test-ns",
+					Podname:   "test-pod",
+				},
+			},
+			capability:            "SYS_ADMIN",
+			wantCompliantCount:    1,
+			wantNonCompliantCount: 0,
+		},
+		{
+			name: "multiple containers mixed compliance",
+			containers: []*provider.Container{
+				{
+					Container: &corev1.Container{
+						Name: "good-container",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"NET_RAW"},
+							},
+						},
+					},
+					Namespace: "test-ns",
+					Podname:   "test-pod",
+				},
+				{
+					Container: &corev1.Container{
+						Name: "bad-container",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"SYS_ADMIN"},
+							},
+						},
+					},
+					Namespace: "test-ns",
+					Podname:   "test-pod",
+				},
+			},
+			capability:            "SYS_ADMIN",
+			wantCompliantCount:    1,
+			wantNonCompliantCount: 1,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := log.GetLogger()
+			compliant, nonCompliant := checkForbiddenCapability(tt.containers, tt.capability, logger)
+			assert.Len(t, compliant, tt.wantCompliantCount)
+			assert.Len(t, nonCompliant, tt.wantNonCompliantCount)
+		})
+	}
+}
+
+func Test_isInstallModeMultiNamespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		installModes []v1alpha1.InstallMode
+		want         bool
+	}{
+		{
+			name:         "empty install modes",
+			installModes: []v1alpha1.InstallMode{},
+			want:         false,
+		},
+		{
+			name: "AllNamespaces supported",
+			installModes: []v1alpha1.InstallMode{
+				{Type: v1alpha1.InstallModeTypeOwnNamespace, Supported: true},
+				{Type: v1alpha1.InstallModeTypeAllNamespaces, Supported: true},
+			},
+			want: true,
+		},
+		{
+			name: "AllNamespaces not present",
+			installModes: []v1alpha1.InstallMode{
+				{Type: v1alpha1.InstallModeTypeOwnNamespace, Supported: true},
+				{Type: v1alpha1.InstallModeTypeSingleNamespace, Supported: true},
+			},
+			want: false,
+		},
+		{
+			name: "only MultiNamespace present",
+			installModes: []v1alpha1.InstallMode{
+				{Type: v1alpha1.InstallModeTypeMultiNamespace, Supported: true},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isInstallModeMultiNamespace(tt.installModes)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_isAllowedExtensionAPIServerRoleBinding(t *testing.T) {
+	t.Parallel()
+
+	olmPod := &provider.Pod{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "test-ns",
+				Labels: map[string]string{
+					"olm.owner": "test-operator.v1.0.0",
+				},
+			},
+		},
+	}
+	nonOLMPod := &provider.Pod{
+		Pod: &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "test-ns",
+				Labels:    map[string]string{"app": "my-app"},
+			},
+		},
+	}
+
+	tests := []struct {
+		name string
+		rb   *rbacv1.RoleBinding
+		pod  *provider.Pod
+		want bool
+	}{
+		{
+			name: "correct namespace and name with OLM pod",
+			rb: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "extension-apiserver-auth-reader",
+					Namespace: extensionAPIServerNamespace,
+				},
+				RoleRef: rbacv1.RoleRef{
+					Name: extensionAPIServerAuthReaderRoleBindingName,
+				},
+			},
+			pod:  olmPod,
+			want: true,
+		},
+		{
+			name: "wrong namespace",
+			rb: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "extension-apiserver-auth-reader",
+					Namespace: "default",
+				},
+				RoleRef: rbacv1.RoleRef{
+					Name: extensionAPIServerAuthReaderRoleBindingName,
+				},
+			},
+			pod:  olmPod,
+			want: false,
+		},
+		{
+			name: "wrong role name",
+			rb: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "some-role-binding",
+					Namespace: extensionAPIServerNamespace,
+				},
+				RoleRef: rbacv1.RoleRef{
+					Name: "some-other-role",
+				},
+			},
+			pod:  olmPod,
+			want: false,
+		},
+		{
+			name: "pod not OLM-managed",
+			rb: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "extension-apiserver-auth-reader",
+					Namespace: extensionAPIServerNamespace,
+				},
+				RoleRef: rbacv1.RoleRef{
+					Name: extensionAPIServerAuthReaderRoleBindingName,
+				},
+			},
+			pod:  nonOLMPod,
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAllowedExtensionAPIServerRoleBinding(tt.rb, tt.pod)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func Test_checkCrossNamespaceRoleBindingViolation(t *testing.T) {
+	log.SetupLogger(io.Discard, "INFO")
+
+	tests := []struct {
+		name          string
+		rb            *rbacv1.RoleBinding
+		pod           *provider.Pod
+		cnfNamespaces []string
+		wantViolation bool
+	}{
+		{
+			name: "subject in CNF namespace - allowed",
+			rb: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-rb",
+					Namespace: "cnf-ns",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "test-sa",
+						Namespace: "test-ns",
+					},
+				},
+			},
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+					},
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "test-sa",
+					},
+				},
+			},
+			cnfNamespaces: []string{"test-ns", "cnf-ns"},
+			wantViolation: false,
+		},
+		{
+			name: "extension API server exception for OLM pod",
+			rb: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "extension-apiserver-auth-reader",
+					Namespace: extensionAPIServerNamespace,
+				},
+				RoleRef: rbacv1.RoleRef{
+					Name: extensionAPIServerAuthReaderRoleBindingName,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "test-sa",
+						Namespace: "test-ns",
+					},
+				},
+			},
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels: map[string]string{
+							"olm.owner": "test-operator.v1.0.0",
+						},
+					},
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "test-sa",
+					},
+				},
+			},
+			cnfNamespaces: []string{"test-ns"},
+			wantViolation: false,
+		},
+		{
+			name: "cross-namespace violation detected",
+			rb: &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foreign-rb",
+					Namespace: "foreign-ns",
+				},
+				RoleRef: rbacv1.RoleRef{
+					Name: "some-role",
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      "test-sa",
+						Namespace: "test-ns",
+					},
+				},
+			},
+			pod: &provider.Pod{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: "test-ns",
+						Labels:    map[string]string{"app": "my-app"},
+					},
+					Spec: corev1.PodSpec{
+						ServiceAccountName: "test-sa",
+					},
+				},
+			},
+			cnfNamespaces: []string{"test-ns"},
+			wantViolation: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := checksdb.NewCheck("test-check", []string{})
+			result := checkCrossNamespaceRoleBindingViolation(tt.rb, tt.pod, tt.cnfNamespaces, check)
+			if tt.wantViolation {
+				assert.NotNil(t, result)
+			} else {
+				assert.Nil(t, result)
+			}
 		})
 	}
 }

--- a/tests/lifecycle/podsets/podsets_test.go
+++ b/tests/lifecycle/podsets/podsets_test.go
@@ -107,6 +107,80 @@ func TestIsStatefulSetReady(t *testing.T) {
 	}
 }
 
+func TestGetDeploymentsInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		deployments []*provider.Deployment
+		want        []string
+	}{
+		{
+			name: "normal list",
+			deployments: []*provider.Deployment{
+				{Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "dep1", Namespace: "ns1"}}},
+				{Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "dep2", Namespace: "ns2"}}},
+			},
+			want: []string{"ns1:dep1", "ns2:dep2"},
+		},
+		{
+			name:        "empty list",
+			deployments: []*provider.Deployment{},
+			want:        []string{},
+		},
+		{
+			name: "single entry",
+			deployments: []*provider.Deployment{
+				{Deployment: &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "only", Namespace: "default"}}},
+			},
+			want: []string{"default:only"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getDeploymentsInfo(tt.deployments)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestGetStatefulSetsInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		statefulSets []*provider.StatefulSet
+		want         []string
+	}{
+		{
+			name: "normal list",
+			statefulSets: []*provider.StatefulSet{
+				{StatefulSet: &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "sts1", Namespace: "ns1"}}},
+				{StatefulSet: &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "sts2", Namespace: "ns2"}}},
+			},
+			want: []string{"ns1:sts1", "ns2:sts2"},
+		},
+		{
+			name:         "empty list",
+			statefulSets: []*provider.StatefulSet{},
+			want:         []string{},
+		},
+		{
+			name: "single entry",
+			statefulSets: []*provider.StatefulSet{
+				{StatefulSet: &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "only", Namespace: "default"}}},
+			},
+			want: []string{"default:only"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getStatefulSetsInfo(tt.statefulSets)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestGetPodSetNodes(t *testing.T) {
 	type args struct {
 		pods    []*corev1.Pod

--- a/tests/lifecycle/suite_test.go
+++ b/tests/lifecycle/suite_test.go
@@ -25,72 +25,102 @@ import (
 
 func TestNameInDeploymentSkipList(t *testing.T) {
 	testCases := []struct {
+		name           string
 		testName       string
 		testNamespace  string
 		testList       []configuration.SkipScalingTestDeploymentsInfo
 		expectedOutput bool
 	}{
 		{
+			name:          "match found",
 			testName:      "test1",
 			testNamespace: "tnf",
 			testList: []configuration.SkipScalingTestDeploymentsInfo{
-				{
-					Name:      "test1",
-					Namespace: "tnf",
-				},
+				{Name: "test1", Namespace: "tnf"},
 			},
 			expectedOutput: true,
 		},
 		{
+			name:          "name matches but namespace does not",
+			testName:      "test1",
+			testNamespace: "other-ns",
+			testList: []configuration.SkipScalingTestDeploymentsInfo{
+				{Name: "test1", Namespace: "tnf"},
+			},
+			expectedOutput: false,
+		},
+		{
+			name:           "empty list",
+			testName:       "test1",
+			testNamespace:  "tnf",
+			testList:       []configuration.SkipScalingTestDeploymentsInfo{},
+			expectedOutput: false,
+		},
+		{
+			name:          "no match",
 			testName:      "test2",
 			testNamespace: "tnf",
 			testList: []configuration.SkipScalingTestDeploymentsInfo{
-				{
-					Name:      "test1",
-					Namespace: "tnf",
-				},
+				{Name: "test1", Namespace: "tnf"},
 			},
 			expectedOutput: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedOutput, nameInDeploymentSkipList(tc.testName, tc.testNamespace, tc.testList))
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, nameInDeploymentSkipList(tc.testName, tc.testNamespace, tc.testList))
+		})
 	}
 }
 
 func TestNameInStatefulSetSkipList(t *testing.T) {
 	testCases := []struct {
+		name           string
 		testName       string
 		testNamespace  string
 		testList       []configuration.SkipScalingTestStatefulSetsInfo
 		expectedOutput bool
 	}{
 		{
+			name:          "match found",
 			testName:      "test1",
 			testNamespace: "tnf",
 			testList: []configuration.SkipScalingTestStatefulSetsInfo{
-				{
-					Name:      "test1",
-					Namespace: "tnf",
-				},
+				{Name: "test1", Namespace: "tnf"},
 			},
 			expectedOutput: true,
 		},
 		{
+			name:          "name matches but namespace does not",
+			testName:      "test1",
+			testNamespace: "other-ns",
+			testList: []configuration.SkipScalingTestStatefulSetsInfo{
+				{Name: "test1", Namespace: "tnf"},
+			},
+			expectedOutput: false,
+		},
+		{
+			name:           "empty list",
+			testName:       "test1",
+			testNamespace:  "tnf",
+			testList:       []configuration.SkipScalingTestStatefulSetsInfo{},
+			expectedOutput: false,
+		},
+		{
+			name:          "no match",
 			testName:      "test2",
 			testNamespace: "tnf",
 			testList: []configuration.SkipScalingTestStatefulSetsInfo{
-				{
-					Name:      "test1",
-					Namespace: "tnf",
-				},
+				{Name: "test1", Namespace: "tnf"},
 			},
 			expectedOutput: false,
 		},
 	}
 
 	for _, tc := range testCases {
-		assert.Equal(t, tc.expectedOutput, nameInStatefulSetSkipList(tc.testName, tc.testNamespace, tc.testList))
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expectedOutput, nameInStatefulSetSkipList(tc.testName, tc.testNamespace, tc.testList))
+		})
 	}
 }

--- a/tests/observability/suite_test.go
+++ b/tests/observability/suite_test.go
@@ -20,8 +20,10 @@ import (
 	"testing"
 
 	apiserv1 "github.com/openshift/api/apiserver/v1"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -257,5 +259,55 @@ func TestEvaluateAPICompliance(t *testing.T) {
 		}
 
 		assert.True(t, valueFound)
+	}
+}
+
+func TestExtractUniqueServiceAccountNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		serviceAccounts []*corev1.ServiceAccount
+		want            map[string]struct{}
+	}{
+		{
+			name: "multiple unique names",
+			serviceAccounts: []*corev1.ServiceAccount{
+				{ObjectMeta: metav1.ObjectMeta{Name: "sa-1"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "sa-2"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "sa-3"}},
+			},
+			want: map[string]struct{}{
+				"sa-1": {},
+				"sa-2": {},
+				"sa-3": {},
+			},
+		},
+		{
+			name: "duplicate names",
+			serviceAccounts: []*corev1.ServiceAccount{
+				{ObjectMeta: metav1.ObjectMeta{Name: "sa-1", Namespace: "ns-a"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "sa-1", Namespace: "ns-b"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "sa-2"}},
+			},
+			want: map[string]struct{}{
+				"sa-1": {},
+				"sa-2": {},
+			},
+		},
+		{
+			name:            "empty slice",
+			serviceAccounts: []*corev1.ServiceAccount{},
+			want:            map[string]struct{}{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testEnv := &provider.TestEnvironment{
+				ServiceAccounts: tt.serviceAccounts,
+			}
+			got := extractUniqueServiceAccountNames(testEnv)
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }

--- a/tests/operator/helper_test.go
+++ b/tests/operator/helper_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -128,6 +129,198 @@ func TestOperatorInstalledMoreThanOnce(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert.Equal(t, tc.expectedOutput, OperatorInstalledMoreThanOnce(tc.testOp1, tc.testOp2))
+	}
+}
+
+func TestGetAllPodsBy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		namespace string
+		pods      []*provider.Pod
+		wantCount int
+	}{
+		{
+			name:      "matching namespace",
+			namespace: "ns-a",
+			pods: []*provider.Pod{
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns-a"}}},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns-a"}}},
+			},
+			wantCount: 2,
+		},
+		{
+			name:      "non-matching namespace",
+			namespace: "ns-b",
+			pods: []*provider.Pod{
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns-a"}}},
+			},
+			wantCount: 0,
+		},
+		{
+			name:      "empty list",
+			namespace: "ns-a",
+			pods:      []*provider.Pod{},
+			wantCount: 0,
+		},
+		{
+			name:      "mixed namespaces",
+			namespace: "ns-a",
+			pods: []*provider.Pod{
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod1", Namespace: "ns-a"}}},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod2", Namespace: "ns-b"}}},
+				{Pod: &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod3", Namespace: "ns-a"}}},
+			},
+			wantCount: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getAllPodsBy(tt.namespace, tt.pods)
+			assert.Len(t, got, tt.wantCount)
+			for _, p := range got {
+				assert.Equal(t, tt.namespace, p.Namespace)
+			}
+		})
+	}
+}
+
+func TestGetCsvsBy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		namespace string
+		csvs      []*v1alpha1.ClusterServiceVersion
+		wantCount int
+	}{
+		{
+			name:      "matching namespace",
+			namespace: "ns-a",
+			csvs: []*v1alpha1.ClusterServiceVersion{
+				{ObjectMeta: metav1.ObjectMeta{Name: "csv1", Namespace: "ns-a"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "csv2", Namespace: "ns-a"}},
+			},
+			wantCount: 2,
+		},
+		{
+			name:      "non-matching namespace",
+			namespace: "ns-b",
+			csvs: []*v1alpha1.ClusterServiceVersion{
+				{ObjectMeta: metav1.ObjectMeta{Name: "csv1", Namespace: "ns-a"}},
+			},
+			wantCount: 0,
+		},
+		{
+			name:      "empty list",
+			namespace: "ns-a",
+			csvs:      []*v1alpha1.ClusterServiceVersion{},
+			wantCount: 0,
+		},
+		{
+			name:      "mixed namespaces",
+			namespace: "ns-a",
+			csvs: []*v1alpha1.ClusterServiceVersion{
+				{ObjectMeta: metav1.ObjectMeta{Name: "csv1", Namespace: "ns-a"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "csv2", Namespace: "ns-b"}},
+				{ObjectMeta: metav1.ObjectMeta{Name: "csv3", Namespace: "ns-a"}},
+			},
+			wantCount: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getCsvsBy(tt.namespace, tt.csvs)
+			assert.Len(t, got, tt.wantCount)
+			for _, csv := range got {
+				assert.Equal(t, tt.namespace, csv.Namespace)
+			}
+		})
+	}
+}
+
+func TestIsSingleNamespacedOperator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		operatorNamespace string
+		targetNamespaces  []string
+		want              bool
+	}{
+		{
+			name:              "single target different from operator namespace",
+			operatorNamespace: "operator-ns",
+			targetNamespaces:  []string{"target-ns"},
+			want:              true,
+		},
+		{
+			name:              "single target same as operator namespace",
+			operatorNamespace: "operator-ns",
+			targetNamespaces:  []string{"operator-ns"},
+			want:              false,
+		},
+		{
+			name:              "multiple targets",
+			operatorNamespace: "operator-ns",
+			targetNamespaces:  []string{"ns-a", "ns-b"},
+			want:              false,
+		},
+		{
+			name:              "empty targets",
+			operatorNamespace: "operator-ns",
+			targetNamespaces:  []string{},
+			want:              false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isSingleNamespacedOperator(tt.operatorNamespace, tt.targetNamespaces)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestIsMultiNamespacedOperator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		operatorNamespace string
+		targetNamespaces  []string
+		want              bool
+	}{
+		{
+			name:              "multiple targets not including operator namespace",
+			operatorNamespace: "operator-ns",
+			targetNamespaces:  []string{"ns-a", "ns-b"},
+			want:              true,
+		},
+		{
+			name:              "multiple targets including operator namespace",
+			operatorNamespace: "operator-ns",
+			targetNamespaces:  []string{"ns-a", "operator-ns"},
+			want:              false,
+		},
+		{
+			name:              "single target",
+			operatorNamespace: "operator-ns",
+			targetNamespaces:  []string{"ns-a"},
+			want:              false,
+		},
+		{
+			name:              "empty targets",
+			operatorNamespace: "operator-ns",
+			targetNamespaces:  []string{},
+			want:              false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isMultiNamespacedOperator(tt.operatorNamespace, tt.targetNamespaces)
+			assert.Equal(t, tt.want, got)
+		})
 	}
 }
 

--- a/webserver/webserver_test.go
+++ b/webserver/webserver_test.go
@@ -4,10 +4,11 @@ package webserver
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	yaml "gopkg.in/yaml.v3"
-
+	"github.com/redhat-best-practices-for-k8s/certsuite-claim/pkg/claim"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/configuration"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestUpdateTnfManagedDeploymentsAndStatefulsets(t *testing.T) {
@@ -77,6 +78,149 @@ func TestUpdateTnfManagedDeploymentsAndStatefulsets(t *testing.T) {
 
 			assert.Equal(t, tc.expectedManagedDeployments, result.ManagedDeployments)
 			assert.Equal(t, tc.expectedManagedStatefulsets, result.ManagedStatefulsets)
+		})
+	}
+}
+
+func TestToJSONString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    map[string]string
+		expected string
+	}{
+		{
+			name: "valid map",
+			input: map[string]string{
+				"key1": "value1",
+			},
+			expected: "{\n  \"key1\": \"value1\"\n}",
+		},
+		{
+			name:     "empty map",
+			input:    map[string]string{},
+			expected: "{}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := toJSONString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestGetSuitesFromIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    []claim.Identifier
+		expected []string
+	}{
+		{
+			name: "multiple identifiers with duplicate suites",
+			input: []claim.Identifier{
+				{Id: "test-1", Suite: "networking"},
+				{Id: "test-2", Suite: "networking"},
+				{Id: "test-3", Suite: "lifecycle"},
+			},
+			expected: []string{"networking", "lifecycle"},
+		},
+		{
+			name: "single identifier",
+			input: []claim.Identifier{
+				{Id: "test-1", Suite: "operator"},
+			},
+			expected: []string{"operator"},
+		},
+		{
+			name:     "empty input",
+			input:    []claim.Identifier{},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := GetSuitesFromIdentifiers(tt.input)
+			assert.ElementsMatch(t, tt.expected, result)
+		})
+	}
+}
+
+func TestCreatePrintableCatalogFromIdentifiers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		input          []claim.Identifier
+		expectedSuites []string
+		expectedCounts map[string]int
+	}{
+		{
+			name: "multiple suites",
+			input: []claim.Identifier{
+				{Id: "net-test-1", Suite: "networking"},
+				{Id: "net-test-2", Suite: "networking"},
+				{Id: "life-test-1", Suite: "lifecycle"},
+			},
+			expectedSuites: []string{"networking", "lifecycle"},
+			expectedCounts: map[string]int{
+				"networking": 2,
+				"lifecycle":  1,
+			},
+		},
+		{
+			name: "single suite",
+			input: []claim.Identifier{
+				{Id: "op-test-1", Suite: "operator"},
+			},
+			expectedSuites: []string{"operator"},
+			expectedCounts: map[string]int{
+				"operator": 1,
+			},
+		},
+		{
+			name:           "empty input",
+			input:          []claim.Identifier{},
+			expectedSuites: nil,
+			expectedCounts: map[string]int{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := CreatePrintableCatalogFromIdentifiers(tt.input)
+
+			require.NotNil(t, result)
+
+			for _, suite := range tt.expectedSuites {
+				entries, ok := result[suite]
+				assert.True(t, ok)
+				assert.Len(t, entries, tt.expectedCounts[suite])
+			}
+
+			for suite, count := range tt.expectedCounts {
+				assert.Len(t, result[suite], count)
+			}
+
+			for _, id := range tt.input {
+				entries := result[id.Suite]
+				found := false
+				for _, e := range entries {
+					if e.testName == id.Id && e.identifier == id {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Add 167 new unit test cases (791 total, up from 624) covering previously untested pure functions across 16 packages
- Create 5 new test files for packages that had zero test coverage (`check/results`, `claim/show/csv`, `generate/config`, `info`, `upload/results_spreadsheet`)
- Extend 11 existing test files with new coverage for untested functions
- Extract extension API server string literals into named constants to satisfy goconst linter

### Packages covered

| Area | Functions Tested |
|------|-----------------|
| tests/accesscontrol | capability checks, OLM ownership, install mode, cross-namespace violations |
| tests/operator | pod/CSV namespace filtering, single/multi namespace classification |
| tests/lifecycle | deployment/statefulset skip lists, podset info formatting |
| tests/observability | service account name extraction |
| internal/log | log level parsing |
| internal/clientsholder | context creation, client timeout, config transformation |
| internal/results | form field creation, proxy configuration |
| webserver | JSON formatting, suite extraction, catalog generation |
| cmd/check/results | log parsing, YAML template handling |
| cmd/generate/config | CRD filter, namespace, deployment/statefulset config loading |
| cmd/claim/show/csv | catalog-by-ID building |
| cmd/pkg/claim | claim file parsing |
| cmd/upload/results_spreadsheet | record preparation, header indexing, URL parsing |
| cmd/info | test description lookup |

## Test plan

- [x] `go test ./...` — 791 tests pass, 0 failures
- [x] `make lint` — golangci-lint reports 0 issues
- [x] All new tests use table-driven subtests with `t.Parallel()` where safe
- [x] No tests require cluster access — all exercise pure functions with in-memory data