### PR TITLE
fix: test hugepages on control-plane nodes in SNO clusters

### DIFF
--- a/tests/platform/suite.go
+++ b/tests/platform/suite.go
@@ -414,9 +414,12 @@ func testHugepages(check *checksdb.Check, env *provider.TestEnvironment) {
 		nodeName := node.Data.Name
 		check.LogInfo("Testing node %q", nodeName)
 		if !node.IsWorkerNode() {
-			check.LogInfo("Node %q is not a worker node", nodeName)
-			compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(nodeName, "Not a worker node", true))
-			continue
+			if !env.IsSNO() {
+				check.LogInfo("Node %q is not a worker node", nodeName)
+				compliantObjects = append(compliantObjects, testhelper.NewNodeReportObject(nodeName, "Not a worker node", true))
+				continue
+			}
+			check.LogInfo("Node %q is a control-plane node on an SNO cluster, testing hugepages as it also runs workloads", nodeName)
 		}
 
 		probePod, exist := env.ProbePods[nodeName]


### PR DESCRIPTION
## Summary

On Single Node OpenShift (SNO), the `platform-alteration-hugepages-config` test skips the node if it doesn't have the `node-role.kubernetes.io/worker` label. Since some SNO configurations only label the single node as `master`/`control-plane` (without an explicit worker label), this causes the test to silently skip all hugepages validation.

On SNO, the control-plane node also runs workloads and its MachineConfig (from the master MCP) contains the hugepages settings. The test should validate this node's hugepages regardless of whether it has the worker label.

### Fix

When the node is not a worker but the cluster is SNO (`env.IsSNO()` — i.e., only 1 node exists), proceed with the hugepages test instead of skipping.

### Impact

- **SNO clusters without worker label**: Test now correctly validates hugepages (previously silently skipped)
- **SNO clusters with worker label**: No change (node already passes the `IsWorkerNode()` check)
- **Multi-node clusters**: No change (non-worker nodes still skipped as before)

### Testing

- All existing `tests/platform/hugepages/` unit tests pass
- Full project builds cleanly
- Follows the same `env.IsSNO()` pattern already used in `tests/lifecycle/suite.go`

Fixes #3237

Made with [Cursor](https://cursor.com)