### PR TITLE
docs: align READMEs and MkDocs with the current CLI and config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ make coverage-html      # Generate and view HTML coverage report
 
 ### Linting
 ```bash
-make lint               # Run all linters (golangci-lint, hadolint, shfmt, markdownlint, yamllint, shellcheck, typos)
+make lint               # Run all linters (checkmake, golangci-lint, hadolint, shfmt, markdownlint, yamllint, shellcheck, typos)
 make markdownlint       # Run markdown linter only
 make yamllint           # Run YAML linter only
 ```
@@ -92,14 +92,14 @@ The CLI is built using Cobra and organized into subcommands:
 - RBAC (roles, bindings)
 - Custom resources and CRDs
 
-**configuration**: Test configuration parsing and validation. Reads `tnf_config.yaml` (or custom config file) to determine:
+**configuration**: Test configuration parsing and validation. Reads `config/certsuite_config.yml` (or a custom `--config-file`) to determine:
 - Target namespaces to test
 - Pod label selectors
 - Operator label selectors
 - Network attachment definitions to check
 - Test-specific parameters
 
-**provider**: Test execution providers and resource access. The `TestEnvironment` interface provides access to discovered resources for test implementations.
+**provider**: Test execution providers and resource access. The `TestEnvironment` struct provides access to discovered resources for test implementations.
 
 **checksdb**: Test case database and results tracking. Each test is registered as a `Check` with metadata, skip conditions, and execution functions.
 
@@ -192,13 +192,14 @@ targetCrdFilters:
 ## Development Guidelines
 
 ### Go Version
-This repository uses Go 1.26.4. Ensure your local environment matches this version.
+This repository uses Go 1.26. Match the version in `go.mod` (`go` and `toolchain` lines).
 
 ### Testing and Mocks
 The codebase uses native Go structs for mocking interfaces in tests. Mock implementations are hand-written and located alongside the interfaces they mock (e.g., `internal/clientsholder/command_mock.go`). This approach avoids external dependencies and makes the code easier to understand and maintain.
 
 ### Linting
 All code must pass the configured linters before submission. Use `make lint` to run all linters. The project uses:
+- `checkmake` (Makefile validation)
 - `golangci-lint` (Go code quality)
 - `hadolint` (Dockerfile linting)
 - `shfmt` (Shell script formatting)
@@ -233,7 +234,7 @@ The claim format is defined in a separate package (`certsuite-claim`) and shared
 
 ### Running a Single Test Suite
 ```bash
-./certsuite run --config-file=tnf_config.yaml --label-filter=networking
+./certsuite run --config-file=config/certsuite_config.yml --label-filter=networking
 ```
 
 ### Comparing Test Results

--- a/CATALOG.md
+++ b/CATALOG.md
@@ -401,7 +401,7 @@ Test Cases are the specifications used to perform a meaningful test. Test cases 
 |Unique ID|access-control-requests|
 |Description|Check that containers have resource requests specified in their spec. Set proper resource requests based on container use case.|
 |Suggested Remediation|Add requests to your container spec. See: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#requests-and-limits|
-|Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requests-limits|
+|Best Practice Reference|https://redhat-best-practices-for-k8s.github.io/guide/#_requests_and_limits_in_kubernetes|
 |Exception Process|Exceptions possible for platform and infrastructure containers. Must identify which container needs access and document why with details.|
 |Impact Statement|Missing resource requests can lead to resource contention, node instability, and unpredictable application performance.|
 |Tags|telco,access-control|

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,17 +55,15 @@ here.
 Contributors should follow [these seven rules](https://chris.beams.io/posts/git-commit/#seven-rules) and keep individual
 commits focused (`git add -p` will help with this).
 
-### Unit Testing Tests
+### Unit tests
 
-Each `tnf.Tester` implementation must have unit tests. Ideally, it should strive for 100% line coverage when possible. For some examples of existing unit tests, consult:
+New checks and helpers must include unit tests. Prefer table-driven tests and keep mocks next to the interfaces they implement. For examples of existing tests, consult:
 
-* pkg/tnf/handlers/base/version_test.go
-* pkg/tnf/handlers/hostname/hostname_test.go
-* pkg/tnf/handlers/ipaddr/ipaddr_test.go
-* pkg/tnf/handlers/ping/ping_test.go
+* `tests/networking/icmp/icmp_test.go`
+* `pkg/checksdb/checksdb_test.go`
+* `internal/clientsholder/command_mock.go`
 
-As always, you should ensure that tests should pass prior to submitting a Pull Request. To run the unit tests issue the
-following command:
+Run the unit tests before submitting a Pull Request:
 
 ```bash
 make test
@@ -90,6 +88,6 @@ In addition, the `redhat-best-practices-for-k8s` project committers expect all P
 configured linters are used. Please ensure you run `make lint` and resolve any issues in your changes before submitting
 your PR. Disabled linting must be justified.
 
-Finally, all contributions should follow the guidance of [Effective Go](https://golang.org/doc/effective_go.html)
+Finally, all contributions should follow the guidance of [Effective Go](https://go.dev/doc/effective_go)
 unless there is a clear and considered reason not to. Contributions are more likely to be accepted quickly if any
 divergence from the guidelines is justified before someone has to ask about it.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![QE OCP 4.21 Testing](https://github.com/redhat-best-practices-for-k8s/certsuite/actions/workflows/qe-ocp-421.yaml/badge.svg)](https://github.com/redhat-best-practices-for-k8s/certsuite/actions/workflows/qe-ocp-421.yaml)
 [![QE OCP 4.22 Testing](https://github.com/redhat-best-practices-for-k8s/certsuite/actions/workflows/qe-ocp-422.yaml/badge.svg)](https://github.com/redhat-best-practices-for-k8s/certsuite/actions/workflows/qe-ocp-422.yaml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/redhat-best-practices-for-k8s/certsuite/badge)](https://scorecard.dev/viewer/?uri=github.com/redhat-best-practices-for-k8s/certsuite)
-[![go-doc](https://godoc.org/github.com/redhat-best-practices-for-k8s/certsuite?status.svg)](https://godoc.org/github.com/redhat-best-practices-for-k8s/certsuite)
+[![go-doc](https://pkg.go.dev/badge/github.com/redhat-best-practices-for-k8s/certsuite.svg)](https://pkg.go.dev/github.com/redhat-best-practices-for-k8s/certsuite)
 [![release)](https://img.shields.io/github/v/release/redhat-best-practices-for-k8s/certsuite?color=blue&label=%20&logo=semver&logoColor=white&style=flat)](https://github.com/redhat-best-practices-for-k8s/certsuite/releases)
 [![red hat](https://img.shields.io/badge/red%20hat---?color=gray&logo=redhat&logoColor=red&style=flat)](https://www.redhat.com)
 [![openshift](https://img.shields.io/badge/openshift---?color=gray&logo=redhatopenshift&logoColor=red&style=flat)](https://www.redhat.com/en/technologies/cloud-computing/openshift)

--- a/cmd/certsuite/generate/config/const.go
+++ b/cmd/certsuite/generate/config/const.go
@@ -111,7 +111,7 @@ Test cases affected: lifecycle-statefulset-scaling`
 	// Settings
 	probeDaemonSetHelp = `Set the namespace where the probe DaemonSet will be deployed.
 The namespace will be created in case it does not exist. If not set, the default namespace
-is "certsuite".
+is "cnf-suite".
 This DaemonSet, called "certsuite-probe" is deployed and used internally by the Certification Suite
 to issue some shell commands that are needed in certain test cases. Some of these test cases might
 fail or be skipped in case it is not deployed correctly.`

--- a/docs/cluster-deploy/README.md
+++ b/docs/cluster-deploy/README.md
@@ -10,10 +10,10 @@ This folder contains two files:
 
 ## certsuite.yaml
 
-This file contains all the kubernetes templates for deploying the Cert Suite inside a Pod named "certsuite" in a namespace also named "certsuite". In order to deploy the pod, just write:
+This file contains all the kubernetes templates for deploying the Cert Suite inside a Pod named "certsuite" in a namespace also named "certsuite". From the repository root:
 
 ```console
-oc apply -f k8s/certsuite.yaml
+oc apply -f docs/cluster-deploy/certsuite.yaml
 namespace/certsuite created
 clusterrole.rbac.authorization.k8s.io/certsuite-cr created
 clusterrolebinding.rbac.authorization.k8s.io/certsuite-crb created
@@ -22,31 +22,35 @@ secret/certsuite-preflight-dockerconfig created
 pod/certsuite created
 ```
 
-The first thing in that yaml is the namespace, so it's the first resource that will be created in the cluster. Then, a cluster role and its cluster role binding will be created. This cluster role is needed because the Cert Suite needs access to all the resources in the whole cluster.
+Or from this directory: `oc apply -f certsuite.yaml`.
 
-Then, there's a configMap with the whole config (certsuite_config.yaml) that will be used by the pod to create the certsuite_config.yaml file inside a volume folder. Also, there's a secret with the preflight's dockerconfig file content that will also be used by the Cert Suite pod.
+The first resource in that yaml is the namespace. Then a cluster role and cluster role binding are created. This cluster role is needed because the Cert Suite needs access to resources across the cluster.
 
-The Cert Suite pod is the last resource defined in the certsuite.yaml file. It has only one container that uses the [quay.io/redhat-best-practices-for-k8s/certsuite:latest](latest) tag of the Cert Suite. The command slice of this container has a hardcoded labels to run as many test cases as possible, excluding the intrusive ones.
+A ConfigMap holds `certsuite_config.yml` and is mounted at `/usr/certsuite/config`. A secret holds the preflight dockerconfig and is mounted at `/usr/certsuite/config/preflight`. The pod command passes `--config-file` and `--preflight-dockerconfig` explicitly (certsuite does not read `CERTSUITE_CONFIGURATION_PATH` or `CERTSUITE_ALLOW_PREFLIGHT_INSECURE`).
+
+The Cert Suite pod uses the [quay.io/redhat-best-practices-for-k8s/certsuite:latest](https://quay.io/repository/redhat-best-practices-for-k8s/certsuite) image. The command runs a broad label filter with `--intrusive=false`. In-cluster kubeconfig is detected automatically.
 
 ## kustomization.yaml
 
-This kustomization file allows the deployment of the Cert Suite using this command:
+This kustomization file allows the deployment of the Cert Suite using this command from the repository root:
 
 ```console
-oc kustomize k8s/ | oc apply -f -
+oc kustomize docs/cluster-deploy/ | oc apply -f -
 ```
+
+Or from this directory: `oc kustomize . | oc apply -f -`.
 
 The `kustomization` tool used by `oc` will parse the content of the [./kustomization.yaml](kustomization.yaml) file, which consists of a set of "transformers" over the resources defined in [./certsuite.yaml](certsuite.yaml).
 
-By default, that command will deploy the Cert Suite Pod without any mutation: it will be deployed in the same namespace and with the same configuration than using the `oc apply -f cluster-deploy/certsuite.yaml`.
+By default, that command will deploy the Cert Suite Pod without any mutation: it will be deployed in the same namespace and with the same configuration as `oc apply -f docs/cluster-deploy/certsuite.yaml`.
 
-But there are the three example of modifications included in [./kustomization.yaml](kustomization.yaml) that can be used out of the box that can be handy:
+There are three example modifications in [./kustomization.yaml](kustomization.yaml):
 
-1. The namespace and the prefix/suffix of each resource's name. By default, the [./certsuite.yaml](certsuite.yaml) uses the namespace "certsuite" to deploy all the reources (except the cluster role and the cluster role binding), but this can be changed uncommenting the line that starts with `namespace:`. It's highly recommended to uncomment at least one of suffixName/prefixName so unique cluster role & cluster role-bindings can be created for each CertSuite Pod. This way, you could run more than one CertSuite Pod in the same cluster!.
-2. The (ginkgo) labels expression, in case you want to run different test cases. Uncomment the object that starts with "patches:". The commented example changes the command to use the "preflight" label only.
-3. Configuring the --intrusive Flag. Uncomment the last object that starts with "patches:". The commented example removes the `--intrusive=false` cli flag, so all the intrusive TCs will run in case the lifecycle TCs are selected to run by the appropriate labels.
+1. The namespace and the prefix/suffix of each resource's name. By default, [./certsuite.yaml](certsuite.yaml) uses the namespace "certsuite" (except the cluster role and cluster role binding). Uncomment the line that starts with `namespace:`. Uncomment at least one of namePrefix/nameSuffix so unique cluster role and cluster role-bindings can be created for each CertSuite Pod. This way, you can run more than one CertSuite Pod in the same cluster.
+2. The label expression, in case you want to run different test cases. Uncomment the object that starts with "patches:". The commented example changes the command to use the "preflight" label only.
+3. Configuring the `--intrusive` flag. Uncomment the last object that starts with "patches:". The commented example removes `--intrusive=false`, so intrusive test cases will run if lifecycle tests are selected.
 
-In case both (1) and (2) wants to be used, just create a list of patches like this:
+If both (1) and (2) are needed, create a list of patches like this:
 
 ```console
 patches:
@@ -58,7 +62,7 @@ patches:
       - op: replace
         path: /spec/containers/0/args/1
         value: |
-          certsuite run -l 'preflight' ; sleep inf
+          certsuite run --config-file=/usr/certsuite/config/certsuite_config.yml --preflight-dockerconfig=/usr/certsuite/config/preflight/preflight_dockerconfig.json -l 'preflight' ; sleep inf
   - target:
       version: v1
       kind: Pod
@@ -67,5 +71,5 @@ patches:
       - op: replace
         path: /spec/containers/0/args/1
         value: |
-          certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context' ; sleep inf
+          certsuite run --config-file=/usr/certsuite/config/certsuite_config.yml --preflight-dockerconfig=/usr/certsuite/config/preflight/preflight_dockerconfig.json -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context' ; sleep inf
 ```

--- a/docs/cluster-deploy/certsuite.yaml
+++ b/docs/cluster-deploy/certsuite.yaml
@@ -63,7 +63,7 @@ data:
     skipScalingTestDeployments:
       - name: deployment1
         namespace: tnf
-    skipScalingTestStatefulsets:
+    skipScalingTestStatefulSets:
       - name: statefulset1
         namespace: tnf
     skipHelmChartList:
@@ -127,18 +127,18 @@ spec:
       args:
         - "-c"
         - |
-          certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context' --intrusive=false ; sleep inf
+          certsuite run \
+            --config-file=/usr/certsuite/config/certsuite_config.yml \
+            --preflight-dockerconfig=/usr/certsuite/config/preflight/preflight_dockerconfig.json \
+            --allow-preflight-insecure \
+            --log-level=trace \
+            -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context' \
+            --intrusive=false ; sleep inf
       volumeMounts:
         - name: config-volume
           mountPath: /usr/certsuite/config
         - name: preflight-dockerconfig
           mountPath: /usr/certsuite/config/preflight
       env:
-        - name: CERTSUITE_ALLOW_PREFLIGHT_INSECURE
-          value: "true"
-        - name: CERTSUITE_LOG_LEVEL
-          value: trace
         - name: PFLT_DOCKERCONFIG
           value: /usr/certsuite/config/preflight/preflight_dockerconfig.json
-        - name: CERTSUITE_CONFIGURATION_PATH
-          value: /usr/certsuite/config/certsuite_config.yaml

--- a/docs/cluster-deploy/kustomization.yaml
+++ b/docs/cluster-deploy/kustomization.yaml
@@ -23,7 +23,7 @@ resources:
 #       - op: replace
 #         path: /spec/containers/0/args/1
 #         value: |
-#           certsuite run -l 'preflight' ; sleep inf
+#           certsuite run --config-file=/usr/certsuite/config/certsuite_config.yml --preflight-dockerconfig=/usr/certsuite/config/preflight/preflight_dockerconfig.json -l 'preflight' ; sleep inf
 
 # Uncomment the next lines (patches) in order to allow intrusive TCs to run.
 # patches:
@@ -35,4 +35,4 @@ resources:
 #       - op: replace
 #         path: /spec/containers/0/args/1
 #         value: |
-#           certsuite run -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context'; sleep inf
+#           certsuite run --config-file=/usr/certsuite/config/certsuite_config.yml --preflight-dockerconfig=/usr/certsuite/config/preflight/preflight_dockerconfig.json -l '!affiliated-certification-container-is-certified-digest && !access-control-security-context'; sleep inf

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,7 +25,7 @@ Here's an example of how to use the tool:
 
 <!-- markdownlint-disable MD033 MD045 -->
 <object type="image/svg+xml" data="./assets/images/demo-config.svg">
-<img src="../assets/images/demo-config.svg">
+<img src="assets/images/demo-config.svg">
 </object>
 <!-- markdownlint-enable MD033 MD045 -->
 
@@ -148,17 +148,7 @@ To enable this, set:
 --create-xml-junit-file true
 ```
 
-This will create a file named `certsuite/certsuite-tests_junit.xml`.
-
-#### Enable running container against OpenShift Local
-
-While running the test suite as a container, you can enable the container to be able to reach the local CRC instance by setting:
-
-```shell
-export CERTSUITE_ENABLE_CRC_TESTING=true
-```
-
-This utilizes the `--add-host` flag in Docker to be able to point `api.crc.testing` to the host gateway.
+This creates `certsuite-tests_junit.xml` in the directory given by `--output-dir` (default `results`).
 
 ### Exceptions
 
@@ -230,7 +220,7 @@ Test cases affected: _lifecycle-deployment-scaling_, _lifecycle-statefulset-scal
 skipScalingTestDeployments:
   - name: deployment1
     namespace: certsuite
-skipScalingTestStatefulSetNames:
+skipScalingTestStatefulSets:
   - name: statefulset1
     namespace: certsuite
 ```
@@ -239,7 +229,7 @@ skipScalingTestStatefulSetNames:
 
 #### probeDaemonSetNamespace
 
-This is an optional field with the name of the namespace where a privileged DaemonSet will be deployed. The namespace will be created in case it does not exist. In case this field is not set, the default namespace for this DaemonSet is _certsuite_.
+This is an optional field with the name of the namespace where a privileged DaemonSet will be deployed. The namespace will be created in case it does not exist. If this field is not set, the default namespace for this DaemonSet is _cnf-suite_.
 
 ``` { .yaml .annotate }
 probeDaemonSetNamespace: cnf-cert
@@ -267,3 +257,31 @@ The label _redhat-best-practices-for-k8s.com/skip_multus_connectivity_tests_ exc
 #### Affinity requirements
 
 For workloads that require Pods to use Pod or Node Affinity rules, the label _AffinityRequired: true_ must be included on the Pod YAML. This will ensure that the affinity best practices are tested and prevent any test cases for anti-affinity to fail.
+
+### Collector and Red Hat Connect
+
+These optional fields configure result upload. They can also be supplied as `certsuite run` flags. See [Data Collection](data-collection.md) for details.
+
+#### executedBy / partnerName / collectorAppPassword / collectorAppEndpoint
+
+Used when `--enable-data-collection` is set. `collectorAppEndpoint` defaults to the Red Hat collector if left empty.
+
+``` { .yaml .annotate }
+executedBy: ""
+partnerName: ""
+collectorAppPassword: ""
+collectorAppEndpoint: "http://claims-collector.cnf-certifications.sysdeseng.com"
+```
+
+#### connectAPIConfig
+
+Credentials and proxy settings for uploading results to the Red Hat Connect portal. Equivalent flags: `--connect-api-key`, `--connect-project-id`, `--connect-api-base-url`, `--connect-api-proxy-url`, `--connect-api-proxy-port`.
+
+``` { .yaml .annotate }
+connectAPIConfig:
+  baseURL: "https://access.redhat.com/hydra/cwe/rest/v1.0"
+  apiKey: ""
+  projectID: ""
+  proxyURL: ""
+  proxyPort: ""
+```

--- a/docs/data-collection.md
+++ b/docs/data-collection.md
@@ -14,3 +14,18 @@ Red Hat team can access data from all partners.
 * Keep track of your test suite results over time.
 * Contribute to our statistics and analysis,
 to improve Red Hat best practices test suite for Kubernetes.
+
+## How to enable collection
+
+Pass `--enable-data-collection` to `certsuite run` and set these fields in
+`certsuite_config.yml` (see [configuration](configuration.md)):
+
+```yaml
+executedBy: ""
+partnerName: ""
+collectorAppPassword: ""
+collectorAppEndpoint: "http://claims-collector.cnf-certifications.sysdeseng.com"
+```
+
+To upload artifacts to the Red Hat Connect portal instead, set `connectAPIConfig`
+(or the `--connect-api-*` flags) with a project ID and API key.

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,19 +1,24 @@
 <!-- markdownlint-disable line-length no-bare-urls -->
 # Steps
 
-To test the newly added test / existing tests locally, follow the steps
+To test a newly added test or existing tests locally, follow the steps
 
 - Clone the repo
-- Set runtime environment variables, as per the requirement.
+- Build the certsuite binary
 
-    For example, to deploy partner deployments in a custom namespace in the test config.
+    ```shell
+    make build
+    ```
+
+- Create or edit `config/certsuite_config.yml`. For example, to deploy partner
+  workloads in a custom namespace:
 
     ```yaml
     targetNameSpaces:
       - name: mynamespace
     ```
 
-- Also, skip intrusive tests
+- Skip intrusive tests if you do not want scaling or pod-recreation checks
 
     ```shell
     ./certsuite run --intrusive=false
@@ -25,13 +30,27 @@ To test the newly added test / existing tests locally, follow the steps
     export KUBECONFIG=<<mypath/.kube/config>>
     ```
 
-- Execute test suite, which would build and run the suite
-
-    For example, to run `networking` tests
+- Execute the test suite. For example, to run `networking` tests:
 
     ```shell
-    ./certsuite run -l networking
+    ./certsuite run -l networking --config-file=config/certsuite_config.yml
     ```
+
+- List matching test cases without running them:
+
+    ```shell
+    ./certsuite info -t networking --list
+    ```
+
+- Run unit tests and linters before opening a pull request:
+
+    ```shell
+    make test
+    make lint
+    ```
+
+See [Runtime environment variables](runtime-env.md) and
+[Test Configuration](configuration.md) for more options.
 
 ## Dependencies on other PR
 

--- a/docs/disconnected.md
+++ b/docs/disconnected.md
@@ -15,7 +15,9 @@ contains additional examples and source code.
 The certsuite deploys a privileged DaemonSet called `certsuite-probe` onto every
 node in the target cluster. This DaemonSet runs commands on the host that many
 test cases depend on (e.g., ping, platform checks). By default the probe image
-is pulled from `quay.io/redhat-best-practices-for-k8s/certsuite-probe:latest`.
+is pulled from `quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.42`
+by default (`--certsuite-probe-image`). Mirror that tag, or `:latest` if you
+override the flag.
 In a disconnected cluster the nodes cannot reach quay.io, so the DaemonSet fails
 to start and the certsuite cannot run.
 
@@ -27,7 +29,7 @@ cluster itself) where to find them.
 
 | Image | Purpose | When needed |
 | --- | --- | --- |
-| `quay.io/redhat-best-practices-for-k8s/certsuite-probe:latest` | Privileged DaemonSet for running platform-level test commands on cluster nodes | Always |
+| `quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.42` (default) or `:latest` | Privileged DaemonSet for running platform-level test commands on cluster nodes | Always. Certsuite defaults to `v0.0.42`; mirror `:latest` only if you pass `--certsuite-probe-image` with that tag. |
 | `quay.io/redhat-best-practices-for-k8s/certsuite:latest` | Certsuite container image | Only when running the certsuite as a pod inside the cluster (see [cluster-deploy](cluster-deploy/README.md)) |
 | `quay.io/redhat-best-practices-for-k8s/oct:latest` | Offline certification database for checking container, operator, and Helm chart certification status | Optional but recommended for fully disconnected environments |
 
@@ -45,7 +47,7 @@ A sample `ImageSetConfiguration` is provided in this repository at
 
 - The `oc-mirror` plugin v2 installed on your connected workstation.
   See the
-  [oc-mirror documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.17/html/disconnected_environments/mirroring-images-for-a-disconnected-installation-using-the-oc-mirror-plugin-v2)
+  [oc-mirror documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/disconnected_environments/about-installing-oc-mirror-v2)
   for installation instructions.
 - A mirror registry accessible from both the connected workstation (for pushing)
   and the disconnected cluster nodes (for pulling).
@@ -63,12 +65,13 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   additionalImages:
+    - name: quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.42
     - name: quay.io/redhat-best-practices-for-k8s/certsuite-probe:latest
     - name: quay.io/redhat-best-practices-for-k8s/certsuite:latest
     - name: quay.io/redhat-best-practices-for-k8s/oct:latest
 ```
 
-Remove any images you do not need. The probe image is always required.
+Remove any images you do not need. Mirror `v0.0.42` to match the certsuite default probe tag, or `:latest` if you override `--certsuite-probe-image`.
 
 ### Step 2: Mirror images to disk
 
@@ -182,19 +185,13 @@ skopeo copy \
 
 Unlike oc-mirror, skopeo does not generate IDMS/ITMS resources. You must tell
 the certsuite where to find the probe image using the `--certsuite-probe-image`
-flag:
+flag. Certsuite defaults to `certsuite-probe:v0.0.42` (see `debugTag` in
+`version.json`); if you mirrored `:latest`, pass that tag explicitly:
 
 ```shell
 certsuite run \
   --certsuite-probe-image=<mirror-registry>/redhat-best-practices-for-k8s/certsuite-probe:latest \
   -l <label-filter> -c <config-file> -k <kubeconfig> -o <output-dir>
-```
-
-Alternatively, set the `SUPPORT_IMAGE` environment variable:
-
-```shell
-export SUPPORT_IMAGE=<mirror-registry>/redhat-best-practices-for-k8s/certsuite-probe:latest
-certsuite run -l <label-filter> -c <config-file> -k <kubeconfig> -o <output-dir>
 ```
 
 ## Offline Certification Database
@@ -253,6 +250,9 @@ Run the certsuite with `--cleanup-probe=false` to keep the probe running after
 tests complete, then verify the DaemonSet pods are running:
 
 ```shell
-oc get daemonset -n certsuite
-oc get pods -n certsuite
+oc get daemonset -n cnf-suite
+oc get pods -n cnf-suite
 ```
+
+Use the namespace from `probeDaemonSetNamespace` if you overrode the default
+(`cnf-suite`).

--- a/docs/exception.md
+++ b/docs/exception.md
@@ -1,6 +1,9 @@
 <!-- markdownlint-disable line-length no-bare-urls -->
 # Exception Process
 
-There may exist some test cases which needs to fail always. The exception raised by the failed tests is published to Red Hat website for that partner.
+Some test cases may fail for a workload that still meets Red Hat best practices
+with a documented exception. The catalog lists the exception process for each
+test case.
 
-[CATALOG](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md) provides the details of such exception.
+See [CATALOG.md](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md)
+for per-test exception guidance.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ This repository provides a set of test cases to verify the conformance of a work
 
     The tool we use to certify a workload.
 
-The purpose of the tests and the framework is to test the interaction of the workload with OpenShift Container Platform (OCP).  
+The purpose of the tests and the framework is to test the interaction of the workload with OpenShift Container Platform (OCP).
 
 !!! info
 
@@ -30,11 +30,11 @@ The purpose of the tests and the framework is to test the interaction of the wor
 
 There are 3 building blocks in the above framework.
 
-* the `CertSuite` represents the workload to be certified. The Test Suite identifies the resources (containers/pods/operators etc) belonging to the workload via labels or static data entries in the Config File
+* the **workload under test** is the application to be certified. The Test Suite identifies its resources (containers, pods, operators, and so on) via labels or static entries in the Config File
 
-* the `Certification container/exec` is the Test Suite running on the platform or in a container. The executable verifies the workload under test configuration and its interactions with OpenShift
+* the **certsuite binary or container** is the Test Suite running on a jump host or in a container. The executable verifies the workload under test configuration and its interactions with OpenShift
 
-* the `Debug` pods are part of a Kubernetes daemonset responsible to run various **privileged commands** on Kubernetes nodes. Debug pods are useful to run platform tests and test commands (e.g. ping) in container namespaces without changing the container image content. The probe daemonset is instantiated via the [privileged-daemonset](https://github.com/redhat-best-practices-for-k8s/privileged-daemonset) repository.
+* the **probe DaemonSet** (`certsuite-probe`) runs privileged commands on Kubernetes nodes. Probe pods are used for platform tests and commands (for example ping) in container namespaces without changing the container image. The DaemonSet is deployed through the [privileged-daemonset](https://github.com/redhat-best-practices-for-k8s/privileged-daemonset) repository.
 
 ## Disconnected Environments
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -2,4 +2,5 @@
 
 - [Contribution Guidelines](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CONTRIBUTING.md)
 - [CATALOG](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md)
-- [Best Practices Document v1.3](https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf)
+- [Kubernetes best practices guide](https://redhat-best-practices-for-k8s.github.io/guide/)
+- [CNF Requirements v1.3 (PDF)](https://connect.redhat.com/sites/default/files/2022-05/Cloud%20Native%20Network%20Function%20Requirements%201-3.pdf)

--- a/docs/runtime-env.md
+++ b/docs/runtime-env.md
@@ -5,8 +5,9 @@ To run the test suite, some runtime environment variables are to be set.
 
 ## OCP >=4.12 Labels
 
-The following labels need to be added to your default namespace in your cluster
-if you are running OCP >=4.12:
+The following labels need to be added to the namespace where the probe DaemonSet
+is deployed (default `cnf-suite`; see `probeDaemonSetNamespace` in the config
+file) if you are running OCP >=4.12:
 
 ```shell
 pod-security.kubernetes.io/enforce: privileged
@@ -16,30 +17,28 @@ pod-security.kubernetes.io/enforce-version: latest
 You can manually label the namespace with:
 
 ```shell
-oc label namespace/default pod-security.kubernetes.io/enforce=privileged
-oc label namespace/default pod-security.kubernetes.io/enforce-version=latest
+oc label namespace/cnf-suite pod-security.kubernetes.io/enforce=privileged
+oc label namespace/cnf-suite pod-security.kubernetes.io/enforce-version=latest
 ```
 
 ## Preflight Integration
 
-When running the `preflight` suite of tests, there are a few environment variables that
-will need to be set:
+When running the `preflight` suite of tests, pass the dockerconfig path to
+certsuite with `--preflight-dockerconfig`. Certsuite skips the preflight suite
+if that flag is empty.
 
-`PFLT_DOCKERCONFIG` is a required variable for running the preflight test suite. This
-provides credentials to the underlying preflight library for being able to pull/manipulate
-images and image bundles for testing.
+`PFLT_DOCKERCONFIG` is still consumed by the underlying
+[Preflight library](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/docs/CONFIG.md)
+for pulling images. Set it to the same file when running as a standalone binary.
+When running as a container, mount the docker config and pass
+`--preflight-dockerconfig` to the `certsuite run` command.
 
-When running as a container, the docker config is mounted to the container via volume mount.
+Allow insecure connections to a private registry with self-signed certificates
+using `--allow-preflight-insecure` (default: false).
 
-When running as a standalone binary, the environment variables are consumed directly from your local machine.
-
-See more about this variable in the [Preflight configuration documentation](https://github.com/redhat-openshift-ecosystem/openshift-preflight/blob/main/docs/CONFIG.md).
-
-`CERTSUITE_ALLOW_PREFLIGHT_INSECURE` (default: false) is required set to `true` if you are running
-against a private container registry that has self-signed certificates.
-
-Note that you can also specify the probe pod image to use with `SUPPORT_IMAGE`
-environment variable, default to `certsuite-probe:v0.0.42`.
+Override the probe DaemonSet image with `--certsuite-probe-image`. The default
+is `quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.42` (see
+`debugTag` in `version.json`).
 
 ## Client Timeout
 

--- a/docs/test-output.md
+++ b/docs/test-output.md
@@ -13,38 +13,11 @@ This file describes the following
 
 **Files that need to be submitted for certification**
 
-When submitting results back to Red Hat for certification, please include the above mentioned claim file, the JUnit file, and any available console logs.
-
-**How to add a workload platform test result to the existing claim file?**
-
-```go
-go run cmd/tools/cmd/main.go claim-add --claimfile=claim.json
---reportdir=/home/$USER/reports
-```
-
- **Args**:
-`--claimfile is an existing claim.json file`
-`--repordir :path to test results that you want to include.`
-
- The tests result files from the given report dir will be appended under the result section of the claim file using file name as the key/value pair.
- The tool will ignore the test result, if the key name is already present under result section of the claim file.
-
-```json
- "results": {
- "certsuite-tests_junit": {
- "testsuite": {
- "-errors": "0",
- "-failures": "2",
- "-name": "CertSuite Certification Test Suite",
- "-tests": "14",
- ...
-```
+When submitting results back to Red Hat for certification, please include the above mentioned claim file, the JUnit file (if generated with `--create-xml-junit-file`), and any available console logs.
 
 **Reference**
 
-For more details on the contents of the claim file
-
-* [Guide](https://redhat-connect.gitbook.io/openshift-badges/badges/cloud-native-network-functions-cnf).
+For more details on the contents of the claim file, see the [best-practices guide](https://redhat-best-practices-for-k8s.github.io/guide/) and the [claim format package](https://github.com/redhat-best-practices-for-k8s/certsuite-claim).
 
 ## Execution logs
 
@@ -160,7 +133,7 @@ make build-certsuite-tool
 #### Compare a claim file against itself: no differences expected
 
 <!-- markdownlint-disable MD033 -->
-<object type="image/svg+xml" data="../assets/images/claim-compare-self.svg" width="100%" height=auto></object>
+<object type="image/svg+xml" data="assets/images/claim-compare-self.svg" width="100%" height=auto></object>
 <!-- markdownlint-disable MD033 -->
 
 #### Different test cases results
@@ -170,7 +143,7 @@ Let's assume we have two claim files, claim1.json and claim2.json, obtained from
 During the second run, there was a test case that failed. Let's simulate it modifying manually the second run's claim file to switch one test case's state from "passed" to "failed".
 
 <!-- markdownlint-disable MD033 -->
-<object type="image/svg+xml" data="../assets/images/claim-compare-results.svg" width="100%" height=auto></object>
+<object type="image/svg+xml" data="assets/images/claim-compare-results.svg" width="100%" height=auto></object>
 <!-- markdownlint-disable MD033 -->
 
 #### Different cluster configurations
@@ -179,17 +152,17 @@ First, let's simulate that the second run took place in a cluster with a differe
 The versions section comparison appears at the very beginning of the `certsuite claim compare` output:
 
 <!-- markdownlint-disable MD033 -->
-<object type="image/svg+xml" data="../assets/images/claim-compare-versions.svg" width="100%" height=auto></object>
+<object type="image/svg+xml" data="assets/images/claim-compare-versions.svg" width="100%" height=auto></object>
 <!-- markdownlint-disable MD033 -->
 
 Now, let's simulate that the cluster was a bit different when the second Test Suite run was performed. First, let's make a manual change in claim2.json to emulate a different CNI version in the first node.
 
 <!-- markdownlint-disable MD033 -->
-<object type="image/svg+xml" data="../assets/images/claim-compare-cni.svg" width="100%" height=auto></object>
+<object type="image/svg+xml" data="assets/images/claim-compare-cni.svg" width="100%" height=auto></object>
 <!-- markdownlint-disable MD033 -->
 
 Finally, we'll simulate that, for some reason, the first node had one label removed when the second run was performed:
 
 <!-- markdownlint-disable MD033 -->
-<object type="image/svg+xml" data="../assets/images/claim-compare-nodes.svg" width="100%" height=auto></object>
+<object type="image/svg+xml" data="assets/images/claim-compare-nodes.svg" width="100%" height=auto></object>
 <!-- markdownlint-disable MD033 -->

--- a/docs/test-run.md
+++ b/docs/test-run.md
@@ -44,9 +44,13 @@ These labels can be combined with some operators to create label filters that ma
 * The label filter "operator && !operator-crd-versioning" will match the _operator_ test suite without the _operator_crd_versioning_ test case.
 * To select all the test cases the _all_ label filter can be used.
 
-To view which test cases will run for a specific label or label filter use the flag `--list`.
+To view which test cases match a label or label filter:
 
-See the [CATALOG.md](CATALOG.md) to find all test labels.
+```shell
+certsuite info -t <label-filter> --list
+```
+
+See the [test catalog](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md) for all test labels.
 
 ## Disable intrusive tests
 
@@ -114,7 +118,7 @@ The `certsuite run` command organizes its flags into groups. To see the complete
 
 ### Probe daemonset flags
 
-* `--certsuite-probe-image`: Override the default certsuite probe daemonset image. Defaults to the version matching the certsuite release.
+* `--certsuite-probe-image`: Override the default certsuite probe daemonset image. Defaults to `quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.42` (`debugTag` in `version.json`).
 
 * `--daemonset-cpu-req`, `--daemonset-cpu-lim`: Set the CPU request and limit for the probe daemonset container. Both default to `100m`.
 
@@ -179,7 +183,7 @@ The test image is available at this [repository](https://quay.io/repository/redh
 docker pull quay.io/redhat-best-practices-for-k8s/certsuite:<image-tag>
 ```
 
-The image tag can be `latest` to select the latest release, `unstable` to fetch the image built with the latest commit in the repository or any existing version number such as `v5.2.1`.
+The image tag can be `latest` to select the latest release, `unstable` to fetch the image built with the latest commit in the repository, or any existing version tag from the [releases page](https://github.com/redhat-best-practices-for-k8s/certsuite/releases).
 
 ### Launch the Test Suite
 

--- a/docs/test-spec-implementation.md
+++ b/docs/test-spec-implementation.md
@@ -1,28 +1,20 @@
 <!-- markdownlint-disable line-length no-bare-urls -->
 # Test Case Implementation
 
-This section explains the implementation of some test cases so that users can have a better idea on what the is code actually doing and, in some cases, which configuration fields are relevant to them.
+This section explains the implementation of some test cases so that users can have a better idea of what the code is actually doing and, in some cases, which configuration fields are relevant to them.
 
 ## [lifecycle-deployment-scaling](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#lifecycle-deployment-scaling) and [lifecycle-statefulset-scaling](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#lifecycle-statefulset-scaling)
 
-For each discovered deployment in the [target namespaces](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/config/certsuite_config.yml#L1), the test case will try to modify its replica count to check whether pod's can be correctly removed and re-deployed in the cluster.
+For each discovered deployment in the [target namespaces](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/config/certsuite_config.yml#L1), the test case will try to modify its replica count to check whether pods can be correctly removed and re-deployed in the cluster.
 
-<!-- markdownlint-disable MD033 MD045 -->
-<img src="../assets/images/tests-flow-charts/lifecycle-deployment-scaling.png"></img>
-<!-- markdownlint-disable MD033 MD045 -->
+The way to modify the number of replicas varies depending on whether the deployment/statefulset's replica count is managed by an HPA, a CR, or it's just a standalone resource.
 
-As depicted in the image, the way to modify the number of replicas varies depending on whether the deployment/statefulset's replica count is managed by an HPA, a CR or it's just a standalone resource.
-
-- If the deployment/statefulset is an standalone resource, the test case just decreases the `.spec.replicas` field by one, waits for that pod to be removed and then it restores the original number increasing the field by one again. The test case passes as soon as the new pod is up and running again.
-- If there's an [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) managing the resource, the test case decreases and increases the HPA's MaxReplicas field accordingly.
-- If [the owner](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications) of the resource is a CR, the test makes sure that CR's CRD matches any of the suffixes in the certsuite_config.yaml's [targetCrdFilters](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/config/certsuite_config.yml#L9) field. If there's a match, the test case is skipped as it's there's another test case called lifecycle-crd-scaling that will test it. Otherwise it will flagged as failed.
+- If the deployment/statefulset is a standalone resource, the test case decreases the `.spec.replicas` field by one, waits for that pod to be removed, and then restores the original number by increasing the field by one again. The test case passes as soon as the new pod is up and running again.
+- If there's a [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) (HPA) managing the resource, the test case decreases and increases the HPA's MaxReplicas field accordingly.
+- If [the owner](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/#owner-references-in-object-specifications) of the resource is a CR, the test makes sure that CR's CRD matches any of the suffixes in the certsuite_config.yml [targetCrdFilters](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/config/certsuite_config.yml#L9) field. If there's a match, the test case is skipped because `lifecycle-crd-scaling` will test it. Otherwise it is flagged as failed.
 
 ## [lifecycle-crd-scaling](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md#lifecycle-crd-scaling)
 
-During the program's startup, an autodiscovery phase is performed where all the CRDs and their existing CRs in the [target namespaces](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/config/certsuite_config.yml#L1) are stored to be tested later. Only CRs whose CRD's suffix matches at least one of the [targetCrdFilters](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/config/certsuite_config.yml#L9) and has an [scale subresource](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource) will be selected as test targets.
+During the program's startup, an autodiscovery phase is performed where all the CRDs and their existing CRs in the [target namespaces](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/config/certsuite_config.yml#L1) are stored to be tested later. Only CRs whose CRD's suffix matches at least one of the [targetCrdFilters](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/config/certsuite_config.yml#L9) and has a [scale subresource](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#scale-subresource) will be selected as test targets.
 
-For every CR under test, a similar approach to the scaling of deployments and statefulsets is done.
-
-<!-- markdownlint-disable MD033 MD045 -->
-<img src="../assets/images/tests-flow-charts/lifecycle-crd-scaling.png"></img>
-<!-- markdownlint-disable MD033 MD045 -->
+For every CR under test, a similar approach to the scaling of deployments and statefulsets is used.

--- a/docs/test-spec.md
+++ b/docs/test-spec.md
@@ -3,41 +3,28 @@
 
 ## Available Test Specs
 
-There are two categories for workload tests.
-
-- **General**
-
-These tests are designed to test any commodity workload running on OpenShift, and include specifications such as
-`Default` network connectivity.
-
-- **Workload-Specific**
-
-These tests are designed to test some unique aspects of the workload under test are behaving correctly. This could
-include specifications such as issuing a `GET` request to a web server, or passing traffic through an IPSEC tunnel.
-
-### General tests
-
 These tests belong to multiple suites that can be run in any combination as is
-appropriate for the workload under test.
+appropriate for the workload under test. Use `--label-filter` with a suite
+name, a test case name, or a category (`common`, `telco`, `faredge`,
+`extended`).
 
 !!! info
 
-    Test suites group tests by the topic areas.
+    Test suites group tests by topic. QE currently covers OpenShift 4.14 through 4.22.
 
-Suite|Test Spec Description|Minimum OpenShift Version
----|---|---
-`access-control`|The access-control test suite is used to test  service account, namespace and cluster/pod role binding for the pods under test. It also tests the pods/containers configuration.|4.6.0
-`affiliated-certification`|The affiliated-certification test suite verifies that the containers and operators discovered or listed in the configuration file are certified by Redhat|4.6.0
-`lifecycle`|The lifecycle test suite verifies the pods deployment, creation, shutdown and survivability.|4.6.0
-`networking`|The networking test suite contains tests that check connectivity and networking config related best practices.|4.6.0
-`operator`|The operator test suite is designed to test basic Kubernetes Operator functionality.|4.6.0
-`platform-alteration`|verifies that key platform configuration is not modified by the workload under test|4.6.0
-`observability`|the observability test suite contains tests that check workload logging is following best practices and that CRDs have status fields|4.6.0
+Suite|Description
+---|---
+`access-control`|Service accounts, namespaces, role bindings, and pod/container security context.
+`affiliated-certification`|Certification status of discovered containers, operators, and Helm charts.
+`lifecycle`|Pod deployment, scaling, shutdown, and survivability.
+`manageability`|Container port names and other manageability best practices.
+`networking`|Connectivity and networking configuration best practices.
+`observability`|Workload logging and CRD status fields.
+`operator`|Operator lifecycle, installation, and related best practices.
+`platform-alteration`|Key platform configuration is not modified by the workload under test.
+`performance`|CPU pinning, exec probes, and related performance checks.
+`preflight`|Red Hat preflight certification checks for containers and operators.
 
 !!! info
 
-    Please refer [CATALOG.md](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md) for more details.
-
-### Workload-specific tests
-
-TODO
+    See [CATALOG.md](https://github.com/redhat-best-practices-for-k8s/certsuite/blob/main/CATALOG.md) for the full list of test cases and labels.

--- a/docs/workload-developers.md
+++ b/docs/workload-developers.md
@@ -2,20 +2,16 @@
 # Workload Guidelines for developers
 
 Developers of Kubernetes workloads, particularly those targeting
-[certification with Red Hat on OpenShift](https://redhat-connect.gitbook.io/openshift-badges/badges/cloud-native-network-functions-cnf),
-can use this suite to test the interaction of their workload with OpenShift.  If interested in certification
-please contact [Red Hat](https://redhat-connect.gitbook.io/red-hat-partner-connect-general-guide/managing-your-account/getting-help/technology-partner-success-desk).
+[Red Hat certification on OpenShift](https://connect.redhat.com),
+can use this suite to test the interaction of their workload with OpenShift.
+If interested in certification, start with
+[Red Hat Partner Connect](https://connect.redhat.com).
 
 **Requirements**
 
-- [OpenShift 4.10 installation](https://docs.openshift.com/container-platform/4.10/welcome/index.html) to run the workload
-- At least one extra machine to host the test suite
-
-## To add private test cases
-
-Refer this documentation
-https://github.com/redhat-best-practices-for-k8s/cnfextensions
+- An [OpenShift cluster](https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html/welcome/index) in a currently supported version (QE covers 4.14 through 4.22)
+- At least one extra machine to host the test suite, or run certsuite as a container or in-cluster pod
 
 **Reference**
 
-[certsuite-sample-workload](https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload) repository provides sample example to model the test setup.
+The [certsuite-sample-workload](https://github.com/redhat-best-practices-for-k8s/certsuite-sample-workload) repository provides a sample setup to model against.

--- a/examples/disconnected/imageset-config.yaml
+++ b/examples/disconnected/imageset-config.yaml
@@ -3,6 +3,8 @@
 #
 # Required:
 #   certsuite-probe - Privileged DaemonSet deployed on cluster nodes during test execution.
+#                     Certsuite defaults to tag v0.0.42 (--certsuite-probe-image). Include that
+#                     tag, or :latest if you override the flag.
 #
 # Optional:
 #   certsuite - Only needed if running the certsuite as a container inside the cluster.
@@ -12,6 +14,7 @@ kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v2alpha1
 mirror:
   additionalImages:
+    - name: quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.42
     - name: quay.io/redhat-best-practices-for-k8s/certsuite-probe:latest
     - name: quay.io/redhat-best-practices-for-k8s/certsuite:latest
     - name: quay.io/redhat-best-practices-for-k8s/oct:latest

--- a/internal/results/html/README.md
+++ b/internal/results/html/README.md
@@ -1,4 +1,4 @@
 # HTML parser page
 
 The HTML parser page (results.html) will be copied here when building
-the CNF test executable
+the certsuite binary

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,9 +54,6 @@ markdown_extensions:
   - pymdownx.mark
   - pymdownx.arithmatex:
       generic: true
-  - pymdownx.snippets:
-      auto_append:
-        - includes/abbreviations.md
 
 plugins:
   - search

--- a/pkg/configuration/config_test.go
+++ b/pkg/configuration/config_test.go
@@ -32,4 +32,12 @@ func TestLoadConfiguration(t *testing.T) {
 	assert.Contains(t, env.CrdFilters, crd1)
 	crd2 := configuration.CrdFilter{NameSuffix: crdSuffix2}
 	assert.Contains(t, env.CrdFilters, crd2)
+	assert.Equal(t, 1, len(env.SkipScalingTestDeployments))
+	assert.Equal(t, "deployment1", env.SkipScalingTestDeployments[0].Name)
+	assert.Equal(t, "tnf", env.SkipScalingTestDeployments[0].Namespace)
+	assert.Equal(t, 1, len(env.SkipScalingTestStatefulSets))
+	assert.Equal(t, "statefulset1", env.SkipScalingTestStatefulSets[0].Name)
+	assert.Equal(t, "tnf", env.SkipScalingTestStatefulSets[0].Namespace)
+	assert.Contains(t, env.ServicesIgnoreList, "hazelcast-platform-controller-manager-service")
+	assert.Contains(t, env.ServicesIgnoreList, "hazelcast-platform-webhook-service")
 }

--- a/pkg/configuration/testdata/tnf_test_config.yml
+++ b/pkg/configuration/testdata/tnf_test_config.yml
@@ -20,12 +20,12 @@ acceptedKernelTaints:
 skipScalingTestDeployments:
   - name: "deployment1"
     namespace: "tnf"
-skipScalingTestStatefulSetNames:
+skipScalingTestStatefulSets:
   - name: "statefulset1"
     namespace: "tnf"
 validProtocolNames:
   - "http3"
   - "sctp"
-ServicesIgnoreList:
+servicesignorelist:
   - "hazelcast-platform-controller-manager-service"
   - "hazelcast-platform-webhook-service"

--- a/tests/identifiers/doclinks.go
+++ b/tests/identifiers/doclinks.go
@@ -51,7 +51,7 @@ const (
 	TestOneProcessPerContainerIdentifierDocLink              = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-one-process-per-container"
 	TestSYSNiceRealtimeCapabilityIdentifierDocLink           = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-sys_nice"
 	TestSysPtraceCapabilityIdentifierDocLink                 = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-sys_ptrace"
-	TestPodRequestsIdentifierDocLink                         = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-requests-limits"
+	TestPodRequestsIdentifierDocLink                         = "https://redhat-best-practices-for-k8s.github.io/guide/#_requests_and_limits_in_kubernetes"
 	TestNamespaceResourceQuotaIdentifierDocLink              = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-memory-allocation"
 	TestNoSSHDaemonsAllowedIdentifierDocLink                 = "https://redhat-best-practices-for-k8s.github.io/guide/#k8s-best-practices-pod-interaction-and-configuration"
 


### PR DESCRIPTION
## Related PRs

| PR | Title | Status |
|----|-------|--------|
| [redhat-best-practices-for-k8s/certsuite#3866](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3866) | docs: align READMEs and MkDocs with the current CLI and config | Merged |
| [redhat-best-practices-for-k8s/checks#52](https://github.com/redhat-best-practices-for-k8s/checks/pull/52) | docs: create CLAUDE.md, update check catalog with 27 missing checks | Merged |
| [redhat-best-practices-for-k8s/certsuite-qe#1546](https://github.com/redhat-best-practices-for-k8s/certsuite-qe/pull/1546) | docs: remove phantom preflight feature, update Makefile targets | Merged |
| [palmsoftware/quick-ocp#168](https://github.com/palmsoftware/quick-ocp/pull/168) | docs: document all inputs and outputs in README | Merged |
| [palmsoftware/quick-ocp#169](https://github.com/palmsoftware/quick-ocp/pull/169) | docs: fix README accuracy and add CLAUDE.md | Open |
| [palmsoftware/quick-k8s#460](https://github.com/palmsoftware/quick-k8s/pull/460) | docs: Fix monitoring, cert-manager, Thanos, and Minikube config docs | Merged |
| [palmsoftware/quick-k8s#461](https://github.com/palmsoftware/quick-k8s/pull/461) | docs: comprehensive documentation fixes and improvements | Open |
| [sebrandon1/succulent-cli#143](https://github.com/sebrandon1/succulent-cli/pull/143) | Sync documentation with the current CLI | Open |
| [sebrandon1/bps-operator#156](https://github.com/sebrandon1/bps-operator/pull/156) | docs: fix stale documentation and update CHANGELOG through v0.0.17 | Open |
| [sebrandon1/eyes-and-ears#138](https://github.com/sebrandon1/eyes-and-ears/pull/138) | docs: audit and refresh README, CLAUDE.md, and agent command | Open |
| [sebrandon1/tls-operator-audit#69](https://github.com/sebrandon1/tls-operator-audit/pull/69) | docs: simplify README and add CLAUDE.md | Merged |
| [sebrandon1/cert-manager-scripts#156](https://github.com/sebrandon1/cert-manager-scripts/pull/156) | Consolidate docs, fix discrepancies, and improve prerequisites | Merged |
| [sebrandon1/tls-compliance-operator#458](https://github.com/sebrandon1/tls-compliance-operator/pull/458) | docs: address documentation gaps across five areas | Merged |
| [sebrandon1/go-skylight#415](https://github.com/sebrandon1/go-skylight/pull/415) | docs: fix missing ctx, wrong photo flags, add template and completion docs | Merged |
| [sebrandon1/go-quay#162](https://github.com/sebrandon1/go-quay/pull/162) | docs: fix library guide method names and complete CLI reference | Merged |

## Summary
- Replace leftover TNF paths, dead commands (`claim-add`, `run --list`), and unused env vars (`SUPPORT_IMAGE`, CRC/preflight vars the binary does not read)
- Match docs and cluster-deploy examples to actual YAML keys, probe namespace `cnf-suite`, `--certsuite-probe-image` (`v0.0.42`), and `--preflight-dockerconfig`
- Fix broken and login-walled links (oc-mirror 4.17 404, GitBook, godoc.org) and the CATALOG guide anchor for resource requests/limits

## Test plan
- [x] CI passes
- [x] `markdownlint` on changed Markdown
- [x] `make check-catalog-links` (requests/limits guide anchor resolves)
- [x] `go test ./pkg/configuration/` (testdata YAML tags now match the struct)
- [x] Spot-check `docs/cluster-deploy` apply paths from repo root