### PR TITLE
Add structured error types to replace string-matching anti-patterns

### DIFF
--- a/internal/clientsholder/command.go
+++ b/internal/clientsholder/command.go
@@ -19,7 +19,6 @@ package clientsholder
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -63,7 +62,7 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 
 	exec, err := remotecommand.NewSPDYExecutor(clientsholder.RestConfig, "POST", req.URL())
 	if err != nil {
-		return stdout, stderr, fmt.Errorf("failed to create SPDY executor for command %q: %w", command, err)
+		return stdout, stderr, newExecError(command, ctx.GetNamespace(), ctx.GetPodName(), err)
 	}
 	// enforce an execution timeout for the remote command
 	goCtx, cancel := context.WithTimeout(context.TODO(), ExecCommandTimeout)
@@ -75,7 +74,7 @@ func (clientsholder *ClientsHolder) ExecCommandContainer(
 	})
 	stdout, stderr = buffOut.String(), buffErr.String()
 	if err != nil {
-		return stdout, stderr, fmt.Errorf("failed to execute command %q in %s/%s: %w", command, ctx.GetNamespace(), ctx.GetPodName(), err)
+		return stdout, stderr, newExecError(command, ctx.GetNamespace(), ctx.GetPodName(), err)
 	}
 	return stdout, stderr, nil
 }

--- a/internal/clientsholder/errors.go
+++ b/internal/clientsholder/errors.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2020-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package clientsholder
+
+import (
+	"errors"
+	"fmt"
+
+	k8sexec "k8s.io/client-go/util/exec"
+)
+
+type ExecError struct {
+	Command   string
+	Namespace string
+	PodName   string
+	ExitCode  int
+	Err       error
+}
+
+func (e *ExecError) Error() string {
+	if e.ExitCode >= 0 {
+		return fmt.Sprintf("failed to execute command %q in %s/%s (exit code %d): %s",
+			e.Command, e.Namespace, e.PodName, e.ExitCode, e.Err)
+	}
+	return fmt.Sprintf("failed to execute command %q in %s/%s: %s",
+		e.Command, e.Namespace, e.PodName, e.Err)
+}
+
+func (e *ExecError) Unwrap() error {
+	return e.Err
+}
+
+func (e *ExecError) HasExitCode(code int) bool {
+	return e.ExitCode == code
+}
+
+func newExecError(command, namespace, podName string, err error) *ExecError {
+	exitCode := -1
+	var codeErr k8sexec.CodeExitError
+	if errors.As(err, &codeErr) {
+		exitCode = codeErr.Code
+	}
+	return &ExecError{
+		Command:   command,
+		Namespace: namespace,
+		PodName:   podName,
+		ExitCode:  exitCode,
+		Err:       err,
+	}
+}

--- a/internal/clientsholder/errors_test.go
+++ b/internal/clientsholder/errors_test.go
@@ -1,0 +1,129 @@
+// Copyright (C) 2020-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package clientsholder
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8sexec "k8s.io/client-go/util/exec"
+)
+
+func TestExecErrorMessage(t *testing.T) {
+	t.Run("with exit code", func(t *testing.T) {
+		e := &ExecError{
+			Command:   "ls /tmp",
+			Namespace: "test-ns",
+			PodName:   "test-pod",
+			ExitCode:  125,
+			Err:       errors.New("container not running"),
+		}
+		assert.Contains(t, e.Error(), "exit code 125")
+		assert.Contains(t, e.Error(), "ls /tmp")
+		assert.Contains(t, e.Error(), "test-ns/test-pod")
+	})
+
+	t.Run("with exit code zero", func(t *testing.T) {
+		e := &ExecError{
+			Command:   "true",
+			Namespace: "ns",
+			PodName:   "pod",
+			ExitCode:  0,
+			Err:       errors.New("stream error"),
+		}
+		assert.Contains(t, e.Error(), "exit code 0")
+	})
+
+	t.Run("without exit code", func(t *testing.T) {
+		e := &ExecError{
+			Command:   "ls /tmp",
+			Namespace: "test-ns",
+			PodName:   "test-pod",
+			ExitCode:  -1,
+			Err:       errors.New("connection refused"),
+		}
+		assert.NotContains(t, e.Error(), "exit code")
+		assert.Contains(t, e.Error(), "connection refused")
+	})
+
+	t.Run("with nil error", func(t *testing.T) {
+		e := &ExecError{
+			Command:   "test",
+			Namespace: "ns",
+			PodName:   "pod",
+			ExitCode:  -1,
+			Err:       nil,
+		}
+		assert.Contains(t, e.Error(), "test")
+		assert.Nil(t, e.Unwrap())
+	})
+}
+
+func TestExecErrorHasExitCode(t *testing.T) {
+	e := &ExecError{ExitCode: 125}
+	assert.True(t, e.HasExitCode(125))
+	assert.False(t, e.HasExitCode(1))
+	assert.False(t, e.HasExitCode(-1))
+}
+
+func TestExecErrorUnwrap(t *testing.T) {
+	inner := errors.New("inner error")
+	e := &ExecError{
+		Command:   "test",
+		Namespace: "ns",
+		PodName:   "pod",
+		ExitCode:  -1,
+		Err:       inner,
+	}
+	assert.ErrorIs(t, e, inner)
+
+	var target *ExecError
+	wrapped := fmt.Errorf("outer: %w", e)
+	assert.True(t, errors.As(wrapped, &target))
+	assert.Equal(t, "test", target.Command)
+}
+
+func TestNewExecErrorWithCodeExitError(t *testing.T) {
+	codeErr := k8sexec.CodeExitError{
+		Err:  errors.New("command terminated with exit code 125"),
+		Code: 125,
+	}
+	e := newExecError("podman diff", "test-ns", "test-pod", codeErr)
+	assert.Equal(t, 125, e.ExitCode)
+	assert.True(t, e.HasExitCode(125))
+	assert.Contains(t, e.Error(), "exit code 125")
+}
+
+func TestNewExecErrorWithPlainError(t *testing.T) {
+	e := newExecError("ls", "test-ns", "test-pod", errors.New("connection refused"))
+	assert.Equal(t, -1, e.ExitCode)
+	assert.False(t, e.HasExitCode(125))
+	assert.NotContains(t, e.Error(), "exit code")
+}
+
+func TestNewExecErrorWithWrappedCodeExitError(t *testing.T) {
+	codeErr := k8sexec.CodeExitError{
+		Err:  errors.New("command terminated with exit code 1"),
+		Code: 1,
+	}
+	wrapped := fmt.Errorf("stream failed: %w", codeErr)
+	e := newExecError("cat /etc/hosts", "ns", "pod", wrapped)
+	assert.Equal(t, 1, e.ExitCode)
+	assert.True(t, e.HasExitCode(1))
+}

--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -102,7 +102,7 @@ func GetContainerPidNamespace(testContainer *provider.Container, env *provider.T
 	command := fmt.Sprintf("lsns -p %d -t pid -n", pid)
 	stdout, stderr, err := clientsholder.GetClientsHolder().ExecCommandContainer(ocpContext, command)
 	if err != nil || stderr != "" {
-		return "", fmt.Errorf("unable to run nsenter due to : %v", err)
+		return "", fmt.Errorf("unable to run nsenter due to: %w", err)
 	}
 
 	return strings.Fields(stdout)[0], nil
@@ -164,7 +164,7 @@ func GetPidsFromPidNamespace(pidNamespace string, container *provider.Container)
 
 	stdout, stderr, err := clientsholder.GetClientsHolder().ExecCommandContainer(ctx, command)
 	if err != nil || stderr != "" {
-		return nil, fmt.Errorf("command %q failed to run in probe pod=%s (node=%s): %v", command, ctx.GetPodName(), container.NodeName, err)
+		return nil, fmt.Errorf("command %q failed to run in probe pod=%s (node=%s): %w", command, ctx.GetPodName(), container.NodeName, err)
 	}
 
 	re := regexp.MustCompile(PsRegex)

--- a/pkg/scheduling/scheduling.go
+++ b/pkg/scheduling/scheduling.go
@@ -17,6 +17,7 @@
 package scheduling
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -44,6 +45,8 @@ const (
 
 	NoProcessFoundErrMsg = "No such process"
 )
+
+var ErrProcessNotFound = errors.New("process not found")
 
 var GetProcessCPUSchedulingFn = GetProcessCPUScheduling
 
@@ -87,7 +90,7 @@ func ProcessPidsCPUScheduling(processes []*crclient.Process, testContainer *prov
 		logger.Debug("Testing process %q", process)
 		schedulePolicy, schedulePriority, err := GetProcessCPUSchedulingFn(process.Pid, testContainer)
 		if err != nil {
-			if strings.Contains(err.Error(), NoProcessFoundErrMsg) {
+			if errors.Is(err, ErrProcessNotFound) {
 				logger.Warn("Process %q in Container %q disappeared (pid no longer exists), treating as compliant", process, testContainer)
 				aPidOut := testhelper.NewContainerReportObject(testContainer.Namespace, testContainer.Podname, testContainer.Name, "process disappeared", true).
 					SetContainerProcessValues("", "", process.Args)
@@ -139,8 +142,12 @@ func GetProcessCPUScheduling(pid int, testContainer *provider.Container) (schedu
 
 	stdout, stderr, err := ch.ExecCommandContainer(ctx, command)
 	if err != nil || stderr != "" {
-		return schedulePolicy, InvalidPriority, fmt.Errorf("command %q failed to run in probe pod %s (node %s): %v (stderr: %v)",
-			command, ctx.GetPodName(), testContainer.NodeName, err, stderr)
+		if strings.Contains(stderr, NoProcessFoundErrMsg) {
+			return schedulePolicy, InvalidPriority, fmt.Errorf("command %q in probe pod %s (node %s): %w",
+				command, ctx.GetPodName(), testContainer.NodeName, ErrProcessNotFound)
+		}
+		return schedulePolicy, InvalidPriority, fmt.Errorf("command %q failed to run in probe pod %s (node %s) (stderr: %s): %w",
+			command, ctx.GetPodName(), testContainer.NodeName, stderr, err)
 	}
 
 	schedulePolicy, schedulePriority, err = parseSchedulingPolicyAndPriority(stdout)

--- a/pkg/scheduling/scheduling_test.go
+++ b/pkg/scheduling/scheduling_test.go
@@ -404,7 +404,7 @@ func TestProcessPidsCPUScheduling(t *testing.T) {
 		{
 			mockGetProcessCPUScheduling: func(pid int, container *provider.Container) (string, int, error) {
 				if pid == 101 {
-					return "", InvalidPriority, fmt.Errorf("command failed: %s", NoProcessFoundErrMsg)
+					return "", InvalidPriority, fmt.Errorf("command failed: %w", ErrProcessNotFound)
 				}
 				return "SCHED_OTHER", 0, nil
 			},

--- a/tests/performance/suite.go
+++ b/tests/performance/suite.go
@@ -17,6 +17,7 @@
 package performance
 
 import (
+	"errors"
 	"fmt"
 	"slices"
 	"strconv"
@@ -348,7 +349,7 @@ func testRtAppsNoExecProbes(check *checksdb.Check, env *provider.TestEnvironment
 			check.LogInfo("Testing process %q", p)
 			schedPolicy, _, err := scheduling.GetProcessCPUScheduling(p.Pid, cut)
 			if err != nil {
-				if strings.Contains(err.Error(), scheduling.NoProcessFoundErrMsg) {
+				if errors.Is(err, scheduling.ErrProcessNotFound) {
 					check.LogWarn("Container process %q disappeared", p)
 					result.AddCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, "Container process disappeared", true).
 						AddField(testhelper.ProcessID, strconv.Itoa(p.Pid)).

--- a/tests/platform/cnffsdiff/fsdiff.go
+++ b/tests/platform/cnffsdiff/fsdiff.go
@@ -18,8 +18,8 @@ package cnffsdiff
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -32,6 +32,7 @@ import (
 const (
 	partnerPodmanFolder      = "/root/podman"
 	tmpMountDestFolder       = "/tmp/tnf-podman"
+	podmanExitCode125        = 125
 	errorCode125RetrySeconds = 15
 )
 
@@ -178,7 +179,8 @@ func (f *FsDiff) RunTest(containerUID string) {
 		// Retry if we get a podman error code 125, which is a known issue where the container/pod
 		// has possibly gone missing or is in CrashLoopBackOff state. Adding a retry here to help
 		// smooth out the test results.
-		if strings.Contains(err.Error(), "command terminated with exit code 125") {
+		var execErr *clientsholder.ExecError
+		if errors.As(err, &execErr) && execErr.HasExitCode(podmanExitCode125) {
 			f.check.LogWarn("Retrying \"podman diff\" due to error code 125 (attempt %d/5)", i+1)
 			time.Sleep(errorCode125RetrySeconds * time.Second)
 			continue

--- a/tests/platform/cnffsdiff/fsdiff_test.go
+++ b/tests/platform/cnffsdiff/fsdiff_test.go
@@ -20,6 +20,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
@@ -59,6 +60,16 @@ func TestRunTest(t *testing.T) {
 		{ // test when an error occurred when running the command
 			expectedResult: testhelper.ERROR,
 			clientErr:      errors.New("error executing the command"),
+		},
+		{ // test when an ExecError with non-125 exit code is returned (should not retry)
+			expectedResult: testhelper.ERROR,
+			clientErr: &clientsholder.ExecError{
+				Command:   "podman diff",
+				Namespace: "test-ns",
+				PodName:   "test-pod",
+				ExitCode:  1,
+				Err:       errors.New("container exited"),
+			},
 		},
 		{ // test when an error message was returned
 			expectedResult: testhelper.ERROR,
@@ -112,6 +123,48 @@ func TestRunTest(t *testing.T) {
 		fsdiff.RunTest("fakeUID")
 		assert.Equal(t, tc.expectedResult, fsdiff.GetResults())
 	}
+}
+
+type ClientHoldersRetryMock struct {
+	callCount atomic.Int32
+	firstErr  error
+	successOn int32
+	output    string
+}
+
+func (m *ClientHoldersRetryMock) ExecCommandContainer(_ clientsholder.Context, cmd string) (stdout, stderr string, err error) {
+	if !strings.Contains(cmd, "podman diff") {
+		return "", "", nil
+	}
+	call := m.callCount.Add(1)
+	if call >= m.successOn {
+		return m.output, "", nil
+	}
+	return "", "", m.firstErr
+}
+
+func TestRunTestExitCode125Retry(t *testing.T) {
+	check := &checksdb.Check{}
+	ocpVersion := "4.13.0"
+
+	exitCode125Err := &clientsholder.ExecError{
+		Command:   "podman diff",
+		Namespace: "test-ns",
+		PodName:   "test-pod",
+		ExitCode:  podmanExitCode125,
+		Err:       errors.New("container gone"),
+	}
+
+	mock := &ClientHoldersRetryMock{
+		firstErr:  exitCode125Err,
+		successOn: 2,
+		output:    "{}",
+	}
+
+	fsdiff := NewFsDiffTester(check, mock, clientsholder.Context{}, ocpVersion)
+	fsdiff.RunTest("fakeUID")
+	assert.Equal(t, testhelper.SUCCESS, fsdiff.GetResults())
+	assert.GreaterOrEqual(t, mock.callCount.Load(), int32(2))
 }
 
 type ClientHoldersMountCustomPodmanMock struct {


### PR DESCRIPTION
## Summary

- Introduce `ExecError` type in `internal/clientsholder` that captures command, namespace, pod name, and exit code from K8s `CodeExitError`, enabling type-safe error checking via `errors.As`/`HasExitCode()`
- Add `ErrProcessNotFound` sentinel error in `pkg/scheduling` for process-disappeared detection via `errors.Is`
- Replace 3 fragile `strings.Contains(err.Error(), ...)` sites with structured error checks:
  - `fsdiff.go`: exit code 125 retry now uses `errors.As` + `HasExitCode(125)`
  - `scheduling.go` + `performance/suite.go`: process-not-found now uses `errors.Is`
- Fix 2 `fmt.Errorf` calls in `crclient.go` using `%v` instead of `%w`, which was silently breaking error chains

## Future work — additional `%v` wrapping sites identified

During the audit we found 204 `fmt.Errorf` calls across the codebase, with zero custom error types prior to this PR. The following sites also use `%v` instead of `%w`, breaking error chains. They were left untouched to keep this PR focused, but are candidates for follow-up:

- `internal/crclient/crclient.go:223` — `execCommandContainer()` uses `%v` for the error in a combined stdout/stderr/err message
- `tests/platform/cnffsdiff/fsdiff.go:223` — `execCommandContainer()` same pattern, `%v` for err in combined output
- `pkg/scheduling/scheduling.go:74` — `parseSchedulingPolicyAndPriority()` default branch uses `%s` for unknown line content (not an error chain issue, but inconsistent)
- `internal/clientsholder/clientsholder.go` — several `fmt.Errorf` calls in cluster config setup that could benefit from wrapping

Additionally, `GetProcessCPUScheduling()` in `pkg/scheduling/scheduling.go` has no direct unit tests — it is always mocked out via `GetProcessCPUSchedulingFn`. The new `ErrProcessNotFound` wrapping logic is only tested indirectly through `ProcessPidsCPUScheduling`. Adding dependency injection for the `clientsholder` and `crclient` calls would enable direct testing.

## Test plan

- [x] New unit tests for `ExecError` type (error messages, exit code extraction, unwrap chain, nil edge cases)
- [x] New test for exit code 125 retry logic with `ExecError` in `fsdiff_test.go`
- [x] Existing scheduling tests updated and passing with sentinel error
- [x] `go build ./...` passes
- [x] `go test` passes across all 5 affected packages (65 tests)
- [x] `make lint` passes with zero issues