### PR TITLE
feat: group CLI flags by category in certsuite run help

### DIFF
--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -5,7 +5,11 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"strings"
+	"text/template"
 	"time"
+
+	flag "github.com/spf13/pflag"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/certsuite"
@@ -16,48 +20,104 @@ import (
 
 const timeoutFlagDefaultvalue = 24 * time.Hour
 
+type flagGroup struct {
+	Name    string
+	FlagSet *flag.FlagSet
+}
+
 var (
 	runCmd = &cobra.Command{
 		Use:   "run",
 		Short: "Run the Red Hat Best Practices Test Suite for Kubernetes",
 		RunE:  runTestSuite,
 	}
+
+	groups []flagGroup
 )
 
 func NewCommand() *cobra.Command {
-	runCmd.PersistentFlags().StringP("output-dir", "o", "results", "The directory where the output artifacts will be placed")
-	runCmd.PersistentFlags().StringP("label-filter", "l", "none", "Label expression to filter test cases  (e.g. --label-filter 'access-control && !access-control-sys-admin-capability')")
-	runCmd.PersistentFlags().String("timeout", timeoutFlagDefaultvalue.String(), "Time allowed for the test suite execution to complete (e.g. --timeout 30m  or -timeout 1h30m)")
-	runCmd.PersistentFlags().StringP("config-file", "c", "config/certsuite_config.yml", "The certsuite configuration file")
-	runCmd.PersistentFlags().StringP("kubeconfig", "k", "", "The target cluster's Kubeconfig file")
-	runCmd.PersistentFlags().Bool("server-mode", false, "Run the certsuite in web server mode")
-	runCmd.PersistentFlags().Bool("omit-artifacts-zip-file", false, "Prevents the creation of a zip file with the result artifacts")
-	runCmd.PersistentFlags().String("log-level", "debug", "Sets the log level")
-	runCmd.PersistentFlags().String("offline-db", "", "Set the location of an offline DB to check the certification status of for container images, operators and helm charts")
-	runCmd.PersistentFlags().String("preflight-dockerconfig", "", "Set the dockerconfig file to be used by the Preflight test suite")
-	runCmd.PersistentFlags().Bool("intrusive", true, "Run intrusive tests that may disrupt the test environment")
-	runCmd.PersistentFlags().Bool("allow-preflight-insecure", false, "Allow insecure connections in the Preflight test suite")
-	runCmd.PersistentFlags().Bool("include-web-files", false, "Save web files in the configured output folder")
-	runCmd.PersistentFlags().Bool("enable-data-collection", false, "Allow sending test results to an external data collector")
-	runCmd.PersistentFlags().Bool("create-xml-junit-file", false, "Create a JUnit file with the test results")
-	runCmd.PersistentFlags().String("certsuite-probe-image", "quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.41", "Certsuite probe image")
-	runCmd.PersistentFlags().String("daemonset-cpu-req", "100m", "CPU request for the probe daemonset container")
-	runCmd.PersistentFlags().String("daemonset-cpu-lim", "100m", "CPU limit for the probe daemonset container")
-	runCmd.PersistentFlags().String("daemonset-mem-req", "100M", "Memory request for the probe daemonset container")
-	runCmd.PersistentFlags().String("daemonset-mem-lim", "100M", "Memory limit for the probe daemonset container")
-	runCmd.PersistentFlags().Bool("sanitize-claim", false, "Sanitize the claim.json file before sending it to the collector")
-	// Include non-Running pods during autodiscovery when enabled (default false)
-	runCmd.PersistentFlags().Bool("allow-non-running", false, "Include non-Running pods during autodiscovery phase")
-	runCmd.PersistentFlags().String("connect-api-key", "", "API Key for Red Hat Connect portal")
-	runCmd.PersistentFlags().String("connect-project-id", "", "Project ID for Red Hat Connect portal")
-	runCmd.PersistentFlags().String("connect-api-base-url", "", "Base URL for Red Hat Connect API")
-	runCmd.PersistentFlags().String("connect-api-proxy-url", "", "Proxy URL for Red Hat Connect API")
-	runCmd.PersistentFlags().String("connect-api-proxy-port", "", "Proxy port for Red Hat Connect API")
-	runCmd.PersistentFlags().Bool("cleanup-probe", true, "Delete the probe daemonset at the end of the test run")
-	runCmd.PersistentFlags().Bool("require-probe", false, "Abort the test run if the probe daemonset fails to deploy")
+	commonFlags := flag.NewFlagSet("common", flag.ContinueOnError)
+	commonFlags.StringP("config-file", "c", "config/certsuite_config.yml", "The certsuite configuration file")
+	commonFlags.StringP("label-filter", "l", "none", "Label expression to filter test cases  (e.g. --label-filter 'access-control && !access-control-sys-admin-capability')")
+	commonFlags.StringP("output-dir", "o", "results", "The directory where the output artifacts will be placed")
+	commonFlags.StringP("kubeconfig", "k", "", "The target cluster's Kubeconfig file")
+	commonFlags.String("timeout", timeoutFlagDefaultvalue.String(), "Time allowed for the test suite execution to complete (e.g. --timeout 30m  or -timeout 1h30m)")
+	commonFlags.String("log-level", "debug", "Sets the log level")
+	commonFlags.Bool("intrusive", true, "Run intrusive tests that may disrupt the test environment")
+
+	behaviorFlags := flag.NewFlagSet("behavior", flag.ContinueOnError)
+	behaviorFlags.Bool("allow-non-running", false, "Include non-Running pods during autodiscovery phase")
+	behaviorFlags.Bool("server-mode", false, "Run the certsuite in web server mode")
+
+	outputFlags := flag.NewFlagSet("output", flag.ContinueOnError)
+	outputFlags.Bool("omit-artifacts-zip-file", false, "Prevents the creation of a zip file with the result artifacts")
+	outputFlags.Bool("include-web-files", false, "Save web files in the configured output folder")
+	outputFlags.Bool("create-xml-junit-file", false, "Create a JUnit file with the test results")
+	outputFlags.Bool("sanitize-claim", false, "Sanitize the claim.json file before sending it to the collector")
+
+	probeFlags := flag.NewFlagSet("probe", flag.ContinueOnError)
+	probeFlags.String("certsuite-probe-image", "quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.41", "Certsuite probe image")
+	probeFlags.String("daemonset-cpu-req", "100m", "CPU request for the probe daemonset container")
+	probeFlags.String("daemonset-cpu-lim", "100m", "CPU limit for the probe daemonset container")
+	probeFlags.String("daemonset-mem-req", "100M", "Memory request for the probe daemonset container")
+	probeFlags.String("daemonset-mem-lim", "100M", "Memory limit for the probe daemonset container")
+	probeFlags.Bool("cleanup-probe", true, "Delete the probe daemonset at the end of the test run")
+	probeFlags.Bool("require-probe", false, "Abort the test run if the probe daemonset fails to deploy")
+
+	preflightFlags := flag.NewFlagSet("preflight", flag.ContinueOnError)
+	preflightFlags.String("preflight-dockerconfig", "", "Set the dockerconfig file to be used by the Preflight test suite")
+	preflightFlags.Bool("allow-preflight-insecure", false, "Allow insecure connections in the Preflight test suite")
+	preflightFlags.String("offline-db", "", "Set the location of an offline DB to check the certification status of for container images, operators and helm charts")
+
+	connectFlags := flag.NewFlagSet("connect", flag.ContinueOnError)
+	connectFlags.Bool("enable-data-collection", false, "Allow sending test results to an external data collector")
+	connectFlags.String("connect-api-key", "", "API Key for Red Hat Connect portal")
+	connectFlags.String("connect-project-id", "", "Project ID for Red Hat Connect portal")
+	connectFlags.String("connect-api-base-url", "", "Base URL for Red Hat Connect API")
+	connectFlags.String("connect-api-proxy-url", "", "Proxy URL for Red Hat Connect API")
+	connectFlags.String("connect-api-proxy-port", "", "Proxy port for Red Hat Connect API")
+
+	groups = []flagGroup{
+		{Name: "Common", FlagSet: commonFlags},
+		{Name: "Test Behavior", FlagSet: behaviorFlags},
+		{Name: "Output & Artifact", FlagSet: outputFlags},
+		{Name: "Probe DaemonSet", FlagSet: probeFlags},
+		{Name: "Preflight", FlagSet: preflightFlags},
+		{Name: "Red Hat Connect", FlagSet: connectFlags},
+	}
+
+	for _, g := range groups {
+		runCmd.PersistentFlags().AddFlagSet(g.FlagSet)
+	}
+
+	runCmd.SetUsageFunc(groupedUsageFunc)
 
 	return runCmd
 }
+
+func groupedUsageFunc(cmd *cobra.Command) error {
+	t := template.Must(template.New("usage").Funcs(template.FuncMap{
+		"trimTrailingWhitespaces": func(s string) string {
+			return strings.TrimRight(s, " \t\n")
+		},
+	}).Parse(groupedUsageTemplate))
+	return t.Execute(cmd.OutOrStderr(), struct {
+		Cmd    *cobra.Command
+		Groups []flagGroup
+	}{Cmd: cmd, Groups: groups})
+}
+
+const groupedUsageTemplate = `Usage:
+  {{.Cmd.UseLine}}
+{{range .Groups}}
+{{.Name}} Flags:
+{{.FlagSet.FlagUsages | trimTrailingWhitespaces}}
+{{end}}{{if .Cmd.HasAvailableInheritedFlags}}
+Global Flags:
+{{.Cmd.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}
+{{end}}
+Use "{{.Cmd.CommandPath}} [command] --help" for more information about a command.
+`
 
 type flagReader struct {
 	cmd *cobra.Command

--- a/docs/test-run.md
+++ b/docs/test-run.md
@@ -72,9 +72,13 @@ certsuite run --intrusive=true
 
 Intrusive tests are enabled by default.
 
-## Selected flags description
+## Flag reference
 
-The following is a non-exhaustive list of the most common flags that the `certsuite run` command accepts. To see the complete list use the `-h, --help` flag.
+The `certsuite run` command organizes its flags into groups. To see the complete list use the `-h, --help` flag.
+
+### Common flags
+
+* `-c, --config-file`: Path to the `certsuite_config.yml` file.
 
 * `-l, --label-filter`: Label expression to filter test cases. Can be a test suite or list or test suites, such as `"observability,access-control"` or a more complex expression with logical operators such as `"access-control && !access-control-sys-admin-capability"`.
 
@@ -86,37 +90,35 @@ The following is a non-exhaustive list of the most common flags that the `certsu
 
 * `-k, --kubeconfig`: Path to the Kubeconfig file of the target cluster.
 
-* `-c, --config-file`: Path to the `certsuite_config.yml` file.
+* `--timeout`: Time allowed for the test suite execution to complete (e.g. `--timeout 30m` or `--timeout 1h30m`). Defaults to `24h`.
 
-* `--preflight-dockerconfig`: Path to the Dockerconfig file to be used by the Preflight test suite
+* `--log-level`: Sets the log level. Defaults to `debug`.
 
-* `--offline-db`: Path to an offline DB to check the certification status of container images, operators and helm charts. Defaults to the DB included in the test container image.
+* `--intrusive`: Run intrusive tests that may disrupt the test environment. Enabled by default. Set to `--intrusive=false` to skip intrusive tests.
 
-!!! note
-
-    See the [OCT tool](https://github.com/redhat-best-practices-for-k8s/oct) for more information on how to create this DB.
+### Test behavior flags
 
 * `--allow-non-running`: Include non-Running pods during the autodiscovery phase. Disabled by default; enable this if your workloads include pods in CrashLoopBackOff or other non-running states that still need testing.
 
-* `--sanitize-claim`: Sanitize the claim.json file by removing sensitive data before sending it to the collector. Only relevant when `--enable-data-collection` is enabled.
+* `--server-mode`: Run the certsuite in web server mode.
+
+### Output & artifact flags
+
+* `--omit-artifacts-zip-file`: Prevents the creation of a zip file with the result artifacts.
 
 * `--include-web-files`: Save the HTML results viewer files in the configured output folder alongside the claim.json and log files.
 
 * `--create-xml-junit-file`: Generate a JUnit XML file with the test results, useful for CI/CD integration with systems that consume JUnit reports.
+
+* `--sanitize-claim`: Sanitize the claim.json file by removing sensitive data before sending it to the collector. Only relevant when `--enable-data-collection` is enabled.
+
+### Probe daemonset flags
 
 * `--certsuite-probe-image`: Override the default certsuite probe daemonset image. Defaults to the version matching the certsuite release.
 
 * `--daemonset-cpu-req`, `--daemonset-cpu-lim`: Set the CPU request and limit for the probe daemonset container. Both default to `100m`.
 
 * `--daemonset-mem-req`, `--daemonset-mem-lim`: Set the memory request and limit for the probe daemonset container. Both default to `100M`.
-
-* `--connect-api-key`: API key for uploading results to the Red Hat Connect portal.
-
-* `--connect-project-id`: Project ID for uploading results to the Red Hat Connect portal.
-
-* `--connect-api-base-url`: Base URL for the Red Hat Connect API.
-
-* `--connect-api-proxy-url`, `--connect-api-proxy-port`: Proxy URL and port for the Red Hat Connect API, for environments that require HTTP proxies.
 
 * `--cleanup-probe`: Controls whether the probe daemonset and its namespace are deleted at the end of the test run. By default (true), the probe daemonset is cleaned up after tests complete. Set to `--cleanup-probe=false` to keep the probe daemonset running on the cluster for debugging or repeated test runs.
 
@@ -138,6 +140,32 @@ docker run --rm --network host \
   --label-filter=all \
   --cleanup-probe=false
 ```
+
+* `--require-probe`: Abort the test run if the probe daemonset fails to deploy. Disabled by default.
+
+### Preflight flags
+
+* `--preflight-dockerconfig`: Path to the Dockerconfig file to be used by the Preflight test suite.
+
+* `--allow-preflight-insecure`: Allow insecure connections in the Preflight test suite.
+
+* `--offline-db`: Path to an offline DB to check the certification status of container images, operators and helm charts. Defaults to the DB included in the test container image.
+
+!!! note
+
+    See the [OCT tool](https://github.com/redhat-best-practices-for-k8s/oct) for more information on how to create this DB.
+
+### Red Hat Connect flags
+
+* `--enable-data-collection`: Allow sending test results to an external data collector.
+
+* `--connect-api-key`: API key for uploading results to the Red Hat Connect portal.
+
+* `--connect-project-id`: Project ID for uploading results to the Red Hat Connect portal.
+
+* `--connect-api-base-url`: Base URL for the Red Hat Connect API.
+
+* `--connect-api-proxy-url`, `--connect-api-proxy-port`: Proxy URL and port for the Red Hat Connect API, for environments that require HTTP proxies.
 
 ## Using the container image
 


### PR DESCRIPTION
## Summary

- Organizes the 28 flags of `certsuite run` into 6 logical groups (Common, Test Behavior, Output & Artifact, Probe DaemonSet, Preflight, Red Hat Connect) using separate `pflag.FlagSet` instances and a custom usage template
- Updates `docs/test-run.md` to mirror the grouped structure with matching subsection headers

## Why

The flat alphabetical list of 28 flags made `--help` output hard to scan. Essential flags like `-c`, `-l`, `-o`, and `-k` were buried among rarely-used ones like `--daemonset-mem-lim` and `--connect-api-proxy-port`. Grouping makes the help output scannable and self-documenting.

## Changes

- **`cmd/certsuite/run/run.go`**: Create named `pflag.FlagSet` per group, add them via `AddFlagSet()`, and render with a custom `SetUsageFunc` template
- **`docs/test-run.md`**: Reorganize "Selected flags description" into grouped `###` subsections matching the CLI output

## Help output after this change

```
Run the Red Hat Best Practices Test Suite for Kubernetes

Usage:
  certsuite run [flags]

Common Flags:
  -c, --config-file string    The certsuite configuration file (default "config/certsuite_config.yml")
      --intrusive             Run intrusive tests that may disrupt the test environment (default true)
  -k, --kubeconfig string     The target cluster's Kubeconfig file
  -l, --label-filter string   Label expression to filter test cases  (e.g. --label-filter 'access-control && !access-control-sys-admin-capability') (default "none")
      --log-level string      Sets the log level (default "debug")
  -o, --output-dir string     The directory where the output artifacts will be placed (default "results")
      --timeout string        Time allowed for the test suite execution to complete (e.g. --timeout 30m  or -timeout 1h30m) (default "24h0m0s")

Test Behavior Flags:
      --allow-non-running   Include non-Running pods during autodiscovery phase
      --server-mode         Run the certsuite in web server mode

Output & Artifact Flags:
      --create-xml-junit-file     Create a JUnit file with the test results
      --include-web-files         Save web files in the configured output folder
      --omit-artifacts-zip-file   Prevents the creation of a zip file with the result artifacts
      --sanitize-claim            Sanitize the claim.json file before sending it to the collector

Probe DaemonSet Flags:
      --certsuite-probe-image string   Certsuite probe image (default "quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.41")
      --cleanup-probe                  Delete the probe daemonset at the end of the test run (default true)
      --daemonset-cpu-lim string       CPU limit for the probe daemonset container (default "100m")
      --daemonset-cpu-req string       CPU request for the probe daemonset container (default "100m")
      --daemonset-mem-lim string       Memory limit for the probe daemonset container (default "100M")
      --daemonset-mem-req string       Memory request for the probe daemonset container (default "100M")
      --require-probe                  Abort the test run if the probe daemonset fails to deploy

Preflight Flags:
      --allow-preflight-insecure        Allow insecure connections in the Preflight test suite
      --offline-db string               Set the location of an offline DB to check the certification status of for container images, operators and helm charts
      --preflight-dockerconfig string   Set the dockerconfig file to be used by the Preflight test suite

Red Hat Connect Flags:
      --connect-api-base-url string     Base URL for Red Hat Connect API
      --connect-api-key string          API Key for Red Hat Connect portal
      --connect-api-proxy-port string   Proxy port for Red Hat Connect API
      --connect-api-proxy-url string    Proxy URL for Red Hat Connect API
      --connect-project-id string       Project ID for Red Hat Connect portal
      --enable-data-collection          Allow sending test results to an external data collector

Use "certsuite run [command] --help" for more information about a command.
```

## Test plan

- [x] `make build` succeeds
- [x] `make test` passes
- [x] `./certsuite run --help` shows all 28 flags grouped under 6 headers
- [x] `make lint` — no new issues (2 pre-existing typos on main)