### PR TITLE
POC: Replace N+1 API calls with single List in pod and operator discovery

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,5 +1,6 @@
 [default.extend-words]
 iif = "iif"
+ITMS = "ITMS"
 odf = "odf"
 ono = "ono"
 

--- a/pkg/autodiscover/autodiscover.go
+++ b/pkg/autodiscover/autodiscover.go
@@ -128,6 +128,15 @@ type labelObject struct {
 	LabelValue string
 }
 
+func matchesAnyLabel(resourceLabels map[string]string, selectors []labelObject) bool {
+	for _, l := range selectors {
+		if resourceLabels[l.LabelKey] == l.LabelValue {
+			return true
+		}
+	}
+	return false
+}
+
 var data = DiscoveredTestData{}
 
 const labelRegexMatches = 3

--- a/pkg/autodiscover/autodiscover_operators.go
+++ b/pkg/autodiscover/autodiscover_operators.go
@@ -69,19 +69,20 @@ func isIstioServiceMeshInstalled(appClient appv1client.AppsV1Interface, allNs []
 }
 
 func findOperatorsMatchingAtLeastOneLabel(olmClient v1alpha1.OperatorsV1alpha1Interface, labels []labelObject, namespace configuration.Namespace) *olmv1Alpha.ClusterServiceVersionList {
-	csvList := &olmv1Alpha.ClusterServiceVersionList{}
-	for _, l := range labels {
-		log.Debug("Searching CSVs in namespace %q with label %q", namespace, l)
-		csv, err := olmClient.ClusterServiceVersions(namespace.Name).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: l.LabelKey + "=" + l.LabelValue,
-		})
-		if err != nil {
-			log.Error("Error when listing csvs in namespace %q with label %q, err: %v", namespace, l.LabelKey+"="+l.LabelValue, err)
-			continue
-		}
-		csvList.Items = append(csvList.Items, csv.Items...)
+	log.Debug("Searching CSVs in namespace %q with labels %v", namespace, labels)
+	allCSVs, err := olmClient.ClusterServiceVersions(namespace.Name).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		log.Error("Error when listing csvs in namespace %q, err: %v", namespace, err)
+		return &olmv1Alpha.ClusterServiceVersionList{}
 	}
-	return csvList
+
+	matched := &olmv1Alpha.ClusterServiceVersionList{}
+	for i := range allCSVs.Items {
+		if matchesAnyLabel(allCSVs.Items[i].Labels, labels) {
+			matched.Items = append(matched.Items, allCSVs.Items[i])
+		}
+	}
+	return matched
 }
 
 func findOperatorsByLabels(olmClient v1alpha1.OperatorsV1alpha1Interface, labels []labelObject, namespaces []configuration.Namespace) (csvs []*olmv1Alpha.ClusterServiceVersion) {

--- a/pkg/autodiscover/autodiscover_operators_test.go
+++ b/pkg/autodiscover/autodiscover_operators_test.go
@@ -313,6 +313,58 @@ func TestFindOperatorsMatchingAtLeastOneLabel(t *testing.T) {
 	}
 }
 
+func TestFindOperatorsMatchingAtLeastOneLabelSkipsNilLabels(t *testing.T) {
+	csv := &olmv1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-labels-csv",
+			Namespace: "default",
+		},
+	}
+
+	client := fakeolmv1alpha1.NewSimpleClientset(csv)
+	labels := []labelObject{{LabelKey: "key", LabelValue: "value"}}
+	result := findOperatorsMatchingAtLeastOneLabel(client.OperatorsV1alpha1(), labels, configuration.Namespace{Name: "default"})
+	assert.Empty(t, result.Items, "CSV with nil labels must not match any label query")
+}
+
+func TestFindOperatorsMatchingAtLeastOneLabelNonMatchingLabels(t *testing.T) {
+	csv := &olmv1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "wrong-label-csv",
+			Namespace: "default",
+			Labels:    map[string]string{"key": "other"},
+		},
+	}
+
+	client := fakeolmv1alpha1.NewSimpleClientset(csv)
+	labels := []labelObject{{LabelKey: "key", LabelValue: "value"}}
+	result := findOperatorsMatchingAtLeastOneLabel(client.OperatorsV1alpha1(), labels, configuration.Namespace{Name: "default"})
+	assert.Empty(t, result.Items, "CSV with non-matching labels must not be returned")
+}
+
+func TestFindOperatorsMatchingMultipleLabelsNoDuplicates(t *testing.T) {
+	csv := &olmv1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multi-label-csv",
+			Namespace: "default",
+			Labels: map[string]string{
+				"app":  "operator",
+				"role": "operator",
+			},
+		},
+	}
+
+	client := fakeolmv1alpha1.NewSimpleClientset(csv)
+	labels := []labelObject{
+		{LabelKey: "app", LabelValue: "operator"},
+		{LabelKey: "role", LabelValue: "operator"},
+	}
+
+	result := findOperatorsMatchingAtLeastOneLabel(client.OperatorsV1alpha1(), labels, configuration.Namespace{Name: "default"})
+	assert.Len(t, result.Items, 1, "CSV matching multiple labels must appear exactly once")
+	assert.Equal(t, "multi-label-csv", result.Items[0].Name)
+}
+
 func TestFindOperatorsByLabels(t *testing.T) {
 	generateClusterServiceVersion := func(name, namespace string) *olmv1alpha1.ClusterServiceVersion {
 		return &olmv1alpha1.ClusterServiceVersion{

--- a/pkg/autodiscover/autodiscover_pods.go
+++ b/pkg/autodiscover/autodiscover_pods.go
@@ -27,19 +27,20 @@ import (
 )
 
 func findPodsMatchingAtLeastOneLabel(oc corev1client.CoreV1Interface, labels []labelObject, namespace string) *corev1.PodList {
-	allPods := &corev1.PodList{}
-	for _, l := range labels {
-		log.Debug("Searching Pods in namespace %s with label %q", namespace, l)
-		pods, err := oc.Pods(namespace).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: l.LabelKey + "=" + l.LabelValue,
-		})
-		if err != nil {
-			log.Error("Error when listing pods in ns=%s label=%s, err: %v", namespace, l.LabelKey+"="+l.LabelValue, err)
-			continue
-		}
-		allPods.Items = append(allPods.Items, pods.Items...)
+	log.Debug("Searching Pods in namespace %s with labels %v", namespace, labels)
+	allPods, err := oc.Pods(namespace).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		log.Error("Error when listing pods in ns=%s, err: %v", namespace, err)
+		return &corev1.PodList{}
 	}
-	return allPods
+
+	matched := &corev1.PodList{}
+	for i := range allPods.Items {
+		if matchesAnyLabel(allPods.Items[i].Labels, labels) {
+			matched.Items = append(matched.Items, allPods.Items[i])
+		}
+	}
+	return matched
 }
 
 func FindPodsByLabels(oc corev1client.CoreV1Interface, labels []labelObject, namespaces []string) (runningPods, allPods []corev1.Pod) {

--- a/pkg/autodiscover/autodiscover_pods_test.go
+++ b/pkg/autodiscover/autodiscover_pods_test.go
@@ -95,3 +95,47 @@ func TestFindPodsUnderTest(t *testing.T) {
 		assert.Equal(t, tc.expectedResults, podResult)
 	}
 }
+
+func TestFindPodsByLabelsSkipsPodsWithNilLabels(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "no-labels-pod",
+			Namespace: "test-ns",
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	oc := clientsholder.GetTestClientsHolder([]runtime.Object{pod})
+	labels := []labelObject{{LabelKey: "app", LabelValue: "target"}}
+
+	result, _ := FindPodsByLabels(oc.K8sClient.CoreV1(), labels, []string{"test-ns"})
+	assert.Empty(t, result, "pod with nil labels must not match any label query")
+}
+
+func TestFindPodsMatchingMultipleLabelsNoDuplicates(t *testing.T) {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multi-label-pod",
+			Namespace: "test-ns",
+			Labels: map[string]string{
+				"app":  "target",
+				"role": "target",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+
+	oc := clientsholder.GetTestClientsHolder([]runtime.Object{pod})
+	labels := []labelObject{
+		{LabelKey: "app", LabelValue: "target"},
+		{LabelKey: "role", LabelValue: "target"},
+	}
+
+	result, _ := FindPodsByLabels(oc.K8sClient.CoreV1(), labels, []string{"test-ns"})
+	assert.Len(t, result, 1, "pod matching multiple labels must appear exactly once")
+	assert.Equal(t, "multi-label-pod", result[0].Name)
+}

--- a/pkg/autodiscover/autodiscover_podset.go
+++ b/pkg/autodiscover/autodiscover_podset.go
@@ -30,34 +30,6 @@ import (
 	"k8s.io/client-go/scale"
 )
 
-// isMatchingAtLeastOneLabel is a generic helper that checks if a controller's pod template
-// matches at least one of the provided labels.
-func isMatchingAtLeastOneLabel[T any](
-	labels []labelObject,
-	namespace string,
-	item *T,
-	resourceType string,
-	getLabelsFn func(*T) map[string]string,
-	getNameFn func(*T) string,
-) bool {
-	name := getNameFn(item)
-	templateLabels := getLabelsFn(item)
-
-	for _, labelObj := range labels {
-		log.Debug("Searching pods in %s %q found in ns %q using label %s=%s",
-			resourceType, name, namespace, labelObj.LabelKey, labelObj.LabelValue)
-
-		if templateLabels[labelObj.LabelKey] == labelObj.LabelValue {
-			log.Info("%s %s found in ns=%s", resourceType, name, namespace)
-			return true
-		}
-	}
-	return false
-}
-
-// findControllersByLabels is a generic implementation for finding pod controllers by labels.
-// It works with any Kubernetes resource type (Deployment, StatefulSet, DaemonSet, etc.) by using
-// accessor functions to extract the necessary fields.
 func findControllersByLabels[T any](
 	appClient appv1client.AppsV1Interface,
 	labels []labelObject,
@@ -82,12 +54,11 @@ func findControllersByLabels[T any](
 
 		for i := range items {
 			if len(labels) > 0 {
-				// The resource is added only once if at least one pod matches one label
-				if isMatchingAtLeastOneLabel(labels, ns, &items[i], resourceType, getLabelsFn, getNameFn) {
+				if matchesAnyLabel(getLabelsFn(&items[i]), labels) {
+					log.Info("%s %s found in ns=%s", resourceType, getNameFn(&items[i]), ns)
 					allResults = append(allResults, items[i])
 				}
 			} else {
-				// If labels are not provided, all resources in the namespaces under test are included
 				name := getNameFn(&items[i])
 				log.Debug("Searching pods in %s %q found in ns %q without label", resourceType, name, ns)
 				allResults = append(allResults, items[i])

--- a/pkg/autodiscover/autodiscover_test.go
+++ b/pkg/autodiscover/autodiscover_test.go
@@ -57,6 +57,52 @@ func TestCreateLabels(t *testing.T) {
 	}
 }
 
+func TestMatchesAnyLabel(t *testing.T) {
+	tests := []struct {
+		name           string
+		resourceLabels map[string]string
+		selectors      []labelObject
+		want           bool
+	}{
+		{
+			name:           "match first selector",
+			resourceLabels: map[string]string{"app": "target"},
+			selectors:      []labelObject{{LabelKey: "app", LabelValue: "target"}},
+			want:           true,
+		},
+		{
+			name:           "match second selector",
+			resourceLabels: map[string]string{"role": "worker"},
+			selectors:      []labelObject{{LabelKey: "app", LabelValue: "target"}, {LabelKey: "role", LabelValue: "worker"}},
+			want:           true,
+		},
+		{
+			name:           "no match",
+			resourceLabels: map[string]string{"app": "other"},
+			selectors:      []labelObject{{LabelKey: "app", LabelValue: "target"}},
+			want:           false,
+		},
+		{
+			name:           "nil labels map",
+			resourceLabels: nil,
+			selectors:      []labelObject{{LabelKey: "app", LabelValue: "target"}},
+			want:           false,
+		},
+		{
+			name:           "empty selectors",
+			resourceLabels: map[string]string{"app": "target"},
+			selectors:      []labelObject{},
+			want:           false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, matchesAnyLabel(tt.resourceLabels, tt.selectors))
+		})
+	}
+}
+
 func TestNamespacesListToStringList(t *testing.T) {
 	testCases := []struct {
 		testList       []configuration.Namespace

--- a/pkg/provider/pods.go
+++ b/pkg/provider/pods.go
@@ -234,7 +234,7 @@ func (p *Pod) IsRuntimeClassNameSpecified() bool {
 // the names only. It's a custom and simplified version of:
 // https://github.com/k8snetworkplumbingwg/multus-cni/blob/e692127d19623c8bdfc4d391224ea542658b584c/pkg/k8sclient/k8sclient.go#L185
 //
-// The cncf netwoks annotation has two different formats:
+// The cncf networks annotation has two different formats:
 //
 //	  a) list of network names: k8s.v1.cni.cncf.io/networks: <network>[,<network>,...]
 //	  b) json array of network objects:


### PR DESCRIPTION
## Summary

- Replace per-label Kubernetes API calls in `findPodsMatchingAtLeastOneLabel` and `findOperatorsMatchingAtLeastOneLabel` with a single `List` per namespace followed by in-memory filtering
- Extract shared `matchesAnyLabel` predicate to eliminate triple duplication of label-matching logic across pods, operators, and podset files
- Inline the now-trivial `isMatchingAtLeastOneLabel` generic wrapper (was 6 parameters for a one-liner)
- Fix latent duplicate bug where resources matching multiple query labels appeared multiple times

## Test plan

- [x] `matchesAnyLabel` unit tests: match first/second selector, no match, nil labels, empty selectors
- [x] Pod dedup test: pod matching multiple labels appears exactly once
- [x] Pod nil-labels test: pod with nil labels is not matched
- [x] Operator dedup test: CSV matching multiple labels appears exactly once
- [x] Operator nil-labels test: CSV with nil labels is not matched
- [x] Operator non-matching labels test: CSV with wrong label values is not matched
- [x] All 50 autodiscover tests pass
- [x] `make lint` passes clean