### PR TITLE
fix: skip RuntimeClass-injected nodeSelector in pod-scheduling check

### DIFF
--- a/tests/lifecycle/pod_scheduling_test.go
+++ b/tests/lifecycle/pod_scheduling_test.go
@@ -1,0 +1,178 @@
+// Copyright (C) 2020-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package lifecycle
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func setupCheck() *checksdb.Check {
+	var logArchive strings.Builder
+	log.SetupLogger(&logArchive, "INFO")
+	return checksdb.NewCheck("test-id", nil)
+}
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestPodNodeSelectorAndAffinityBestPractices(t *testing.T) {
+	testCases := []struct {
+		name           string
+		pods           []*provider.Pod
+		expectedResult checksdb.CheckResult
+	}{
+		{
+			name: "pod with no nodeSelector and no affinity is compliant",
+			pods: []*provider.Pod{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+						Spec:       corev1.PodSpec{},
+					},
+				},
+			},
+			expectedResult: checksdb.CheckResultPassed,
+		},
+		{
+			name: "pod with nodeSelector and no runtimeClassName is non-compliant",
+			pods: []*provider.Pod{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+						Spec: corev1.PodSpec{
+							NodeSelector: map[string]string{"node-role.kubernetes.io/master": ""},
+						},
+					},
+				},
+			},
+			expectedResult: checksdb.CheckResultFailed,
+		},
+		{
+			name: "pod with nodeSelector AND runtimeClassName is compliant (RuntimeClass injection)",
+			pods: []*provider.Pod{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "upf-testpod-0-0", Namespace: "upf1"},
+						Spec: corev1.PodSpec{
+							RuntimeClassName: strPtr("performance-performance-master"),
+							NodeSelector:     map[string]string{"node-role.kubernetes.io/master": ""},
+						},
+					},
+				},
+			},
+			expectedResult: checksdb.CheckResultPassed,
+		},
+		{
+			name: "pod with nodeAffinity and no runtimeClassName is non-compliant",
+			pods: []*provider.Pod{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+						Spec: corev1.PodSpec{
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{Key: "node-role.kubernetes.io/worker", Operator: corev1.NodeSelectorOpExists},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: checksdb.CheckResultFailed,
+		},
+		{
+			name: "pod with nodeAffinity AND runtimeClassName still reports affinity non-compliance",
+			pods: []*provider.Pod{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+						Spec: corev1.PodSpec{
+							RuntimeClassName: strPtr("performance-worker"),
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{Key: "node-role.kubernetes.io/worker", Operator: corev1.NodeSelectorOpExists},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: checksdb.CheckResultFailed,
+		},
+		{
+			name: "pod with both nodeSelector and runtimeClassName plus affinity reports failure for affinity only",
+			pods: []*provider.Pod{
+				{
+					Pod: &corev1.Pod{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-pod", Namespace: "default"},
+						Spec: corev1.PodSpec{
+							RuntimeClassName: strPtr("performance-performance-master"),
+							NodeSelector:     map[string]string{"node-role.kubernetes.io/master": ""},
+							Affinity: &corev1.Affinity{
+								NodeAffinity: &corev1.NodeAffinity{
+									RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+										NodeSelectorTerms: []corev1.NodeSelectorTerm{
+											{
+												MatchExpressions: []corev1.NodeSelectorRequirement{
+													{Key: "custom-key", Operator: corev1.NodeSelectorOpExists},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: checksdb.CheckResultFailed,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			check := setupCheck()
+			testPodNodeSelectorAndAffinityBestPractices(tc.pods, check)
+			assert.Equal(t, tc.expectedResult, check.Result)
+		})
+	}
+}

--- a/tests/lifecycle/suite.go
+++ b/tests/lifecycle/suite.go
@@ -365,9 +365,13 @@ func testPodNodeSelectorAndAffinityBestPractices(testPods []*provider.Pod, check
 		check.LogInfo("Testing Pod %q", put)
 		compliantPod := true
 		if put.HasNodeSelector() {
-			check.LogError("Pod %q has a node selector. Node selector: %v", put, put.Spec.NodeSelector)
-			nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod has node selector", false))
-			compliantPod = false
+			if put.IsRuntimeClassNameSpecified() {
+				check.LogInfo("Pod %q has a node selector injected via RuntimeClass %q, skipping", put, *put.Spec.RuntimeClassName)
+			} else {
+				check.LogError("Pod %q has a node selector. Node selector: %v", put, put.Spec.NodeSelector)
+				nonCompliantObjects = append(nonCompliantObjects, testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod has node selector", false))
+				compliantPod = false
+			}
 		}
 		if put.Spec.Affinity != nil && put.Spec.Affinity.NodeAffinity != nil {
 			check.LogError("Pod %q has a node affinity clause. Node affinity: %v", put, put.Spec.Affinity.NodeAffinity)


### PR DESCRIPTION
## Summary

The `lifecycle-pod-scheduling` test (`TestPodNodeSelectorAndAffinityBestPractices`) incorrectly reports pods as non-compliant when their `spec.nodeSelector` is automatically injected by the Kubernetes API server via `RuntimeClass.scheduling.nodeSelector`, rather than explicitly set by the workload author.

This applies the same `IsRuntimeClassNameSpecified()` guard already used in the pod-recreation test (line 626 of `suite.go`) to avoid false positives for pods derived from performance profiles or RuntimeClasses with scheduling configuration.

## Changes

- **`tests/lifecycle/suite.go`**: When a pod has a `nodeSelector` AND `runtimeClassName` is set, skip the nodeSelector non-compliance check (the selector was injected by the RuntimeClass admission controller, not the workload author)
- **`tests/lifecycle/pod_scheduling_test.go`**: New test file with 6 test cases covering all combinations:
  - Pod with no selector/affinity → compliant ✓
  - Pod with nodeSelector, no runtimeClassName → non-compliant ✓
  - Pod with nodeSelector + runtimeClassName → compliant (RuntimeClass injection) ✓
  - Pod with nodeAffinity, no runtimeClassName → non-compliant ✓
  - Pod with nodeAffinity + runtimeClassName → still non-compliant (affinity is separate) ✓
  - Pod with nodeSelector + runtimeClassName + affinity → fails for affinity only ✓

## Rationale

The `RuntimeClass` admission controller [merges `scheduling.nodeSelector`](https://kubernetes.io/docs/concepts/containers/runtime-class/#scheduling) into the pod spec at admission time. This means the workload template never defined a `nodeSelector` — it only appears on the live pod object. The existing pattern at line 626 already handles this for the pod-recreation test.

Fixes #3716

Made with [Cursor](https://cursor.com)