### PR TITLE
feat: add forbidden capability checks for SYS_MODULE, DAC_OVERRIDE, and DAC_READ_SEARCH

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -7,13 +7,13 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 
 ## Test cases summary
 
-### Total test cases: 121
+### Total test cases: 124
 
 ### Total suites: 10
 
 |Suite|Tests per suite|Link|
 |---|---|---|
-|access-control|28|[access-control](#access-control)|
+|access-control|31|[access-control](#access-control)|
 |affiliated-certification|4|[affiliated-certification](#affiliated-certification)|
 |lifecycle|19|[lifecycle](#lifecycle)|
 |manageability|2|[manageability](#manageability)|
@@ -36,11 +36,11 @@ Depending on the workload type, not all tests are required to pass to satisfy be
 |---|---|---|
 |8|1|
 
-### Non-Telco specific tests only: 52
+### Non-Telco specific tests only: 55
 
 |Mandatory|Optional|
 |---|---|---|
-|43|9|
+|46|9|
 
 ### Telco specific tests only: 28
 
@@ -121,6 +121,40 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Far-Edge|Optional|
 |Non-Telco|Optional|
 |Telco|Optional|
+
+#### access-control-dac-override-capability-check
+
+|Property|Description|
+|---|---|
+|Unique ID|access-control-dac-override-capability-check|
+|Description|Ensures that containers do not use DAC_OVERRIDE capability. DAC_OVERRIDE bypasses file permission checks and usually indicates incorrect file ownership in the container image.|
+|Suggested Remediation|Remove the DAC_OVERRIDE capability from the container/pod definitions. Fix file ownership in the container image (for example, chown the application files to the non-root runtime UID in the Dockerfile) instead of bypassing permission checks.|
+|Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-linux-capabilities|
+|Exception Process|No exceptions|
+|Impact Statement|DAC_OVERRIDE capability bypasses file permission checks and typically indicates incorrect image file ownership; it can enable unauthorized file access and privilege escalation.|
+|Tags|common,access-control|
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Mandatory|
+|Far-Edge|Mandatory|
+|Non-Telco|Mandatory|
+|Telco|Mandatory|
+
+#### access-control-dac-read-search-capability-check
+
+|Property|Description|
+|---|---|
+|Unique ID|access-control-dac-read-search-capability-check|
+|Description|Ensures that containers do not use DAC_READ_SEARCH capability. DAC_READ_SEARCH enables open_by_handle_at()-style access and is a known container escape risk.|
+|Suggested Remediation|Remove the DAC_READ_SEARCH capability from the container/pod definitions. Containers must not use this capability due to container escape risk. If the application needs to read files it does not own, fix file ownership or permissions in the Dockerfile instead of granting this capability.|
+|Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-linux-capabilities|
+|Exception Process|No exceptions|
+|Impact Statement|DAC_READ_SEARCH capability enables open_by_handle_at()-style access and is a known container escape vector that can compromise host isolation.|
+|Tags|common,access-control|
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Mandatory|
+|Far-Edge|Mandatory|
+|Non-Telco|Mandatory|
+|Telco|Mandatory|
 
 #### access-control-ipc-lock-capability-check
 
@@ -489,6 +523,23 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-avoid-sys_admin|
 |Exception Process|No exceptions|
 |Impact Statement|SYS_ADMIN capability provides extensive privileges that can compromise container isolation, enable host system access, and create serious security vulnerabilities.|
+|Tags|common,access-control|
+|**Scenario**|**Optional/Mandatory**|
+|Extended|Mandatory|
+|Far-Edge|Mandatory|
+|Non-Telco|Mandatory|
+|Telco|Mandatory|
+
+#### access-control-sys-module-capability-check
+
+|Property|Description|
+|---|---|
+|Unique ID|access-control-sys-module-capability-check|
+|Description|Ensures that containers do not use SYS_MODULE capability. SYS_MODULE allows loading kernel modules from a container and creates a host/cluster takeover risk.|
+|Suggested Remediation|Remove the SYS_MODULE capability from the container/pod definitions. Containers must not load kernel modules. If kernel modules are needed, they should be loaded on the host via a MachineConfig or at node provisioning time.|
+|Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-linux-capabilities|
+|Exception Process|No exceptions|
+|Impact Statement|SYS_MODULE capability allows loading kernel modules from a container, which can compromise the host kernel and enable cluster-wide takeover.|
 |Tags|common,access-control|
 |**Scenario**|**Optional/Mandatory**|
 |Extended|Mandatory|

--- a/expected_results.yaml
+++ b/expected_results.yaml
@@ -4,6 +4,8 @@ testCases:
     - access-control-cluster-role-bindings
     - access-control-container-host-port
     - access-control-crd-roles
+    - access-control-dac-override-capability-check
+    - access-control-dac-read-search-capability-check
     - access-control-ipc-lock-capability-check
     - access-control-namespace
     - access-control-namespace-resource-quota
@@ -26,6 +28,7 @@ testCases:
     - access-control-service-type
     - access-control-ssh-daemons
     - access-control-sys-admin-capability-check
+    - access-control-sys-module-capability-check
     - lifecycle-affinity-required-pods
     - lifecycle-container-prestop
     - lifecycle-container-poststart

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -93,6 +93,27 @@ func LoadChecks() {
 			return nil
 		}))
 
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestSysModuleIdentifier)).
+		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env)).
+		WithCheckFn(func(c *checksdb.Check) error {
+			testSysModuleCapability(c, &env)
+			return nil
+		}))
+
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestDacOverrideIdentifier)).
+		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env)).
+		WithCheckFn(func(c *checksdb.Check) error {
+			testDacOverrideCapability(c, &env)
+			return nil
+		}))
+
+	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestDacReadSearchIdentifier)).
+		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env)).
+		WithCheckFn(func(c *checksdb.Check) error {
+			testDacReadSearchCapability(c, &env)
+			return nil
+		}))
+
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestNetAdminIdentifier)).
 		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env)).
 		WithCheckFn(func(c *checksdb.Check) error {
@@ -325,6 +346,21 @@ func checkForbiddenCapability(containers []*provider.Container, capability strin
 
 func testSysAdminCapability(check *checksdb.Check, env *provider.TestEnvironment) {
 	compliantObjects, nonCompliantObjects := checkForbiddenCapability(env.Containers, "SYS_ADMIN", check.GetLogger())
+	check.SetResult(compliantObjects, nonCompliantObjects)
+}
+
+func testSysModuleCapability(check *checksdb.Check, env *provider.TestEnvironment) {
+	compliantObjects, nonCompliantObjects := checkForbiddenCapability(env.Containers, "SYS_MODULE", check.GetLogger())
+	check.SetResult(compliantObjects, nonCompliantObjects)
+}
+
+func testDacOverrideCapability(check *checksdb.Check, env *provider.TestEnvironment) {
+	compliantObjects, nonCompliantObjects := checkForbiddenCapability(env.Containers, "DAC_OVERRIDE", check.GetLogger())
+	check.SetResult(compliantObjects, nonCompliantObjects)
+}
+
+func testDacReadSearchCapability(check *checksdb.Check, env *provider.TestEnvironment) {
+	compliantObjects, nonCompliantObjects := checkForbiddenCapability(env.Containers, "DAC_READ_SEARCH", check.GetLogger())
 	check.SetResult(compliantObjects, nonCompliantObjects)
 }
 

--- a/tests/accesscontrol/suite_test.go
+++ b/tests/accesscontrol/suite_test.go
@@ -407,6 +407,66 @@ func Test_checkForbiddenCapability(t *testing.T) {
 			wantCompliantCount:    1,
 			wantNonCompliantCount: 1,
 		},
+		{
+			name: "container with SYS_MODULE is non-compliant",
+			containers: []*provider.Container{
+				{
+					Container: &corev1.Container{
+						Name: "test-container",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"SYS_MODULE"},
+							},
+						},
+					},
+					Namespace: "test-ns",
+					Podname:   "test-pod",
+				},
+			},
+			capability:            "SYS_MODULE",
+			wantCompliantCount:    0,
+			wantNonCompliantCount: 1,
+		},
+		{
+			name: "container with DAC_OVERRIDE is non-compliant",
+			containers: []*provider.Container{
+				{
+					Container: &corev1.Container{
+						Name: "test-container",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"DAC_OVERRIDE"},
+							},
+						},
+					},
+					Namespace: "test-ns",
+					Podname:   "test-pod",
+				},
+			},
+			capability:            "DAC_OVERRIDE",
+			wantCompliantCount:    0,
+			wantNonCompliantCount: 1,
+		},
+		{
+			name: "container with DAC_READ_SEARCH is non-compliant",
+			containers: []*provider.Container{
+				{
+					Container: &corev1.Container{
+						Name: "test-container",
+						SecurityContext: &corev1.SecurityContext{
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{"DAC_READ_SEARCH"},
+							},
+						},
+					},
+					Namespace: "test-ns",
+					Podname:   "test-pod",
+				},
+			},
+			capability:            "DAC_READ_SEARCH",
+			wantCompliantCount:    0,
+			wantNonCompliantCount: 1,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/tests/identifiers/accesscontrol.go
+++ b/tests/identifiers/accesscontrol.go
@@ -36,6 +36,8 @@ var (
 	TestBpfIdentifier                                 claim.Identifier
 	TestContainerHostPort                             claim.Identifier
 	TestCrdRoleIdentifier                             claim.Identifier
+	TestDacOverrideIdentifier                         claim.Identifier
+	TestDacReadSearchIdentifier                       claim.Identifier
 	TestIpcLockIdentifier                             claim.Identifier
 	TestNamespaceBestPracticesIdentifier              claim.Identifier
 	TestNamespaceResourceQuotaIdentifier              claim.Identifier
@@ -59,6 +61,7 @@ var (
 	TestSecContextIdentifier                          claim.Identifier
 	TestServicesDoNotUseNodeportsIdentifier           claim.Identifier
 	TestSysAdminIdentifier                            claim.Identifier
+	TestSysModuleIdentifier                           claim.Identifier
 	TestSysPtraceCapabilityIdentifier                 claim.Identifier
 )
 
@@ -127,6 +130,39 @@ func init() {
 			Extended: Mandatory,
 		},
 		TagExtended)
+
+	TestDacOverrideIdentifier = AddCatalogEntry(
+		"dac-override-capability-check",
+		common.AccessControlTestKey,
+		`Ensures that containers do not use DAC_OVERRIDE capability. DAC_OVERRIDE bypasses file permission checks and usually indicates incorrect file ownership in the container image.`,
+		DacOverrideCapabilityRemediation,
+		NoExceptions,
+		TestDacOverrideIdentifierDocLink,
+		true,
+		map[string]string{
+			FarEdge:  Mandatory,
+			Telco:    Mandatory,
+			NonTelco: Mandatory,
+			Extended: Mandatory,
+		},
+		TagCommon)
+
+	TestDacReadSearchIdentifier = AddCatalogEntry(
+		"dac-read-search-capability-check",
+		common.AccessControlTestKey,
+		`Ensures that containers do not use DAC_READ_SEARCH capability. DAC_READ_SEARCH enables open_by_handle_at()-style access and is a known container escape risk.`,
+		DacReadSearchCapabilityRemediation,
+		NoExceptions,
+		TestDacReadSearchIdentifierDocLink,
+		true,
+		map[string]string{
+			FarEdge:  Mandatory,
+			Telco:    Mandatory,
+			NonTelco: Mandatory,
+			Extended: Mandatory,
+		},
+		TagCommon)
+
 	TestIpcLockIdentifier = AddCatalogEntry(
 		"ipc-lock-capability-check",
 		common.AccessControlTestKey,
@@ -488,6 +524,22 @@ tag. (2) It does not have any of the following prefixes: default, openshift-, is
 		SecConRemediation+" Containers should not use the SYS_ADMIN Linux capability.",
 		NoExceptions,
 		TestSysAdminIdentifierDocLink,
+		true,
+		map[string]string{
+			FarEdge:  Mandatory,
+			Telco:    Mandatory,
+			NonTelco: Mandatory,
+			Extended: Mandatory,
+		},
+		TagCommon)
+
+	TestSysModuleIdentifier = AddCatalogEntry(
+		"sys-module-capability-check",
+		common.AccessControlTestKey,
+		`Ensures that containers do not use SYS_MODULE capability. SYS_MODULE allows loading kernel modules from a container and creates a host/cluster takeover risk.`,
+		SysModuleCapabilityRemediation,
+		NoExceptions,
+		TestSysModuleIdentifierDocLink,
 		true,
 		map[string]string{
 			FarEdge:  Mandatory,

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -26,6 +26,9 @@ const (
 	Test1337UIDIdentifierDocLink                             = NoDocLinkExtended
 	TestNetAdminIdentifierDocLink                            = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-net_admin"
 	TestSysAdminIdentifierDocLink                            = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-avoid-sys_admin"
+	TestSysModuleIdentifierDocLink                           = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-linux-capabilities"
+	TestDacOverrideIdentifierDocLink                         = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-linux-capabilities"
+	TestDacReadSearchIdentifierDocLink                       = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-linux-capabilities"
 	TestIpcLockIdentifierDocLink                             = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-ipc_lock"
 	TestNetRawIdentifierDocLink                              = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-user-plane-cnfs"
 	TestBpfIdentifierDocLink                                 = NoDocLinkTelco

--- a/tests/identifiers/impact.go
+++ b/tests/identifiers/impact.go
@@ -42,6 +42,9 @@ const (
 	Test1337UIDIdentifierImpact                             = `UID 1337 is reserved for use by Istio service mesh components; using it for applications can cause conflicts with Istio sidecars and break service mesh functionality.`
 	TestNetAdminIdentifierImpact                            = `NET_ADMIN capability allows network configuration changes that can compromise cluster networking, enable privilege escalation, and bypass network security controls.`
 	TestSysAdminIdentifierImpact                            = `SYS_ADMIN capability provides extensive privileges that can compromise container isolation, enable host system access, and create serious security vulnerabilities.`
+	TestSysModuleIdentifierImpact                           = `SYS_MODULE capability allows loading kernel modules from a container, which can compromise the host kernel and enable cluster-wide takeover.`
+	TestDacOverrideIdentifierImpact                         = `DAC_OVERRIDE capability bypasses file permission checks and typically indicates incorrect image file ownership; it can enable unauthorized file access and privilege escalation.`
+	TestDacReadSearchIdentifierImpact                       = `DAC_READ_SEARCH capability enables open_by_handle_at()-style access and is a known container escape vector that can compromise host isolation.`
 	TestIpcLockIdentifierImpact                             = `IPC_LOCK capability can be exploited to lock system memory, potentially causing denial of service and affecting other workloads on the same node.`
 	TestNetRawIdentifierImpact                              = `NET_RAW capability enables packet manipulation and network sniffing, which can be used for attacks against other workloads and compromise network security.`
 	TestBpfIdentifierImpact                                 = `BPF capability allows kernel-level programming that can bypass security controls, monitor other processes, and potentially compromise the entire host system.`
@@ -185,6 +188,9 @@ var ImpactMap = map[string]string{
 	"access-control-no-1337-uid":                                 Test1337UIDIdentifierImpact,
 	"access-control-net-admin-capability-check":                  TestNetAdminIdentifierImpact,
 	"access-control-sys-admin-capability-check":                  TestSysAdminIdentifierImpact,
+	"access-control-sys-module-capability-check":                 TestSysModuleIdentifierImpact,
+	"access-control-dac-override-capability-check":               TestDacOverrideIdentifierImpact,
+	"access-control-dac-read-search-capability-check":            TestDacReadSearchIdentifierImpact,
 	"access-control-ipc-lock-capability-check":                   TestIpcLockIdentifierImpact,
 	"access-control-net-raw-capability-check":                    TestNetRawIdentifierImpact,
 	"access-control-bpf-capability-check":                        TestBpfIdentifierImpact,

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -45,6 +45,12 @@ const (
 
 	BpfCapabilityRemediation = `Remove the following capability from the container/pod definitions: BPF`
 
+	SysModuleCapabilityRemediation = `Remove the SYS_MODULE capability from the container/pod definitions. Containers must not load kernel modules.`
+
+	DacOverrideCapabilityRemediation = `Remove the DAC_OVERRIDE capability from the container/pod definitions. Fix file ownership in the container image (for example, chown the application files to the non-root runtime UID in the Dockerfile) instead of bypassing permission checks.`
+
+	DacReadSearchCapabilityRemediation = `Remove the DAC_READ_SEARCH capability from the container/pod definitions. Containers must not use this capability due to container escape risk.`
+
 	SecConPrivilegeRemediation = `Configure privilege escalation to false. Privileged escalation should not be allowed (AllowPrivilegeEscalation=false).`
 
 	SecConReadOnlyFilesystem = `Ensure that the pods have the read-only root filesystem setting enabled.`

--- a/tests/identifiers/remediation.go
+++ b/tests/identifiers/remediation.go
@@ -45,11 +45,11 @@ const (
 
 	BpfCapabilityRemediation = `Remove the following capability from the container/pod definitions: BPF`
 
-	SysModuleCapabilityRemediation = `Remove the SYS_MODULE capability from the container/pod definitions. Containers must not load kernel modules.`
+	SysModuleCapabilityRemediation = `Remove the SYS_MODULE capability from the container/pod definitions. Containers must not load kernel modules. If kernel modules are needed, they should be loaded on the host via a MachineConfig or at node provisioning time.`
 
 	DacOverrideCapabilityRemediation = `Remove the DAC_OVERRIDE capability from the container/pod definitions. Fix file ownership in the container image (for example, chown the application files to the non-root runtime UID in the Dockerfile) instead of bypassing permission checks.`
 
-	DacReadSearchCapabilityRemediation = `Remove the DAC_READ_SEARCH capability from the container/pod definitions. Containers must not use this capability due to container escape risk.`
+	DacReadSearchCapabilityRemediation = `Remove the DAC_READ_SEARCH capability from the container/pod definitions. Containers must not use this capability due to container escape risk. If the application needs to read files it does not own, fix file ownership or permissions in the Dockerfile instead of granting this capability.`
 
 	SecConPrivilegeRemediation = `Configure privilege escalation to false. Privileged escalation should not be allowed (AllowPrivilegeEscalation=false).`
 


### PR DESCRIPTION
## Summary
- Add three access-control tests that fail when containers request `SYS_MODULE`, `DAC_OVERRIDE`, or `DAC_READ_SEARCH`
- Reuse existing `checkForbiddenCapability()` helper (same pattern as `SYS_ADMIN`)
- Catalog, remediation, impact, expected results, and unit tests updated
- Fixes #3807

## Test plan
- [x] `go test ./tests/accesscontrol/ ./tests/identifiers/`
- [x] `make build-catalog-md` regenerated `CATALOG.md`
- [ ] CI green on PR
- [ ] Spot-check a workload that adds `DAC_OVERRIDE` fails the new check


Made with [Cursor](https://cursor.com)