### PR TITLE
fix: probe unsecured ports from the node-local probe pod

### DIFF
--- a/.github/actions/test-scenarios/networking/README.md
+++ b/.github/actions/test-scenarios/networking/README.md
@@ -14,6 +14,20 @@ Validates that the `networking-tls-minimum-version` test correctly checks servic
 | TLS 1.2 Allowed (compliant) | `tls12-allowed.yaml` | TLS 1.2 + 1.3, Intermediate ciphers | `passed` |
 | Plain HTTP (compliant) | `plain-http.yaml` | No TLS | `passed` |
 
+### unsecured-container-ports
+
+Validates that `networking-unsecured-container-ports` probes plaintext TCP
+listeners on every node, not only the node of a randomly chosen probe pod.
+Smoke Kind clusters have two workers; required pod anti-affinity spreads two
+replicas across them. The runner also requires at least two non-compliant
+objects so one same-node plaintext hit plus a cross-node timeout cannot pass
+as a generic FAIL.
+
+| Scenario | Manifest | Workload | Expected Test Result |
+|---|---|---|---|
+| Plain HTTP spread across nodes | `plain-http-spread.yaml` | Two replicas, plaintext :8080, hostname anti-affinity | `failed` (min 2 non-compliant objects) |
+| TLS spread across nodes | `tls-spread.yaml` | Two replicas, TLS :8443, hostname anti-affinity | `passed` (min 2 objects containing "uses TLS") |
+
 ## Adding a new scenario
 
 1. Create a directory under the appropriate test suite (e.g., `networking/<test-name>/`).
@@ -28,7 +42,13 @@ Validates that the `networking-tls-minimum-version` test correctly checks servic
      "path": "networking/<test-name>",
      "manifest": "<workload>.yaml",
      "expected_result": "passed|failed",
+     "min_noncompliant": 2,
+     "min_compliant": 2,
+     "compliant_contains": "uses TLS",
      "output_dir": "<workload>-results"
    }
    ```
+   `min_noncompliant` and `min_compliant` are optional. `compliant_contains`
+   limits the compliant-object count to entries whose details include that
+   string (so an unreachable port cannot satisfy a TLS pass).
    The runner script (`../run-scenarios.sh`) picks up all entries automatically. Validation is data-driven: the runner checks that the test state in `claim.json` matches `expected_result`.

--- a/.github/actions/test-scenarios/networking/unsecured-container-ports/cleanup.sh
+++ b/.github/actions/test-scenarios/networking/unsecured-container-ports/cleanup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Clean up unsecured-container-ports scenario resources.
+
+NAMESPACE="unsecured-ports-ns"
+RESULTS_DIR="${1:-unsecured-ports-results}"
+
+kubectl delete namespace "$NAMESPACE" --ignore-not-found
+rm -rf "$RESULTS_DIR"
+
+echo "Unsecured ports test resources cleaned up."

--- a/.github/actions/test-scenarios/networking/unsecured-container-ports/deploy.sh
+++ b/.github/actions/test-scenarios/networking/unsecured-container-ports/deploy.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy an unsecured-container-ports workload spread across nodes.
+# Usage: deploy.sh <manifest-file>
+
+MANIFEST_FILE="${1:?Usage: deploy.sh <manifest-file>}"
+DEPLOY_NAME="${MANIFEST_FILE%.yaml}"
+
+NAMESPACE="unsecured-ports-ns"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MANIFESTS_DIR="${SCRIPT_DIR}/manifests"
+
+kubectl create namespace "$NAMESPACE"
+
+if [[ "$MANIFEST_FILE" == tls-* ]]; then
+  openssl req -x509 -nodes -days 1 -newkey rsa:2048 \
+    -keyout /tmp/tls.key -out /tmp/tls.crt \
+    -subj "/CN=tls-test.${NAMESPACE}.svc"
+
+  kubectl create secret tls tls-test-cert \
+    --cert=/tmp/tls.crt --key=/tmp/tls.key \
+    -n "$NAMESPACE"
+
+  kubectl create configmap nginx-tls -n "$NAMESPACE" --from-literal=default.conf='
+server {
+    listen 8443 ssl;
+    ssl_certificate /etc/tls/tls.crt;
+    ssl_certificate_key /etc/tls/tls.key;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    location / { return 200 "tls"; }
+}'
+fi
+
+kubectl apply -n "$NAMESPACE" -f "${MANIFESTS_DIR}/${MANIFEST_FILE}"
+kubectl wait deployment -n "$NAMESPACE" "$DEPLOY_NAME" --for=condition=Available --timeout=120s
+
+NODE_COUNT=$(kubectl get pods -n "$NAMESPACE" -l "app=${DEPLOY_NAME}" \
+  -o jsonpath='{range .items[*]}{.spec.nodeName}{"\n"}{end}' | sort -u | grep -c . || true)
+
+if [[ "${NODE_COUNT}" -lt 2 ]]; then
+  echo "FAIL: expected pods on at least 2 nodes, got ${NODE_COUNT}"
+  kubectl get pods -n "$NAMESPACE" -o wide
+  exit 1
+fi
+
+echo "Workload '${DEPLOY_NAME}' deployed on ${NODE_COUNT} nodes."

--- a/.github/actions/test-scenarios/networking/unsecured-container-ports/manifests/certsuite-config.yaml
+++ b/.github/actions/test-scenarios/networking/unsecured-container-ports/manifests/certsuite-config.yaml
@@ -1,0 +1,6 @@
+---
+targetNameSpaces:
+  - name: unsecured-ports-ns
+podsUnderTestLabels:
+  - "unsecured-ports: target"
+operatorsUnderTestLabels: []

--- a/.github/actions/test-scenarios/networking/unsecured-container-ports/manifests/plain-http-spread.yaml
+++ b/.github/actions/test-scenarios/networking/unsecured-container-ports/manifests/plain-http-spread.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: plain-http-spread
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: plain-http-spread
+      unsecured-ports: target
+  template:
+    metadata:
+      labels:
+        app: plain-http-spread
+        unsecured-ports: target
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: plain-http-spread
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            tcpSocket:
+              port: 8080
+            initialDelaySeconds: 1
+            periodSeconds: 2
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: plain-http-spread-svc
+spec:
+  selector:
+    app: plain-http-spread
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/.github/actions/test-scenarios/networking/unsecured-container-ports/manifests/tls-spread.yaml
+++ b/.github/actions/test-scenarios/networking/unsecured-container-ports/manifests/tls-spread.yaml
@@ -1,0 +1,58 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tls-spread
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: tls-spread
+      unsecured-ports: target
+  template:
+    metadata:
+      labels:
+        app: tls-spread
+        unsecured-ports: target
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: tls-spread
+              topologyKey: kubernetes.io/hostname
+      containers:
+        - name: nginx
+          image: nginxinc/nginx-unprivileged:1.27
+          ports:
+            - containerPort: 8443
+          readinessProbe:
+            tcpSocket:
+              port: 8443
+            initialDelaySeconds: 1
+            periodSeconds: 2
+          volumeMounts:
+            - name: tls
+              mountPath: /etc/tls
+              readOnly: true
+            - name: conf
+              mountPath: /etc/nginx/conf.d
+      volumes:
+        - name: tls
+          secret:
+            secretName: tls-test-cert
+        - name: conf
+          configMap:
+            name: nginx-tls
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tls-spread-svc
+spec:
+  selector:
+    app: tls-spread
+  ports:
+    - port: 443
+      targetPort: 8443

--- a/.github/actions/test-scenarios/run-scenarios.sh
+++ b/.github/actions/test-scenarios/run-scenarios.sh
@@ -14,6 +14,25 @@ SCENARIOS_FILE="${SCRIPT_DIR}/scenarios.json"
 LOG_LEVEL="${SMOKE_TESTS_LOG_LEVEL:-info}"
 OVERALL_RC=0
 
+claim_object_count() {
+  local claim_file=$1 test_id=$2 list_name=$3 needle=$4
+  jq -r --arg id "$test_id" --arg list "$list_name" --arg needle "$needle" '
+    .claim.results[$id].checkDetails // "{}"
+    | fromjson?
+    | [.[$list] // [] | .[] | select(($needle == "") or ((.ObjectFieldsValues | join(" ")) | contains($needle)))]
+    | length
+  ' "$claim_file"
+}
+
+require_min_objects() {
+  local label=$1 count=$2 min=$3
+  if [[ "$count" -lt "$min" ]]; then
+    echo "FAIL: expected at least ${min} ${label} objects, got ${count}"
+    return 1
+  fi
+  echo "PASS: ${label} object count ${count} >= ${min}"
+}
+
 scenario_count=$(jq 'length' "$SCENARIOS_FILE")
 echo "=== Running ${scenario_count} test scenario(s) ==="
 
@@ -24,6 +43,9 @@ for i in $(seq 0 $((scenario_count - 1))); do
   MANIFEST=$(jq -r ".[$i].manifest" "$SCENARIOS_FILE")
   OUTPUT_DIR=$(jq -r ".[$i].output_dir" "$SCENARIOS_FILE")
   EXPECTED_RESULT=$(jq -r ".[$i].expected_result" "$SCENARIOS_FILE")
+  MIN_NONCOMPLIANT=$(jq -r ".[$i].min_noncompliant // empty" "$SCENARIOS_FILE")
+  MIN_COMPLIANT=$(jq -r ".[$i].min_compliant // empty" "$SCENARIOS_FILE")
+  COMPLIANT_CONTAINS=$(jq -r ".[$i].compliant_contains // empty" "$SCENARIOS_FILE")
 
   SCENARIO_DIR="${SCRIPT_DIR}/${SCENARIO_PATH}"
   CONFIG_FILE="${SCENARIO_DIR}/manifests/certsuite-config.yaml"
@@ -72,6 +94,14 @@ for i in $(seq 0 $((scenario_count - 1))); do
         RC=1
       else
         echo "PASS: test state '${ACTUAL_STATE}' matches expected '${EXPECTED_RESULT}'"
+        if [[ -n "${MIN_NONCOMPLIANT}" ]]; then
+          NONCOMPLIANT_COUNT=$(claim_object_count "$CLAIM_FILE" "$LABEL_FILTER" "NonCompliantObjectsOut" "")
+          require_min_objects "non-compliant" "$NONCOMPLIANT_COUNT" "$MIN_NONCOMPLIANT" || RC=1
+        fi
+        if [[ -n "${MIN_COMPLIANT}" ]]; then
+          COMPLIANT_COUNT=$(claim_object_count "$CLAIM_FILE" "$LABEL_FILTER" "CompliantObjectsOut" "$COMPLIANT_CONTAINS")
+          require_min_objects "compliant" "$COMPLIANT_COUNT" "$MIN_COMPLIANT" || RC=1
+        fi
       fi
     fi
   fi
@@ -80,7 +110,7 @@ for i in $(seq 0 $((scenario_count - 1))); do
   if [[ $RC -ne 0 ]]; then
     echo "--- Scenario certsuite.log (debug) ---"
     if [[ -f "certsuite.log" ]]; then
-      grep -i "tls\|tlsversion\|Probing\|exec.*fallback\|probe.*pod\|probePods\|DaemonSet\|daemonset\|cnf-suite" certsuite.log || echo "(no matching log lines)"
+      grep -iE "tls|tlsversion|Probing|exec.*fallback|probe.*pod|probePods|DaemonSet|daemonset|cnf-suite|unsecured|plaintext|openssl|TLS probe" certsuite.log || echo "(no matching log lines)"
     else
       echo "(certsuite.log not found)"
     fi

--- a/.github/actions/test-scenarios/scenarios.json
+++ b/.github/actions/test-scenarios/scenarios.json
@@ -34,5 +34,26 @@
     "manifest": "plain-http.yaml",
     "expected_result": "passed",
     "output_dir": "plain-http-results"
+  },
+  {
+    "name": "Unsecured container ports across nodes (non-compliant)",
+    "description": "Deploys two plaintext HTTP pods with required hostname anti-affinity so they land on different nodes. networking-unsecured-container-ports must fail both pods as plaintext. A single plaintext failure with the other pod marked unreachable is the cross-node openssl flake this scenario guards against.",
+    "label_filter": "networking-unsecured-container-ports",
+    "path": "networking/unsecured-container-ports",
+    "manifest": "plain-http-spread.yaml",
+    "expected_result": "failed",
+    "min_noncompliant": 2,
+    "output_dir": "plain-http-spread-results"
+  },
+  {
+    "name": "Secured container ports across nodes (compliant)",
+    "description": "Deploys two TLS HTTP pods with required hostname anti-affinity so they land on different nodes. networking-unsecured-container-ports must pass, and both pods must be classified as using TLS. A pass with one pod marked unreachable is the cross-node openssl flake this scenario guards against.",
+    "label_filter": "networking-unsecured-container-ports",
+    "path": "networking/unsecured-container-ports",
+    "manifest": "tls-spread.yaml",
+    "expected_result": "passed",
+    "min_compliant": 2,
+    "compliant_contains": "uses TLS",
+    "output_dir": "tls-spread-results"
   }
 ]

--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -51,7 +51,7 @@ func (p *Process) String() string {
 // information from a node where a pod/container under test is running.
 func GetNodeProbePodContext(node string, env *provider.TestEnvironment) (clientsholder.Context, error) {
 	probePod := env.ProbePods[node]
-	if probePod == nil {
+	if probePod == nil || len(probePod.Spec.Containers) == 0 {
 		return clientsholder.Context{}, fmt.Errorf("probe pod not found on node %s", node)
 	}
 

--- a/internal/crclient/crclient_test.go
+++ b/internal/crclient/crclient_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2022 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,3 +15,50 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package crclient
+
+import (
+	"testing"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetNodeProbePodContext(t *testing.T) {
+	t.Parallel()
+
+	usable := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "probe-a", Namespace: "cnf-suite"},
+		Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "container-00"}}},
+	}
+
+	tests := []struct {
+		name      string
+		node      string
+		probePods map[string]*corev1.Pod
+		wantErr   bool
+		wantPod   string
+	}{
+		{name: "missing node", node: "node-b", probePods: map[string]*corev1.Pod{"node-a": usable}, wantErr: true},
+		{name: "empty node name", node: "", probePods: map[string]*corev1.Pod{"node-a": usable}, wantErr: true},
+		{name: "nil probe", node: "node-a", probePods: map[string]*corev1.Pod{"node-a": nil}, wantErr: true},
+		{name: "no containers", node: "node-a", probePods: map[string]*corev1.Pod{"node-a": {ObjectMeta: metav1.ObjectMeta{Name: "probe"}}}, wantErr: true},
+		{name: "usable probe", node: "node-a", probePods: map[string]*corev1.Pod{"node-a": usable}, wantPod: "probe-a"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctx, err := GetNodeProbePodContext(tt.node, &provider.TestEnvironment{ProbePods: tt.probePods})
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantPod, ctx.GetPodName())
+			assert.Equal(t, "cnf-suite", ctx.GetNamespace())
+			assert.Equal(t, "container-00", ctx.GetContainerName())
+		})
+	}
+}

--- a/tests/networking/icmp/icmp_test.go
+++ b/tests/networking/icmp/icmp_test.go
@@ -989,12 +989,5 @@ var TestPingSuccess = func(sourceContainerID *provider.Container, targetContaine
 }
 
 var TestPingFailure = func(sourceContainerID *provider.Container, targetContainerIP netcommons.ContainerIP, count int) (results PingResults, err error) {
-	return PingResults{
-			outcome:     testhelper.FAILURE,
-			transmitted: 10,
-			received:    5,
-			errors:      5,
-		}, fmt.Errorf(
-			"ping failed",
-		)
+	return PingResults{outcome: testhelper.FAILURE, transmitted: 10, received: 5, errors: 5}, fmt.Errorf("ping failed")
 }

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/crclient"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
@@ -270,16 +271,15 @@ func parseNonTLSPortsAnnotation(pod *provider.Pod, check *checksdb.Check) map[in
 	return exempt
 }
 
-func getFirstProbeContext(env *provider.TestEnvironment) (clientsholder.Command, clientsholder.Context, bool) {
-	for _, probePod := range env.ProbePods {
-		if probePod == nil || len(probePod.Spec.Containers) == 0 {
-			continue
+func usableProbeContexts(env *provider.TestEnvironment) map[string]clientsholder.Context {
+	out := make(map[string]clientsholder.Context, len(env.ProbePods))
+	for nodeName := range env.ProbePods {
+		ctx, err := crclient.GetNodeProbePodContext(nodeName, env)
+		if err == nil {
+			out[nodeName] = ctx
 		}
-		return clientsholder.GetClientsHolder(), clientsholder.NewContext(
-			probePod.Namespace, probePod.Name, probePod.Spec.Containers[0].Name,
-		), true
 	}
-	return nil, clientsholder.Context{}, false
+	return out
 }
 
 func newPortReportObject(namespace, name, message string, compliant bool, port netutil.PortInfo) *testhelper.ReportObject {
@@ -289,10 +289,45 @@ func newPortReportObject(namespace, name, message string, compliant bool, port n
 		AddField(testhelper.PortProtocol, port.Protocol)
 }
 
+// getListeningPorts is replaced in tests so checkPodPortTLS can run without nsenter.
+var getListeningPorts = netutil.GetListeningPorts
+
+func addPortTLSResult(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult, port netutil.PortInfo, isTLS, reachable bool, reason string) {
+	switch {
+	case !reachable:
+		result.AddCompliantObject(
+			newPortReportObject(put.Namespace, put.Name,
+				fmt.Sprintf("Port %d unreachable (%s)", port.PortNumber, reason), true, port))
+	case isTLS:
+		result.AddCompliantObject(
+			newPortReportObject(put.Namespace, put.Name,
+				fmt.Sprintf("Port %d uses TLS (%s)", port.PortNumber, reason), true, port))
+	default:
+		check.LogError("Port %d on %q is plaintext (%s)", port.PortNumber, put, reason)
+		result.AddNonCompliantObject(
+			newPortReportObject(put.Namespace, put.Name,
+				fmt.Sprintf("Port %d accepts plaintext connections (%s)", port.PortNumber, reason), false, port))
+	}
+}
+
 func checkPodPortTLS(check *checksdb.Check, put *provider.Pod, ch clientsholder.Command,
 	probeCtx clientsholder.Context, result *checksdb.ParallelResult) {
-	firstContainer := put.Containers[0]
-	listeningPorts, err := netutil.GetListeningPorts(firstContainer)
+	if len(put.Containers) == 0 {
+		check.LogError("Pod %q has no containers", put)
+		result.AddNonCompliantObject(
+			testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod has no containers", false))
+		return
+	}
+
+	podIP := put.Status.PodIP
+	if podIP == "" {
+		check.LogError("Pod %q has no PodIP", put)
+		result.AddNonCompliantObject(
+			testhelper.NewPodReportObject(put.Namespace, put.Name, "Pod has no PodIP", false))
+		return
+	}
+
+	listeningPorts, err := getListeningPorts(put.Containers[0])
 	if err != nil {
 		check.LogError("Failed to get pod %q listening ports, err: %v", put, err)
 		result.AddNonCompliantObject(
@@ -307,11 +342,6 @@ func checkPodPortTLS(check *checksdb.Check, put *provider.Pod, ch clientsholder.
 	}
 
 	exemptPorts := parseNonTLSPortsAnnotation(put, check)
-	podIP := put.Status.PodIP
-	if podIP == "" {
-		check.LogError("Pod %q has no PodIP, skipping TLS probe", put)
-		return
-	}
 
 	for port := range listeningPorts {
 		if port.Protocol != "TCP" {
@@ -330,35 +360,28 @@ func checkPodPortTLS(check *checksdb.Check, put *provider.Pod, ch clientsholder.
 		isTLS, reachable, reason := tlsversion.IsPortTLS(ch, probeCtx, podIP, port.PortNumber)
 		check.LogInfo("TLS probe %s:%d: isTLS=%v reachable=%v reason=%q",
 			podIP, port.PortNumber, isTLS, reachable, reason)
-
-		switch {
-		case !reachable:
-			result.AddCompliantObject(
-				newPortReportObject(put.Namespace, put.Name,
-					fmt.Sprintf("Port %d unreachable (%s)", port.PortNumber, reason), true, port))
-		case isTLS:
-			result.AddCompliantObject(
-				newPortReportObject(put.Namespace, put.Name,
-					fmt.Sprintf("Port %d uses TLS (%s)", port.PortNumber, reason), true, port))
-		default:
-			check.LogError("Port %d on %q is plaintext (%s)", port.PortNumber, put, reason)
-			result.AddNonCompliantObject(
-				newPortReportObject(put.Namespace, put.Name,
-					fmt.Sprintf("Port %d accepts plaintext connections (%s)", port.PortNumber, reason), false, port))
-		}
+		addPortTLSResult(check, put, result, port, isTLS, reachable, reason)
 	}
 }
 
 func testUnsecuredContainerPorts(check *checksdb.Check, env *provider.TestEnvironment) {
-	ch, probeCtx, probeAvailable := getFirstProbeContext(env)
-	if !probeAvailable {
+	probes := usableProbeContexts(env)
+	if len(probes) == 0 {
 		check.LogError("No probe pods available for TLS checks, skipping")
 		check.SetResult(nil, nil)
 		return
 	}
 
 	checksdb.ForEachParallel(check, env.Pods, len(env.ProbePods), func(check *checksdb.Check, put *provider.Pod, result *checksdb.ParallelResult) {
-		checkPodPortTLS(check, put, ch, probeCtx, result)
+		probeCtx, ok := probes[put.Spec.NodeName]
+		if !ok {
+			check.LogError("No probe pod available on node %q for pod %q", put.Spec.NodeName, put)
+			result.AddNonCompliantObject(
+				testhelper.NewPodReportObject(put.Namespace, put.Name,
+					fmt.Sprintf("No probe pod available on node %q", put.Spec.NodeName), false))
+			return
+		}
+		checkPodPortTLS(check, put, clientsholder.GetClientsHolder(), probeCtx, result)
 	})
 }
 

--- a/tests/networking/suite_test.go
+++ b/tests/networking/suite_test.go
@@ -17,8 +17,11 @@
 package networking
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/testhelper"
@@ -134,47 +137,52 @@ func TestNewPortReportObject(t *testing.T) {
 	assert.Contains(t, nonCompliant.ObjectFieldsValues, "plaintext")
 }
 
-func TestGetFirstProbeContext(t *testing.T) {
+func testProbePod(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "cnf-suite"},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "container-00"}},
+		},
+	}
+}
+
+func TestUsableProbeContexts(t *testing.T) {
 	t.Parallel()
 
+	usable := testProbePod("probe-a")
 	tests := []struct {
 		name      string
 		probePods map[string]*corev1.Pod
-		wantOK    bool
+		wantPods  map[string]string
 	}{
+		{name: "nil map", probePods: nil, wantPods: map[string]string{}},
+		{name: "empty map", probePods: map[string]*corev1.Pod{}, wantPods: map[string]string{}},
+		{name: "nil probe", probePods: map[string]*corev1.Pod{"node-a": nil}, wantPods: map[string]string{}},
+		{name: "no containers", probePods: map[string]*corev1.Pod{"node-a": {ObjectMeta: metav1.ObjectMeta{Name: "probe"}}}, wantPods: map[string]string{}},
+		{name: "usable probe", probePods: map[string]*corev1.Pod{"node-a": usable}, wantPods: map[string]string{"node-a": "probe-a"}},
+		{name: "mixed nil and usable", probePods: map[string]*corev1.Pod{"node-a": nil, "node-b": usable}, wantPods: map[string]string{"node-b": "probe-a"}},
 		{
-			name:      "nil map",
-			probePods: nil,
-			wantOK:    false,
-		},
-		{
-			name:      "empty map",
-			probePods: map[string]*corev1.Pod{},
-			wantOK:    false,
-		},
-		{
-			name:      "nil probe pod",
-			probePods: map[string]*corev1.Pod{"node1": nil},
-			wantOK:    false,
-		},
-		{
-			name: "probe pod with no containers",
+			name: "two nodes",
 			probePods: map[string]*corev1.Pod{
-				"node1": {
-					ObjectMeta: metav1.ObjectMeta{Name: "probe", Namespace: "cnf-certsuite"},
-					Spec:       corev1.PodSpec{},
-				},
+				"node-a": testProbePod("probe-a"),
+				"node-b": testProbePod("probe-b"),
 			},
-			wantOK: false,
+			wantPods: map[string]string{"node-a": "probe-a", "node-b": "probe-b"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			env := &provider.TestEnvironment{ProbePods: tt.probePods}
-			_, _, ok := getFirstProbeContext(env)
-			assert.Equal(t, tt.wantOK, ok)
+			got := usableProbeContexts(&provider.TestEnvironment{ProbePods: tt.probePods})
+			assert.Len(t, got, len(tt.wantPods))
+			for node, wantPod := range tt.wantPods {
+				ctx, ok := got[node]
+				assert.True(t, ok, "missing context for node %s", node)
+				assert.Equal(t, wantPod, ctx.GetPodName())
+				assert.Equal(t, "cnf-suite", ctx.GetNamespace())
+				assert.Equal(t, "container-00", ctx.GetContainerName())
+			}
 		})
 	}
 }
@@ -186,4 +194,185 @@ func TestUnsecuredContainerPorts_NoProbePods(t *testing.T) {
 	env := &provider.TestEnvironment{ProbePods: map[string]*corev1.Pod{}}
 	testUnsecuredContainerPorts(check, env)
 	assert.Equal(t, checksdb.CheckResultSkipped, check.Result.String())
+}
+
+func TestUnsecuredContainerPorts_MissingNodeLocalProbe(t *testing.T) {
+	t.Parallel()
+
+	check := checksdb.NewCheck("test-unsecured-ports", []string{"test"})
+	env := &provider.TestEnvironment{
+		ProbePods: map[string]*corev1.Pod{
+			"node-a": testProbePod("probe-a"),
+		},
+		Pods: []*provider.Pod{
+			{
+				Pod: &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Name: "workload", Namespace: "app-ns"},
+					Spec:       corev1.PodSpec{NodeName: "node-b"},
+				},
+			},
+		},
+	}
+	testUnsecuredContainerPorts(check, env)
+	assert.Equal(t, checksdb.CheckResultFailed, check.Result.String())
+	assert.Contains(t, check.GetLogs(), `No probe pod available on node "node-b"`)
+}
+
+func joinedReportValues(objs []*testhelper.ReportObject) string {
+	var parts []string
+	for _, o := range objs {
+		parts = append(parts, o.ObjectFieldsValues...)
+	}
+	return strings.Join(parts, " ")
+}
+
+func TestCheckPodPortTLS(t *testing.T) {
+	orig := getListeningPorts
+	t.Cleanup(func() { getListeningPorts = orig })
+
+	probeCtx := clientsholder.NewContext("cnf-suite", "probe-a", "container-00")
+	app := &provider.Container{Container: &corev1.Container{Name: "app"}}
+	istio := &provider.Container{Container: &corev1.Container{Name: provider.IstioProxyContainerName}}
+	tcp8080 := netutil.PortInfo{PortNumber: 8080, Protocol: "TCP"}
+	udp53 := netutil.PortInfo{PortNumber: 53, Protocol: "UDP"}
+	istioPort := netutil.PortInfo{PortNumber: 15001, Protocol: "TCP"}
+
+	newPod := func(ip string, anns map[string]string, containers ...*provider.Container) *provider.Pod {
+		return &provider.Pod{
+			Pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Name: "workload", Namespace: "app-ns", Annotations: anns},
+				Status:     corev1.PodStatus{PodIP: ip},
+			},
+			Containers: containers,
+		}
+	}
+
+	tests := []struct {
+		name                     string
+		pod                      *provider.Pod
+		ports                    map[netutil.PortInfo]bool
+		portsErr                 error
+		opensslStdout            string
+		opensslErr               error
+		wantCompliant            int
+		wantNonCompliant         int
+		wantCompliantContains    string
+		wantNonCompliantContains string
+		wantCalls                int
+	}{
+		{
+			name:                     "listening ports error",
+			pod:                      newPod("10.0.0.1", nil, app),
+			portsErr:                 fmt.Errorf("ss failed"),
+			wantNonCompliant:         1,
+			wantNonCompliantContains: "Failed to get listening ports",
+		},
+		{
+			name:                  "no listening ports",
+			pod:                   newPod("10.0.0.1", nil, app),
+			ports:                 map[netutil.PortInfo]bool{},
+			wantCompliant:         1,
+			wantCompliantContains: "No listening ports",
+		},
+		{
+			name:                     "no containers",
+			pod:                      newPod("10.0.0.1", nil),
+			wantNonCompliant:         1,
+			wantNonCompliantContains: "no containers",
+		},
+		{
+			name:                     "empty pod IP",
+			pod:                      newPod("", nil, app),
+			ports:                    map[netutil.PortInfo]bool{tcp8080: true},
+			wantNonCompliant:         1,
+			wantNonCompliantContains: "no PodIP",
+		},
+		{
+			name:  "udp only is ignored",
+			pod:   newPod("10.0.0.1", nil, app),
+			ports: map[netutil.PortInfo]bool{udp53: true},
+		},
+		{
+			name:                  "exempt annotation",
+			pod:                   newPod("10.0.0.1", map[string]string{nonTLSPortsAnnotation: "8080"}, app),
+			ports:                 map[netutil.PortInfo]bool{tcp8080: true},
+			wantCompliant:         1,
+			wantCompliantContains: "exempt via annotation",
+		},
+		{
+			name:                  "tls port",
+			pod:                   newPod("10.0.0.1", nil, app),
+			ports:                 map[netutil.PortInfo]bool{tcp8080: true},
+			opensslStdout:         "CONNECTED(00000003)\n---\nProtocol  : TLSv1.3\nCipher    : TLS_AES_256_GCM_SHA384\n---",
+			wantCompliant:         1,
+			wantCompliantContains: "uses TLS",
+			wantCalls:             1,
+		},
+		{
+			name:                     "plaintext port",
+			pod:                      newPod("10.0.0.1", nil, app),
+			ports:                    map[netutil.PortInfo]bool{tcp8080: true},
+			opensslStdout:            "CONNECTED(00000003)\n---\nCipher is (NONE)\npacket length too long\n---",
+			wantNonCompliant:         1,
+			wantNonCompliantContains: "plaintext",
+			wantCalls:                1,
+		},
+		{
+			name:                  "unreachable port",
+			pod:                   newPod("10.0.0.1", nil, app),
+			ports:                 map[netutil.PortInfo]bool{tcp8080: true},
+			opensslStdout:         "connect:errno=111\nConnection refused",
+			wantCompliant:         1,
+			wantCompliantContains: "unreachable",
+			wantCalls:             1,
+		},
+		{
+			name:                  "exec probe failed treated as unreachable",
+			pod:                   newPod("10.0.0.1", nil, app),
+			ports:                 map[netutil.PortInfo]bool{tcp8080: true},
+			opensslErr:            fmt.Errorf("command not found"),
+			wantCompliant:         1,
+			wantCompliantContains: "unreachable",
+			wantCalls:             1,
+		},
+		{
+			name:  "istio reserved port skipped",
+			pod:   newPod("10.0.0.1", nil, app, istio),
+			ports: map[netutil.PortInfo]bool{istioPort: true},
+		},
+		{
+			name:                     "istio reserved port ignored, app port classified",
+			pod:                      newPod("10.0.0.1", nil, app, istio),
+			ports:                    map[netutil.PortInfo]bool{istioPort: true, tcp8080: true},
+			opensslStdout:            "CONNECTED(00000003)\n---\nCipher is (NONE)\npacket length too long\n---",
+			wantNonCompliant:         1,
+			wantNonCompliantContains: "plaintext",
+			wantCalls:                1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			getListeningPorts = func(*provider.Container) (map[netutil.PortInfo]bool, error) {
+				return tt.ports, tt.portsErr
+			}
+			mock := &clientsholder.MockCommand{
+				ExecFunc: func(_ clientsholder.Context, _ string) (string, string, error) {
+					return tt.opensslStdout, "", tt.opensslErr
+				},
+			}
+			result := &checksdb.ParallelResult{}
+			checkPodPortTLS(checksdb.NewCheck("test-unsecured-ports", []string{"test"}), tt.pod, mock, probeCtx, result)
+			compliant, nonCompliant := result.Results()
+			assert.Len(t, compliant, tt.wantCompliant)
+			assert.Len(t, nonCompliant, tt.wantNonCompliant)
+			if tt.wantCompliantContains != "" {
+				assert.Contains(t, joinedReportValues(compliant), tt.wantCompliantContains)
+			}
+			if tt.wantNonCompliantContains != "" {
+				assert.Contains(t, joinedReportValues(nonCompliant), tt.wantNonCompliantContains)
+			}
+			assert.Equal(t, tt.wantCalls, mock.CallCount())
+		})
+	}
 }

--- a/tests/networking/suite_test.go
+++ b/tests/networking/suite_test.go
@@ -309,6 +309,15 @@ func TestCheckPodPortTLS(t *testing.T) {
 			wantCalls:             1,
 		},
 		{
+			name:                  "openssl 3 tls 1.3 cipher is",
+			pod:                   newPod("10.0.0.1", nil, app),
+			ports:                 map[netutil.PortInfo]bool{tcp8080: true},
+			opensslStdout:         "CONNECTED(00000003)\n---\nNew, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384\nProtocol: TLSv1.3\n---",
+			wantCompliant:         1,
+			wantCompliantContains: "uses TLS",
+			wantCalls:             1,
+		},
+		{
 			name:                     "plaintext port",
 			pod:                      newPod("10.0.0.1", nil, app),
 			ports:                    map[netutil.PortInfo]bool{tcp8080: true},

--- a/tests/networking/tlsversion/tlsversion.go
+++ b/tests/networking/tlsversion/tlsversion.go
@@ -19,6 +19,7 @@ package tlsversion
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"strconv"
@@ -48,13 +49,18 @@ const (
 	truncateLen = 200
 
 	// openssl output patterns used to classify TLS probe results.
-	opensslCipherNone       = "Cipher is (NONE)"
-	opensslAlertProtoVer    = "alert protocol version"
-	opensslAlertHandshake   = "alert handshake failure"
-	opensslHandshakeFailure = "handshake failure"
-	opensslNoCiphers        = "no ciphers available"
-	opensslConnected        = "CONNECTED"
-	opensslConnErrno        = "errno"
+	opensslCipherColonSpaced = "Cipher    :"
+	opensslCipherColon       = "Cipher:"
+	opensslCipherIsPrefix    = "Cipher is "
+	opensslCipherNoneValue   = "(NONE)"
+	opensslCipherZero        = "0000"
+	opensslCipherNone        = opensslCipherIsPrefix + opensslCipherNoneValue
+	opensslAlertProtoVer     = "alert protocol version"
+	opensslAlertHandshake    = "alert handshake failure"
+	opensslHandshakeFailure  = "handshake failure"
+	opensslNoCiphers         = "no ciphers available"
+	opensslConnected         = "CONNECTED"
+	opensslConnErrno         = "errno"
 
 	// OCPTLSProfileEnforcementVersion is the minimum OCP version at which the
 	// APIServer CR's TLS security profile is reliably enforced. On older versions,
@@ -68,7 +74,10 @@ const (
 
 	cipherECDHERSAAES128GCMSHA256 = "ECDHE-RSA-AES128-GCM-SHA256"
 	reasonPortUnreachable         = "port unreachable"
-	reasonUnknown                 = "unknown"
+
+	// GNU timeout exits 124 when openssl s_client does not finish in time.
+	opensslTimeoutExitCode  = 124
+	opensslTLSProbeAttempts = 3
 )
 
 // TLSPolicy holds the resolved effective TLS policy for the cluster.
@@ -319,12 +328,25 @@ func CheckServiceTLSCompliance(check *checksdb.Check, env *provider.TestEnvironm
 	return compliant, nonCompliant
 }
 
+func isOpensslTimeout(err error) bool {
+	var execErr *clientsholder.ExecError
+	return errors.As(err, &execErr) && execErr.HasExitCode(opensslTimeoutExitCode)
+}
+
 // IsPortTLS probes a single TCP port via openssl to determine whether it speaks TLS.
 // It does not validate TLS version or cipher compliance — only whether TLS is present.
 func IsPortTLS(ch clientsholder.Command, ctx clientsholder.Context, address string, port int32) (isTLS, reachable bool, reason string) {
 	endpoint := net.JoinHostPort(address, strconv.Itoa(int(port)))
 	cmd := fmt.Sprintf("echo | timeout 5 openssl s_client -connect %s 2>&1", endpoint)
-	stdout, _, err := ch.ExecCommandContainer(ctx, cmd)
+
+	var stdout string
+	var err error
+	for range opensslTLSProbeAttempts {
+		stdout, _, err = ch.ExecCommandContainer(ctx, cmd)
+		if err == nil || hasOpensslOutput(stdout) || !isOpensslTimeout(err) {
+			break
+		}
+	}
 
 	if err != nil && !hasOpensslOutput(stdout) {
 		return false, false, fmt.Sprintf("exec probe failed: %v", err)
@@ -345,14 +367,8 @@ func IsPortTLS(ch clientsholder.Command, ctx clientsholder.Context, address stri
 		return true, true, "TLS server detected (handshake alert)"
 	}
 
-	// Successful TLS handshake: cipher is not NONE
-	if !strings.Contains(stdout, opensslCipherNone) {
-		if strings.Contains(stdout, "Cipher    :") || strings.Contains(stdout, "Cipher:") {
-			cipher := extractOpenSSLCipher(stdout)
-			if cipher != "" && cipher != "0000" && cipher != "(NONE)" {
-				return true, true, fmt.Sprintf("TLS negotiated (cipher: %s)", cipher)
-			}
-		}
+	if cipher := extractOpenSSLCipher(stdout); isNegotiatedCipher(cipher) {
+		return true, true, fmt.Sprintf("TLS negotiated (cipher: %s)", cipher)
 	}
 
 	// Connected but no TLS indicators — plaintext service
@@ -639,20 +655,18 @@ func probeExecCipherCompliance(ch clientsholder.Command, ctx clientsholder.Conte
 		return nil
 	}
 
-	// Server negotiated a cipher from the disallowed set — non-compliant.
-	if strings.Contains(stdout, "Cipher    :") || strings.Contains(stdout, "Cipher:") {
-		cipherName := extractOpenSSLCipher(stdout)
-		result := TLSProbeResult{
-			Compliant:     false,
-			IsTLS:         true,
-			Reachable:     true,
-			NegotiatedVer: TLSVersionNameTLS12,
-			Reason:        fmt.Sprintf("server accepted disallowed cipher %s (not in %s profile, via exec probe)", cipherName, policy.ProfileType),
-		}
-		return &result
+	cipherName := extractOpenSSLCipher(stdout)
+	if !isNegotiatedCipher(cipherName) {
+		return nil
 	}
 
-	return nil
+	return &TLSProbeResult{
+		Compliant:     false,
+		IsTLS:         true,
+		Reachable:     true,
+		NegotiatedVer: TLSVersionNameTLS12,
+		Reason:        fmt.Sprintf("server accepted disallowed cipher %s (not in %s profile, via exec probe)", cipherName, policy.ProfileType),
+	}
 }
 
 // computeDisallowedOpenSSLCiphers returns OpenSSL cipher names that are NOT in the policy's allowed list.
@@ -671,19 +685,27 @@ func computeDisallowedOpenSSLCiphers(policy TLSPolicy) []string {
 	return disallowed
 }
 
-// extractOpenSSLCipher parses the "Cipher    :" or "Cipher:" line from openssl
-// s_client output and returns the negotiated cipher name.
+// extractOpenSSLCipher parses the negotiated cipher name from openssl s_client
+// output. OpenSSL 1.1 uses "Cipher    : NAME" / "Cipher: NAME"; OpenSSL 3 also
+// emits "Cipher is NAME" (including on the "New, TLSv1.3, Cipher is NAME" line).
 func extractOpenSSLCipher(stdout string) string {
 	for line := range strings.SplitSeq(stdout, "\n") {
 		trimmed := strings.TrimSpace(line)
-		if after, ok := strings.CutPrefix(trimmed, "Cipher    :"); ok {
+		if after, ok := strings.CutPrefix(trimmed, opensslCipherColonSpaced); ok {
 			return strings.TrimSpace(after)
 		}
-		if after, ok := strings.CutPrefix(trimmed, "Cipher:"); ok {
+		if after, ok := strings.CutPrefix(trimmed, opensslCipherColon); ok {
+			return strings.TrimSpace(after)
+		}
+		if _, after, ok := strings.Cut(trimmed, opensslCipherIsPrefix); ok {
 			return strings.TrimSpace(after)
 		}
 	}
-	return reasonUnknown
+	return ""
+}
+
+func isNegotiatedCipher(cipher string) bool {
+	return cipher != "" && cipher != opensslCipherZero && cipher != opensslCipherNoneValue
 }
 
 // opensslVersionFlag converts a Go TLS version constant to the corresponding

--- a/tests/networking/tlsversion/tlsversion_test.go
+++ b/tests/networking/tlsversion/tlsversion_test.go
@@ -1273,6 +1273,28 @@ func TestProbeExecCipherCompliance_TLS13SkipsCipherCheck(t *testing.T) {
 	ctx := clientsholder.NewContext("ns", "pod", "container")
 	result := probeExecCipherCompliance(mock, ctx, "10.0.0.1:443", modernPolicy())
 	assert.Nil(t, result, "Modern profile (TLS 1.3) should skip cipher check")
+	assert.Equal(t, 0, mock.CallCount())
+}
+
+func TestProbeExecCipherCompliance_OldProfileSkips(t *testing.T) {
+	mock := newMockCommand()
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	oldPolicy := ResolveTLSProfile(&configv1.TLSSecurityProfile{Type: configv1.TLSProfileOldType})
+	result := probeExecCipherCompliance(mock, ctx, "10.0.0.1:443", oldPolicy)
+	assert.Nil(t, result, "Old profile has no disallowed ciphers to probe")
+	assert.Equal(t, 0, mock.CallCount())
+}
+
+func TestProbeExecCipherCompliance_NoNegotiatedCipher(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "-cipher",
+			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\n---",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	result := probeExecCipherCompliance(mock, ctx, "10.0.0.1:443", intermediatePolicy())
+	assert.Nil(t, result, "expected nil when handshake was not rejected and no cipher was negotiated")
+	assert.Equal(t, 1, mock.CallCount())
 }
 
 func TestProbeExecCipherCompliance_ServerRejectsDisallowed(t *testing.T) {

--- a/tests/networking/tlsversion/tlsversion_test.go
+++ b/tests/networking/tlsversion/tlsversion_test.go
@@ -492,6 +492,20 @@ func TestIsPortTLS_TLSServer(t *testing.T) {
 	assert.Contains(t, reason, "TLS negotiated")
 }
 
+func TestIsPortTLS_OpenSSL3TLS13Format(t *testing.T) {
+	mock := newMockCommand(
+		mockPattern{key: "s_client",
+			stdout: "CONNECTED(00000003)\n---\nNew, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384\nProtocol: TLSv1.3\n---",
+		},
+	)
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 8443)
+	assert.True(t, isTLS, "expected TLS from OpenSSL 3 TLS 1.3 output, reason: %s", reason)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "TLS negotiated")
+	assert.Contains(t, reason, "TLS_AES_256_GCM_SHA384")
+}
+
 func TestIsPortTLS_PlaintextService(t *testing.T) {
 	mock := newMockCommand(
 		mockPattern{key: "s_client",
@@ -1060,6 +1074,101 @@ func TestIsPortTLS_IPv6Address(t *testing.T) {
 	assert.Contains(t, mock.Calls()[0].Command, "[2001:db8::1]:443")
 }
 
+func timeoutExecErr() error {
+	return &clientsholder.ExecError{
+		Command:   "openssl s_client",
+		Namespace: "ns",
+		PodName:   "pod",
+		ExitCode:  opensslTimeoutExitCode,
+		Err:       fmt.Errorf("command terminated with exit code %d", opensslTimeoutExitCode),
+	}
+}
+
+func TestIsOpensslTimeout(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "generic error", err: fmt.Errorf("command not found"), want: false},
+		{name: "wrong exit code", err: &clientsholder.ExecError{ExitCode: 1, Err: fmt.Errorf("fail")}, want: false},
+		{name: "timeout 124", err: timeoutExecErr(), want: true},
+		{name: "wrapped timeout", err: fmt.Errorf("probe: %w", timeoutExecErr()), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, isOpensslTimeout(tt.err))
+		})
+	}
+}
+
+func TestIsPortTLS_TimeoutThenPlaintext(t *testing.T) {
+	mock := &clientsholder.MockCommand{}
+	mock.ExecFunc = func(_ clientsholder.Context, _ string) (string, string, error) {
+		if mock.CallCount() < 2 {
+			return "", "", timeoutExecErr()
+		}
+		return "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\n---", "", nil
+	}
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 8080)
+	assert.False(t, isTLS)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "plaintext")
+	assert.Equal(t, 2, mock.CallCount())
+}
+
+func TestIsPortTLS_TimeoutExhausted(t *testing.T) {
+	mock := &clientsholder.MockCommand{
+		ExecFunc: func(_ clientsholder.Context, _ string) (string, string, error) {
+			return "", "", timeoutExecErr()
+		},
+	}
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 8080)
+	assert.False(t, isTLS)
+	assert.False(t, reachable)
+	assert.Contains(t, reason, "exec probe failed")
+	assert.Equal(t, opensslTLSProbeAttempts, mock.CallCount())
+}
+
+func TestIsPortTLS_TimeoutNotRetriedWhenConnected(t *testing.T) {
+	mock := &clientsholder.MockCommand{
+		ExecFunc: func(_ clientsholder.Context, _ string) (string, string, error) {
+			return "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\n---", "", timeoutExecErr()
+		},
+	}
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 8080)
+	assert.False(t, isTLS)
+	assert.True(t, reachable)
+	assert.Contains(t, reason, "plaintext")
+	assert.Equal(t, 1, mock.CallCount())
+}
+
+func TestIsPortTLS_NonTimeoutExecNotRetried(t *testing.T) {
+	mock := &clientsholder.MockCommand{
+		ExecFunc: func(_ clientsholder.Context, _ string) (string, string, error) {
+			return "", "", fmt.Errorf("command not found")
+		},
+	}
+
+	ctx := clientsholder.NewContext("ns", "pod", "container")
+	isTLS, reachable, reason := IsPortTLS(mock, ctx, "10.0.0.1", 8080)
+	assert.False(t, isTLS)
+	assert.False(t, reachable)
+	assert.Contains(t, reason, "exec probe failed")
+	assert.Equal(t, 1, mock.CallCount())
+}
+
 func TestExtractOpenSSLCipher(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -1068,9 +1177,11 @@ func TestExtractOpenSSLCipher(t *testing.T) {
 	}{
 		{"with spaces", "Cipher    : ECDHE-RSA-AES128-GCM-SHA256\nProtocol  : TLSv1.2", "ECDHE-RSA-AES128-GCM-SHA256"},
 		{"without spaces", "Cipher: TLS_AES_256_GCM_SHA384\nProtocol: TLSv1.3", "TLS_AES_256_GCM_SHA384"},
+		{"openssl 3 cipher is", "New, TLSv1.3, Cipher is TLS_AES_256_GCM_SHA384", "TLS_AES_256_GCM_SHA384"},
+		{"cipher is none", "Cipher is (NONE)\nProtocol  : TLSv1.2", "(NONE)"},
 		{"cipher 0000", "Cipher    : 0000\nProtocol  : TLSv1.2", "0000"},
-		{"no cipher line", "Protocol  : TLSv1.2\nSome other output", "unknown"},
-		{"empty output", "", "unknown"},
+		{"no cipher line", "Protocol  : TLSv1.2\nSome other output", ""},
+		{"empty output", "", ""},
 	}
 
 	for _, tc := range tests {
@@ -1137,17 +1248,24 @@ func assertReportField(t *testing.T, ro *testhelper.ReportObject, key, expectedV
 }
 
 func TestProbeExecCipherCompliance_ServerAcceptsDisallowed(t *testing.T) {
-	mock := newMockCommand(
-		mockPattern{key: "-cipher",
-			stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\nCipher    : DES-CBC3-SHA\n---",
-		},
-	)
+	tests := []struct {
+		name   string
+		stdout string
+	}{
+		{name: "openssl 1.1 cipher colon", stdout: "CONNECTED(00000003)\n---\nProtocol  : TLSv1.2\nCipher    : DES-CBC3-SHA\n---"},
+		{name: "openssl 3 cipher is", stdout: "CONNECTED(00000003)\n---\nNew, TLSv1.2, Cipher is DES-CBC3-SHA\n---"},
+	}
 
-	ctx := clientsholder.NewContext("ns", "pod", "container")
-	result := probeExecCipherCompliance(mock, ctx, "10.0.0.1:443", intermediatePolicy())
-	assert.NotNil(t, result, "expected non-nil result for accepted disallowed cipher")
-	assert.False(t, result.Compliant)
-	assert.Contains(t, result.Reason, "disallowed cipher")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mock := newMockCommand(mockPattern{key: "-cipher", stdout: tt.stdout})
+			ctx := clientsholder.NewContext("ns", "pod", "container")
+			result := probeExecCipherCompliance(mock, ctx, "10.0.0.1:443", intermediatePolicy())
+			assert.NotNil(t, result, "expected non-nil result for accepted disallowed cipher")
+			assert.False(t, result.Compliant)
+			assert.Contains(t, result.Reason, "DES-CBC3-SHA")
+		})
+	}
 }
 
 func TestProbeExecCipherCompliance_TLS13SkipsCipherCheck(t *testing.T) {


### PR DESCRIPTION
## Summary
openssl ran from a random probe pod, not the one on the same node as the workload. Same-node probes worked. Cross-node probes hit the 5s timeout (exit 124) and were treated as unreachable, which counts as a pass. A plaintext app could pass or fail depending on which probe was chosen.

On Kind, UBI9 openssl 3 prints TLS 1.3 as `Cipher is TLS_AES_...` with no colon. We only matched the old `Cipher    :` format, so a real TLS listener looked like plaintext.

- Probe from the workload node (same probe `ss` already uses)
- Retry openssl exit 124 when there is no usable output
- Parse OpenSSL 3 `Cipher is` as a negotiated cipher
- Missing node-local probe, empty PodIP, or empty container list is non-compliant
- Kind `plain-http-spread` / `tls-spread` require both anti-affinity replicas to be classified

Smoke CNF pods still serve plaintext `:8080`, so this test now fails for real. GitHub smoke already expects that. DCI still expects a pass until its allowlist is updated. sample-workload is unchanged.

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [redhat-best-practices-for-k8s/certsuite#3614](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3614) | feat: add unsecured container ports TLS detection test | Merged |
| [redhat-best-practices-for-k8s/checks#59](https://github.com/redhat-best-practices-for-k8s/checks/pull/59) | feat: add TLS minimum version and unsecured container ports checks | Merged |
| [redhat-best-practices-for-k8s/certsuite#3554](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3554) | feat: migrate to checks library as single source of truth | Open |
| [dci-labs/bos2-ci-config#704](https://github.com/dci-labs/bos2-ci-config/pull/704) | feat: add networking-unsecured-container-ports to expected results exclusion | Merged |
| [dci-labs/vcp-config#1631](https://github.com/dci-labs/vcp-config/pull/1631) | feat: add networking-unsecured-container-ports to expected results exclusion | Merged |

## Test Plan
- [x] `go test ./tests/networking/ ./tests/networking/tlsversion/ ./internal/crclient/ -count=1`
- [x] Kind `plain-http-spread`: test fails with at least 2 non-compliant plaintext ports
- [x] Kind `tls-spread`: test passes with at least 2 compliant objects containing "uses TLS"
- [x] GitHub Actions (unit, lint, local smoke, container smoke, QE image)
- [ ] DCI `verify_tests` is expected to fail: sample-workload plaintext `:8080` plus an unrelated `lifecycle-pod-recreation` miss
