### PR TITLE
ci: increase CRC workflow default job timeout to 300 minutes

### DIFF
--- a/.github/workflows/_qe-ocp-crc.yaml
+++ b/.github/workflows/_qe-ocp-crc.yaml
@@ -23,7 +23,7 @@ on:
         description: 'Job-level timeout in minutes'
         required: false
         type: number
-        default: 240
+        default: 300
       test-timeout:
         description: 'Per-test retry timeout in minutes'
         required: false


### PR DESCRIPTION
## Summary

- CRC-based nightly runs (OCP 4.18-4.22) intermittently fail when the ~5.7 GiB CRC bundle cache misses on GitHub-hosted runners
- The full download + extraction + cluster boot can consume 30-60 minutes, leaving insufficient headroom within the 240-minute default for test execution
- Bumps the default job-timeout from 240 to 300 minutes (matching what intrusive workflows already use) to accommodate cold-cache scenarios
- Non-intrusive CRC workflows that rely on the default automatically pick up the increase; intrusive workflows already pass job-timeout: 300 explicitly so they are unaffected

## Test plan

- [ ] Monitor CRC-based nightlies (4.18-4.22) for 2-3 nights after merge
- [ ] Verify that previously-failing jobs (especially platformalteration4-ocp on 4.22) now pass when cache misses occur