### PR TITLE
Fix RHCOS update workflow to pass PAT via token input

### DIFF
--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -69,9 +69,8 @@ jobs:
 
       - name: Create PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.UPDATE_CERTIFIED_DB_TOKEN }}
         with:
+          token: ${{ secrets.UPDATE_CERTIFIED_DB_TOKEN }}
           commit-message: Update RHCOS to OCP version map
           title: Update RHCOS to OCP version map
           body: |


### PR DESCRIPTION
## Summary

- The UPDATE_CERTIFIED_DB_TOKEN PAT was passed as env: GITHUB_TOKEN, but peter-evans/create-pull-request reads its token from the token input parameter (defaulting to github.token). The env var does not override github.token, so the PAT was silently ignored.
- As a result, RHCOS update PRs were created as github-actions[bot], causing all PR-triggered workflows (CI, do-not-merge, CodeQL) to require manual approval -- and CI has **never actually run** on these PRs.
- Moving the secret to with: token: ensures the action authenticates as the PAT owner, so triggered workflows run automatically.

## Test plan

- [ ] Trigger the RHCOS update workflow manually (workflow_dispatch) and verify the resulting PR is authored by the PAT owner, not github-actions[bot]
- [ ] Verify CI workflows run automatically on the new PR without requiring approval