### PR TITLE
Revert RHCOS workflow to use default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/update-rhcos-mapping.yml
+++ b/.github/workflows/update-rhcos-mapping.yml
@@ -70,7 +70,6 @@ jobs:
       - name: Create PR
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.UPDATE_CERTIFIED_DB_TOKEN }}
           commit-message: Update RHCOS to OCP version map
           title: Update RHCOS to OCP version map
           body: |


### PR DESCRIPTION
Reverts the token change from #3856. The UPDATE_CERTIFIED_DB_TOKEN PAT is expired, and using it via the token input caused the workflow to fail at git push. This removes the explicit token so the action falls back to its default GITHUB_TOKEN, matching the parser and probe update workflows.