### PR TITLE
Extract default beforeEachFn into checksdb.DefaultBeforeEachFn

### DIFF
--- a/pkg/checksdb/checksgroup.go
+++ b/pkg/checksdb/checksgroup.go
@@ -54,6 +54,13 @@ func (group *ChecksGroup) WithBeforeAllFn(beforeAllFn func(checks []*Check) erro
 	return group
 }
 
+func DefaultBeforeEachFn(refreshEnv func()) func(*Check) error {
+	return func(check *Check) error {
+		refreshEnv()
+		return nil
+	}
+}
+
 func (group *ChecksGroup) WithBeforeEachFn(beforeEachFn func(check *Check) error) *ChecksGroup {
 	group.beforeEachFn = beforeEachFn
 

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -61,14 +61,7 @@ var (
 	knownContainersToSkip = map[string]bool{"kube-rbac-proxy": true}
 )
 
-var (
-	env provider.TestEnvironment
-
-	beforeEachFn = func(check *checksdb.Check) error {
-		env = provider.GetTestEnvironment()
-		return nil
-	}
-)
+var env provider.TestEnvironment
 
 // LoadChecks loads all the checks.
 //
@@ -77,7 +70,7 @@ func LoadChecks() {
 	log.Debug("Loading %s suite checks", common.AccessControlTestKey)
 
 	checksGroup := checksdb.NewChecksGroup(common.AccessControlTestKey).
-		WithBeforeEachFn(beforeEachFn)
+		WithBeforeEachFn(checksdb.DefaultBeforeEachFn(func() { env = provider.GetTestEnvironment() }))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestSecContextIdentifier)).
 		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env)).

--- a/tests/lifecycle/suite.go
+++ b/tests/lifecycle/suite.go
@@ -48,11 +48,6 @@ const (
 var (
 	env provider.TestEnvironment
 
-	beforeEachFn = func(check *checksdb.Check) error {
-		env = provider.GetTestEnvironment()
-		return nil
-	}
-
 	// podset = deployment or statefulset
 	skipIfNoPodSetsetsUnderTest = func() (bool, string) {
 		if len(env.Deployments) == 0 && len(env.StatefulSets) == 0 {
@@ -67,7 +62,7 @@ func LoadChecks() {
 	log.Debug("Loading %s suite checks", common.LifecycleTestKey)
 
 	checksGroup := checksdb.NewChecksGroup(common.LifecycleTestKey).
-		WithBeforeEachFn(beforeEachFn)
+		WithBeforeEachFn(checksdb.DefaultBeforeEachFn(func() { env = provider.GetTestEnvironment() }))
 
 	// Prestop test
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestContainerPrestopIdentifier)).

--- a/tests/manageability/suite.go
+++ b/tests/manageability/suite.go
@@ -30,11 +30,6 @@ import (
 var (
 	env provider.TestEnvironment
 
-	beforeEachFn = func(check *checksdb.Check) error {
-		env = provider.GetTestEnvironment()
-		return nil
-	}
-
 	skipIfNoContainersFn = func() (bool, string) {
 		if len(env.Containers) == 0 {
 			log.Warn("No containers to check...")
@@ -49,7 +44,7 @@ func LoadChecks() {
 	log.Debug("Loading %s suite checks", common.ManageabilityTestKey)
 
 	checksGroup := checksdb.NewChecksGroup(common.ManageabilityTestKey).
-		WithBeforeEachFn(beforeEachFn)
+		WithBeforeEachFn(checksdb.DefaultBeforeEachFn(func() { env = provider.GetTestEnvironment() }))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestContainersImageTag)).
 		WithSkipCheckFn(skipIfNoContainersFn).

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -45,21 +45,14 @@ type Port []struct {
 	Protocol      string
 }
 
-var (
-	env provider.TestEnvironment
-
-	beforeEachFn = func(check *checksdb.Check) error {
-		env = provider.GetTestEnvironment()
-		return nil
-	}
-)
+var env provider.TestEnvironment
 
 //nolint:funlen
 func LoadChecks() {
 	log.Debug("Loading %s suite checks", common.NetworkingTestKey)
 
 	checksGroup := checksdb.NewChecksGroup(common.NetworkingTestKey).
-		WithBeforeEachFn(beforeEachFn)
+		WithBeforeEachFn(checksdb.DefaultBeforeEachFn(func() { env = provider.GetTestEnvironment() }))
 
 	// Default interface ICMP IPv4 test case
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestICMPv4ConnectivityIdentifier)).

--- a/tests/observability/suite.go
+++ b/tests/observability/suite.go
@@ -39,20 +39,13 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 )
 
-var (
-	env provider.TestEnvironment
-
-	beforeEachFn = func(check *checksdb.Check) error {
-		env = provider.GetTestEnvironment()
-		return nil
-	}
-)
+var env provider.TestEnvironment
 
 func LoadChecks() {
 	log.Debug("Loading %s suite checks", common.ObservabilityTestKey)
 
 	checksGroup := checksdb.NewChecksGroup(common.ObservabilityTestKey).
-		WithBeforeEachFn(beforeEachFn)
+		WithBeforeEachFn(checksdb.DefaultBeforeEachFn(func() { env = provider.GetTestEnvironment() }))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestLoggingIdentifier)).
 		WithSkipCheckFn(testhelper.GetNoContainersUnderTestSkipFn(&env)).

--- a/tests/operator/suite.go
+++ b/tests/operator/suite.go
@@ -38,21 +38,14 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/versions"
 )
 
-var (
-	env provider.TestEnvironment
-
-	beforeEachFn = func(check *checksdb.Check) error {
-		env = provider.GetTestEnvironment()
-		return nil
-	}
-)
+var env provider.TestEnvironment
 
 //nolint:funlen
 func LoadChecks() {
 	log.Debug("Loading %s suite checks", common.OperatorTestKey)
 
 	checksGroup := checksdb.NewChecksGroup(common.OperatorTestKey).
-		WithBeforeEachFn(beforeEachFn)
+		WithBeforeEachFn(checksdb.DefaultBeforeEachFn(func() { env = provider.GetTestEnvironment() }))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestOperatorInstallStatusSucceededIdentifier)).
 		WithSkipCheckFn(testhelper.GetNoOperatorsSkipFn(&env)).

--- a/tests/performance/suite.go
+++ b/tests/performance/suite.go
@@ -41,11 +41,6 @@ const (
 var (
 	env provider.TestEnvironment
 
-	beforeEachFn = func(check *checksdb.Check) error {
-		env = provider.GetTestEnvironment()
-		return nil
-	}
-
 	skipIfNoGuaranteedPodContainersWithExclusiveCPUs = func() (bool, string) {
 		var guaranteedPodContainersWithExclusiveCPUs = env.GetGuaranteedPodContainersWithExclusiveCPUs()
 		if len(guaranteedPodContainersWithExclusiveCPUs) == 0 {
@@ -83,7 +78,7 @@ func LoadChecks() { //nolint:funlen
 	log.Debug("Loading %s suite checks", common.PerformanceTestKey)
 
 	checksGroup := checksdb.NewChecksGroup(common.PerformanceTestKey).
-		WithBeforeEachFn(beforeEachFn)
+		WithBeforeEachFn(checksdb.DefaultBeforeEachFn(func() { env = provider.GetTestEnvironment() }))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestExclusiveCPUPoolIdentifier)).
 		WithSkipCheckFn(testhelper.GetNoPodsUnderTestSkipFn(&env)).

--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -42,21 +42,14 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var (
-	env provider.TestEnvironment
-
-	beforeEachFn = func(check *checksdb.Check) error {
-		env = provider.GetTestEnvironment()
-		return nil
-	}
-)
+var env provider.TestEnvironment
 
 //nolint:funlen
 func LoadChecks() {
 	log.Debug("Loading %s suite checks", common.PlatformAlterationTestKey)
 
 	checksGroup := checksdb.NewChecksGroup(common.PlatformAlterationTestKey).
-		WithBeforeEachFn(beforeEachFn)
+		WithBeforeEachFn(checksdb.DefaultBeforeEachFn(func() { env = provider.GetTestEnvironment() }))
 
 	checksGroup.Add(checksdb.NewCheck(identifiers.GetTestIDAndLabels(identifiers.TestHyperThreadEnable)).
 		WithSkipCheckFn(

--- a/tests/preflight/suite.go
+++ b/tests/preflight/suite.go
@@ -29,14 +29,7 @@ import (
 	"github.com/redhat-best-practices-for-k8s/certsuite/tests/identifiers"
 )
 
-var (
-	env provider.TestEnvironment
-
-	beforeEachFn = func(check *checksdb.Check) error {
-		env = provider.GetTestEnvironment()
-		return nil
-	}
-)
+var env provider.TestEnvironment
 
 func labelsAllowTestRun(labelFilter string, allowedLabels []string) bool {
 	for _, label := range allowedLabels {
@@ -80,7 +73,7 @@ func LoadChecks() {
 
 	checksGroup := checksdb.NewChecksGroup(common.PreflightTestKey)
 	checksGroup.ResetChecks()
-	checksGroup = checksGroup.WithBeforeEachFn(beforeEachFn)
+	checksGroup = checksGroup.WithBeforeEachFn(checksdb.DefaultBeforeEachFn(func() { env = provider.GetTestEnvironment() }))
 
 	testPreflightContainers(checksGroup, &env)
 	if provider.IsOCPCluster() {


### PR DESCRIPTION
## Summary

- Add `checksdb.DefaultBeforeEachFn` helper that takes a generic `func()` callback and returns the standard `beforeEachFn` closure
- Replace 9 identical `beforeEachFn` closures across test suites with calls to the new helper
- Certification suite retains its custom closure (extra cert DB validator init)

Net result: **-50 lines**, zero new dependencies, no behavior change.