### PR TITLE
fix: dump live probe status on exec failures so they are not read as CNF findings

### DIFF
--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -42,6 +42,18 @@ const (
 	RetrySleepSeconds = 3
 )
 
+var (
+	probeCommand       clientsholder.Command
+	getTestEnvironment = provider.GetTestEnvironment
+)
+
+func probeExec() clientsholder.Command {
+	if probeCommand != nil {
+		return probeCommand
+	}
+	return clientsholder.GetClientsHolder()
+}
+
 func (p *Process) String() string {
 	return fmt.Sprintf("cmd: %s, pid: %d, ppid: %d, pidNs: %d", p.Args, p.Pid, p.PPid, p.PidNs)
 }
@@ -73,10 +85,9 @@ func GetPidFromContainer(cut *provider.Container, ctx clientsholder.Context) (in
 		return 0, fmt.Errorf("container runtime %s not supported", cut.Runtime)
 	}
 
-	ch := clientsholder.GetClientsHolder()
-	outStr, errStr, err := ch.ExecCommandContainer(ctx, pidCmd)
+	outStr, errStr, err := probeExec().ExecCommandContainer(ctx, pidCmd)
 	if err != nil {
-		return 0, fmt.Errorf("cannot execute command: \" %s \"  on %s err:%w", pidCmd, cut, err)
+		return 0, handleProbeExecError(ctx, fmt.Errorf("cannot execute command: \" %s \"  on %s err:%w", pidCmd, cut, err))
 	}
 	if errStr != "" {
 		return 0, fmt.Errorf("cmd: \" %s \" on %s returned %s", pidCmd, cut, errStr)
@@ -100,9 +111,12 @@ func GetContainerPidNamespace(testContainer *provider.Container, env *provider.T
 	log.Debug("Obtained process id for %s is %d", testContainer, pid)
 
 	command := fmt.Sprintf("lsns -p %d -t pid -n", pid)
-	stdout, stderr, err := clientsholder.GetClientsHolder().ExecCommandContainer(ocpContext, command)
+	stdout, stderr, err := probeExec().ExecCommandContainer(ocpContext, command)
 	if err != nil || stderr != "" {
-		return "", fmt.Errorf("unable to run nsenter due to: %w", err)
+		if err == nil {
+			err = fmt.Errorf("stderr: %s", stderr)
+		}
+		return "", handleProbeExecError(ocpContext, fmt.Errorf("unable to run nsenter due to: %w", err))
 	}
 
 	return strings.Fields(stdout)[0], nil
@@ -120,13 +134,13 @@ func GetContainerProcesses(container *provider.Container, env *provider.TestEnvi
 // ExecCommandContainerNSEnter executes a command in the specified container namespace using nsenter
 func ExecCommandContainerNSEnter(command string,
 	aContainer *provider.Container) (outStr, errStr string, err error) {
-	env := provider.GetTestEnvironment()
+	env := getTestEnvironment()
 	ctx, err := GetNodeProbePodContext(aContainer.NodeName, &env)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to get probe pod's context for container %s: %w", aContainer, err)
 	}
 
-	ch := clientsholder.GetClientsHolder()
+	ch := probeExec()
 
 	// Get the container PID to build the nsenter command
 	containerPid, err := GetPidFromContainer(aContainer, ctx)
@@ -137,10 +151,11 @@ func ExecCommandContainerNSEnter(command string,
 	// Add the container PID and the specific command to run with nsenter
 	nsenterCommand := "nsenter -t " + strconv.Itoa(containerPid) + " -n " + command
 
-	// Run the nsenter command on the probe pod with retry logic
+	// Retry transient exec errors. Probe outages (container not found, SPDY
+	// upgrade failure, deadline exceeded) will not recover after a sleep.
 	for attempt := 1; attempt <= RetryAttempts; attempt++ {
 		outStr, errStr, err = ch.ExecCommandContainer(ctx, nsenterCommand)
-		if err == nil {
+		if err == nil || IsProbeExecFailure(err) {
 			break
 		}
 		if attempt < RetryAttempts {
@@ -148,7 +163,7 @@ func ExecCommandContainerNSEnter(command string,
 		}
 	}
 	if err != nil {
-		return "", "", fmt.Errorf("cannot execute command: \" %s \"  on %s err:%w", command, aContainer, err)
+		return "", "", handleProbeExecError(ctx, fmt.Errorf("cannot execute command: \" %s \"  on %s err:%w", command, aContainer, err))
 	}
 
 	return outStr, errStr, err
@@ -156,15 +171,18 @@ func ExecCommandContainerNSEnter(command string,
 
 func GetPidsFromPidNamespace(pidNamespace string, container *provider.Container) (p []*Process, err error) {
 	const command = "trap \"\" SIGURG ; ps -e -o pidns,pid,ppid,args"
-	env := provider.GetTestEnvironment()
+	env := getTestEnvironment()
 	ctx, err := GetNodeProbePodContext(container.NodeName, &env)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get probe pod's context for container %s: %w", container, err)
 	}
 
-	stdout, stderr, err := clientsholder.GetClientsHolder().ExecCommandContainer(ctx, command)
+	stdout, stderr, err := probeExec().ExecCommandContainer(ctx, command)
 	if err != nil || stderr != "" {
-		return nil, fmt.Errorf("command %q failed to run in probe pod=%s (node=%s): %w", command, ctx.GetPodName(), container.NodeName, err)
+		if err == nil {
+			err = fmt.Errorf("stderr: %s", stderr)
+		}
+		return nil, handleProbeExecError(ctx, fmt.Errorf("command %q failed to run in probe pod=%s (node=%s): %w", command, ctx.GetPodName(), container.NodeName, err))
 	}
 
 	re := regexp.MustCompile(PsRegex)

--- a/internal/crclient/probe_status.go
+++ b/internal/crclient/probe_status.go
@@ -1,0 +1,130 @@
+// Copyright (C) 2020-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package crclient
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	probeExecErrContainerNotFound = "container not found"
+	probeExecErrUnableToUpgrade   = "unable to upgrade connection"
+)
+
+var getProbePod = defaultGetProbePod
+
+// probeDumpOnce dumps live probe status at most once per namespace/name.
+var probeDumpOnce sync.Map // map[string]*sync.Once
+
+func defaultGetProbePod(namespace, name string) (*corev1.Pod, error) {
+	ch := clientsholder.GetClientsHolder()
+	return ch.K8sClient.CoreV1().Pods(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func resetProbeStatusDumpState() {
+	probeDumpOnce = sync.Map{}
+}
+
+// IsProbeExecFailure reports whether err is a probe-pod exec outage
+// (container not found, SPDY upgrade failure, or deadline exceeded)
+// rather than a CNF finding.
+func IsProbeExecFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, probeExecErrContainerNotFound) ||
+		strings.Contains(msg, probeExecErrUnableToUpgrade)
+}
+
+func handleProbeExecError(ctx clientsholder.Context, err error) error {
+	if err == nil || !IsProbeExecFailure(err) {
+		return err
+	}
+	dumpProbePodStatusOnce(ctx)
+	return fmt.Errorf("probe pod exec failed in %s/%s container %q (not a CNF container failure): %w",
+		ctx.GetNamespace(), ctx.GetPodName(), ctx.GetContainerName(), err)
+}
+
+func dumpProbePodStatusOnce(ctx clientsholder.Context) {
+	key := ctx.GetNamespace() + "/" + ctx.GetPodName()
+	onceVal, _ := probeDumpOnce.LoadOrStore(key, &sync.Once{})
+	onceVal.(*sync.Once).Do(func() {
+		dumpProbePodStatus(ctx)
+	})
+}
+
+func dumpProbePodStatus(ctx clientsholder.Context) {
+	ns, name := ctx.GetNamespace(), ctx.GetPodName()
+	pod, err := getProbePod(ns, name)
+	if err != nil {
+		log.Error("Could not get live status of probe pod %s/%s after exec failure: %v", ns, name, err)
+		return
+	}
+	log.Error("%s", formatProbePodStatus(pod))
+}
+
+func formatProbePodStatus(pod *corev1.Pod) string {
+	if pod == nil {
+		return "Probe pod live status: <nil>"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "Probe pod %s/%s live status: phase=%s node=%s podIP=%s",
+		pod.Namespace, pod.Name, pod.Status.Phase, pod.Spec.NodeName, pod.Status.PodIP)
+	for i := range pod.Status.ContainerStatuses {
+		cs := &pod.Status.ContainerStatuses[i]
+		fmt.Fprintf(&b, "\n  container %s ready=%v restarts=%d state=%s lastTermination=%s",
+			cs.Name, cs.Ready, cs.RestartCount, formatContainerState(cs.State), formatLastTermination(cs.LastTerminationState))
+	}
+	return b.String()
+}
+
+func formatContainerState(state corev1.ContainerState) string {
+	switch {
+	case state.Waiting != nil:
+		return fmt.Sprintf("waiting(reason=%s message=%s)", state.Waiting.Reason, state.Waiting.Message)
+	case state.Running != nil:
+		return fmt.Sprintf("running(startedAt=%s)", state.Running.StartedAt.UTC().Format(time.RFC3339))
+	case state.Terminated != nil:
+		t := state.Terminated
+		return fmt.Sprintf("terminated(reason=%s exit=%d finishedAt=%s)", t.Reason, t.ExitCode, t.FinishedAt.UTC().Format(time.RFC3339))
+	default:
+		return "unknown"
+	}
+}
+
+func formatLastTermination(state corev1.ContainerState) string {
+	if state.Terminated == nil {
+		return "none"
+	}
+	t := state.Terminated
+	return fmt.Sprintf("reason=%s exit=%d oom=%v finishedAt=%s",
+		t.Reason, t.ExitCode, t.Reason == "OOMKilled", t.FinishedAt.UTC().Format(time.RFC3339))
+}

--- a/internal/crclient/probe_status_test.go
+++ b/internal/crclient/probe_status_test.go
@@ -1,0 +1,457 @@
+// Copyright (C) 2020-2026 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along
+// with this program; if not, write to the Free Software Foundation, Inc.,
+// 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+package crclient
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/clientsholder"
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func stubProbePodGetter(t *testing.T, fn func(namespace, name string) (*corev1.Pod, error)) {
+	t.Helper()
+	orig := getProbePod
+	getProbePod = fn
+	resetProbeStatusDumpState()
+	t.Cleanup(func() {
+		getProbePod = orig
+		resetProbeStatusDumpState()
+	})
+}
+
+func stubProbeCommand(t *testing.T, cmd clientsholder.Command) {
+	t.Helper()
+	orig := probeCommand
+	probeCommand = cmd
+	t.Cleanup(func() {
+		probeCommand = orig
+	})
+}
+
+func stubTestEnvironment(t *testing.T, env *provider.TestEnvironment) {
+	t.Helper()
+	orig := getTestEnvironment
+	getTestEnvironment = func() provider.TestEnvironment { return *env }
+	t.Cleanup(func() {
+		getTestEnvironment = orig
+	})
+}
+
+func testCNFContainer() *provider.Container {
+	return &provider.Container{
+		Container: &corev1.Container{Name: "fm"},
+		Namespace: "samsung",
+		Podname:   "nf-alert-s2rns",
+		NodeName:  "worker-0",
+		Runtime:   "cri-o",
+		UID:       "abc123",
+	}
+}
+
+func TestIsProbeExecFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", err: nil, want: false},
+		{name: "unrelated", err: errors.New("connection refused"), want: false},
+		{name: "container not found", err: errors.New(`unable to upgrade connection: container not found ("container-00")`), want: true},
+		{name: "mixed case container not found", err: errors.New(`Unable to Upgrade Connection: Container Not Found ("container-00")`), want: true},
+		{name: "unable to upgrade connection", err: errors.New("unable to upgrade connection: error dialing backend"), want: true},
+		{name: "context deadline exceeded", err: context.DeadlineExceeded, want: true},
+		{name: "wrapped deadline exceeded", err: fmt.Errorf("exec failed: %w", context.DeadlineExceeded), want: true},
+		{name: "wrapped container not found", err: fmt.Errorf("cannot execute command: %w", errors.New(`container not found ("container-00")`)), want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, IsProbeExecFailure(tt.err))
+		})
+	}
+}
+
+func TestFormatProbePodStatus_Running(t *testing.T) {
+	t.Parallel()
+
+	started := metav1.NewTime(time.Date(2026, 8, 18, 20, 0, 0, 0, time.UTC))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "certsuite-probe-bf2nm", Namespace: "cnf-suite"},
+		Spec:       corev1.PodSpec{NodeName: "worker-0"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.0.0.12",
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "container-00",
+				Ready:        true,
+				RestartCount: 0,
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{
+					StartedAt: started,
+				}},
+			}},
+		},
+	}
+
+	got := formatProbePodStatus(pod)
+	assert.Contains(t, got, "Probe pod cnf-suite/certsuite-probe-bf2nm live status: phase=Running node=worker-0 podIP=10.0.0.12")
+	assert.Contains(t, got, "container container-00 ready=true restarts=0")
+	assert.Contains(t, got, "state=running(startedAt=2026-08-18T20:00:00Z)")
+	assert.Contains(t, got, "lastTermination=none")
+}
+
+func TestFormatProbePodStatus_OOMKilled(t *testing.T) {
+	t.Parallel()
+
+	finished := metav1.NewTime(time.Date(2026, 8, 18, 20, 2, 17, 0, time.UTC))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "certsuite-probe-bf2nm", Namespace: "cnf-suite"},
+		Spec:       corev1.PodSpec{NodeName: "worker-0"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.0.0.12",
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "container-00",
+				Ready:        false,
+				RestartCount: 3,
+				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+					Reason:  "CrashLoopBackOff",
+					Message: "back-off 5m0s restarting failed container",
+				}},
+				LastTerminationState: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					Reason:     "OOMKilled",
+					ExitCode:   137,
+					FinishedAt: finished,
+				}},
+			}},
+		},
+	}
+
+	got := formatProbePodStatus(pod)
+	assert.Contains(t, got, "phase=Running")
+	assert.Contains(t, got, "container container-00 ready=false restarts=3")
+	assert.Contains(t, got, "state=waiting(reason=CrashLoopBackOff")
+	assert.Contains(t, got, "lastTermination=reason=OOMKilled exit=137 oom=true finishedAt=2026-08-18T20:02:17Z")
+}
+
+func TestFormatProbePodStatus_Terminated(t *testing.T) {
+	t.Parallel()
+
+	finished := metav1.NewTime(time.Date(2026, 8, 18, 20, 5, 0, 0, time.UTC))
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "probe-a", Namespace: "cnf-suite"},
+		Spec:       corev1.PodSpec{NodeName: "worker-1"},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodFailed,
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name: "container-00",
+				State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+					Reason:     "Error",
+					ExitCode:   1,
+					FinishedAt: finished,
+				}},
+			}},
+		},
+	}
+
+	got := formatProbePodStatus(pod)
+	assert.Contains(t, got, "phase=Failed")
+	assert.Contains(t, got, "state=terminated(reason=Error exit=1 finishedAt=2026-08-18T20:05:00Z)")
+}
+
+func TestFormatProbePodStatus_NoContainers(t *testing.T) {
+	t.Parallel()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "probe-a", Namespace: "cnf-suite"},
+		Spec:       corev1.PodSpec{NodeName: "worker-1"},
+		Status:     corev1.PodStatus{Phase: corev1.PodPending, PodIP: ""},
+	}
+
+	got := formatProbePodStatus(pod)
+	assert.Equal(t, "Probe pod cnf-suite/probe-a live status: phase=Pending node=worker-1 podIP=", got)
+	assert.NotContains(t, got, "container ")
+}
+
+func TestFormatProbePodStatus_NilPod(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "Probe pod live status: <nil>", formatProbePodStatus(nil))
+}
+
+func TestFormatContainerState(t *testing.T) {
+	t.Parallel()
+
+	started := metav1.NewTime(time.Date(2026, 8, 18, 20, 0, 0, 0, time.UTC))
+	finished := metav1.NewTime(time.Date(2026, 8, 18, 20, 5, 0, 0, time.UTC))
+
+	tests := []struct {
+		name  string
+		state corev1.ContainerState
+		want  string
+	}{
+		{name: "unknown empty", state: corev1.ContainerState{}, want: "unknown"},
+		{
+			name:  "waiting",
+			state: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff", Message: "backoff"}},
+			want:  "waiting(reason=CrashLoopBackOff message=backoff)",
+		},
+		{
+			name:  "running",
+			state: corev1.ContainerState{Running: &corev1.ContainerStateRunning{StartedAt: started}},
+			want:  "running(startedAt=2026-08-18T20:00:00Z)",
+		},
+		{
+			name:  "terminated",
+			state: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{Reason: "Error", ExitCode: 1, FinishedAt: finished}},
+			want:  "terminated(reason=Error exit=1 finishedAt=2026-08-18T20:05:00Z)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.want, formatContainerState(tt.state))
+		})
+	}
+}
+
+func TestFormatLastTermination(t *testing.T) {
+	t.Parallel()
+
+	finished := metav1.NewTime(time.Date(2026, 8, 18, 20, 2, 17, 0, time.UTC))
+
+	assert.Equal(t, "none", formatLastTermination(corev1.ContainerState{}))
+	assert.Equal(t, "reason=OOMKilled exit=137 oom=true finishedAt=2026-08-18T20:02:17Z",
+		formatLastTermination(corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			Reason: "OOMKilled", ExitCode: 137, FinishedAt: finished,
+		}}))
+	assert.Equal(t, "reason=Error exit=1 oom=false finishedAt=2026-08-18T20:02:17Z",
+		formatLastTermination(corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+			Reason: "Error", ExitCode: 1, FinishedAt: finished,
+		}}))
+}
+
+func TestHandleProbeExecError_Passthrough(t *testing.T) {
+	ctx := clientsholder.NewContext("cnf-suite", "probe-a", "container-00")
+	assert.Nil(t, handleProbeExecError(ctx, nil))
+
+	origErr := errors.New("connection refused")
+	got := handleProbeExecError(ctx, origErr)
+	assert.Equal(t, origErr, got)
+}
+
+func TestHandleProbeExecError_WrapsAndDumps(t *testing.T) {
+	var logArchive bytes.Buffer
+	log.SetupLogger(&logArchive, "ERROR")
+
+	pod := runningProbePod()
+	stubProbePodGetter(t, func(namespace, name string) (*corev1.Pod, error) {
+		assert.Equal(t, "cnf-suite", namespace)
+		assert.Equal(t, "certsuite-probe-bf2nm", name)
+		return pod, nil
+	})
+
+	ctx := clientsholder.NewContext("cnf-suite", "certsuite-probe-bf2nm", "container-00")
+	inner := errors.New(`unable to upgrade connection: container not found ("container-00")`)
+	got := handleProbeExecError(ctx, inner)
+
+	require.Error(t, got)
+	assert.ErrorIs(t, got, inner)
+	assert.Contains(t, got.Error(), `probe pod exec failed in cnf-suite/certsuite-probe-bf2nm container "container-00" (not a CNF container failure)`)
+	assert.Contains(t, logArchive.String(), "Probe pod cnf-suite/certsuite-probe-bf2nm live status")
+	assert.Contains(t, logArchive.String(), "container container-00")
+}
+
+func TestDumpProbePodStatusOnce_DumpsOncePerProbe(t *testing.T) {
+	var logArchive bytes.Buffer
+	log.SetupLogger(&logArchive, "ERROR")
+
+	var calls atomic.Int32
+	stubProbePodGetter(t, func(_, _ string) (*corev1.Pod, error) {
+		calls.Add(1)
+		return runningProbePod(), nil
+	})
+
+	ctx := clientsholder.NewContext("cnf-suite", "certsuite-probe-bf2nm", "container-00")
+	inner := errors.New(`container not found ("container-00")`)
+
+	_ = handleProbeExecError(ctx, inner)
+	_ = handleProbeExecError(ctx, inner)
+	_ = handleProbeExecError(ctx, inner)
+
+	assert.Equal(t, int32(1), calls.Load())
+	assert.Equal(t, 1, strings.Count(logArchive.String(), "Probe pod cnf-suite/certsuite-probe-bf2nm live status"))
+}
+
+func TestDumpProbePodStatusOnce_SeparateProbes(t *testing.T) {
+	var logArchive bytes.Buffer
+	log.SetupLogger(&logArchive, "ERROR")
+
+	var calls atomic.Int32
+	stubProbePodGetter(t, func(_, _ string) (*corev1.Pod, error) {
+		calls.Add(1)
+		return runningProbePod(), nil
+	})
+
+	inner := errors.New(`container not found ("container-00")`)
+	_ = handleProbeExecError(clientsholder.NewContext("cnf-suite", "probe-a", "container-00"), inner)
+	_ = handleProbeExecError(clientsholder.NewContext("cnf-suite", "probe-b", "container-00"), inner)
+
+	assert.Equal(t, int32(2), calls.Load())
+}
+
+func TestDumpProbePodStatus_NotFound(t *testing.T) {
+	var logArchive bytes.Buffer
+	log.SetupLogger(&logArchive, "ERROR")
+
+	notFound := apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "certsuite-probe-bf2nm")
+	stubProbePodGetter(t, func(_, _ string) (*corev1.Pod, error) {
+		return nil, notFound
+	})
+
+	ctx := clientsholder.NewContext("cnf-suite", "certsuite-probe-bf2nm", "container-00")
+	got := handleProbeExecError(ctx, errors.New(`container not found ("container-00")`))
+
+	require.Error(t, got)
+	assert.Contains(t, logArchive.String(), "Could not get live status of probe pod cnf-suite/certsuite-probe-bf2nm after exec failure")
+	assert.Contains(t, logArchive.String(), "not found")
+}
+
+func runningProbePod() *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "certsuite-probe-bf2nm", Namespace: "cnf-suite"},
+		Spec: corev1.PodSpec{
+			NodeName:   "worker-0",
+			Containers: []corev1.Container{{Name: "container-00"}},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+			PodIP: "10.0.0.12",
+			ContainerStatuses: []corev1.ContainerStatus{{
+				Name:         "container-00",
+				Ready:        true,
+				RestartCount: 1,
+				State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{
+					StartedAt: metav1.NewTime(time.Date(2026, 8, 18, 19, 30, 0, 0, time.UTC)),
+				}},
+			}},
+		},
+	}
+}
+
+func TestGetPidFromContainer_ProbeContainerNotFound(t *testing.T) {
+	var logArchive bytes.Buffer
+	log.SetupLogger(&logArchive, "ERROR")
+
+	inner := errors.New(`unable to upgrade connection: container not found ("container-00")`)
+	mock := &clientsholder.MockCommand{
+		ExecFunc: func(_ clientsholder.Context, _ string) (string, string, error) {
+			return "", "", inner
+		},
+	}
+	stubProbeCommand(t, mock)
+
+	var dumps atomic.Int32
+	stubProbePodGetter(t, func(_, _ string) (*corev1.Pod, error) {
+		dumps.Add(1)
+		return runningProbePod(), nil
+	})
+
+	ctx := clientsholder.NewContext("cnf-suite", "certsuite-probe-bf2nm", "container-00")
+	pid, err := GetPidFromContainer(testCNFContainer(), ctx)
+
+	assert.Equal(t, 0, pid)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, inner)
+	assert.True(t, IsProbeExecFailure(err))
+	assert.Contains(t, err.Error(), `probe pod exec failed in cnf-suite/certsuite-probe-bf2nm container "container-00" (not a CNF container failure)`)
+	assert.Equal(t, 1, mock.CallCount())
+	assert.Equal(t, int32(1), dumps.Load())
+	assert.Contains(t, logArchive.String(), "Probe pod cnf-suite/certsuite-probe-bf2nm live status")
+}
+
+func TestExecCommandContainerNSEnter_ProbeContainerNotFound(t *testing.T) {
+	var logArchive bytes.Buffer
+	log.SetupLogger(&logArchive, "ERROR")
+
+	inner := errors.New(`unable to upgrade connection: container not found ("container-00")`)
+	mock := &clientsholder.MockCommand{
+		ExecFunc: func(_ clientsholder.Context, command string) (string, string, error) {
+			if strings.Contains(command, "crictl inspect") {
+				return "1234\n", "", nil
+			}
+			return "", "", inner
+		},
+	}
+	stubProbeCommand(t, mock)
+
+	probe := runningProbePod()
+	stubTestEnvironment(t, &provider.TestEnvironment{
+		ProbePods: map[string]*corev1.Pod{probe.Spec.NodeName: probe},
+	})
+
+	var dumps atomic.Int32
+	stubProbePodGetter(t, func(_, _ string) (*corev1.Pod, error) {
+		dumps.Add(1)
+		return probe, nil
+	})
+
+	_, _, err := ExecCommandContainerNSEnter("ss -tpln | grep sshd", testCNFContainer())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, inner)
+	assert.True(t, IsProbeExecFailure(err))
+	assert.Contains(t, err.Error(), `probe pod exec failed in cnf-suite/certsuite-probe-bf2nm container "container-00" (not a CNF container failure)`)
+	assert.Equal(t, 2, mock.CallCount())
+	assert.Equal(t, int32(1), dumps.Load())
+	assert.Contains(t, logArchive.String(), "Probe pod cnf-suite/certsuite-probe-bf2nm live status")
+}
+
+func TestDefaultGetProbePod(t *testing.T) {
+	t.Cleanup(clientsholder.ClearTestClientsHolder)
+
+	pod := runningProbePod()
+	clientsholder.GetTestClientsHolder([]runtime.Object{pod})
+
+	got, err := defaultGetProbePod("cnf-suite", "certsuite-probe-bf2nm")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, corev1.PodRunning, got.Status.Phase)
+	assert.Equal(t, "worker-0", got.Spec.NodeName)
+	assert.Equal(t, "10.0.0.12", got.Status.PodIP)
+
+	_, err = defaultGetProbePod("cnf-suite", "missing-probe")
+	require.Error(t, err)
+	assert.True(t, apierrors.IsNotFound(err))
+}

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -869,14 +869,14 @@ func testOneProcessPerContainer(check *checksdb.Check, env *provider.TestEnviron
 		pid, err := crclient.GetPidFromContainer(cut, ocpContext)
 		if err != nil {
 			check.LogError("Could not get PID for Container %q, error: %v", cut, err)
-			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, err.Error(), false))
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, probeExecFailureReason(err), false))
 			return
 		}
 
 		nbProcesses, err := getNbOfProcessesInPidNamespace(ocpContext, pid, clientsholder.GetClientsHolder())
 		if err != nil {
 			check.LogError("Could not get number of processes for Container %q, error: %v", cut, err)
-			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, err.Error(), false))
+			result.AddNonCompliantObject(testhelper.NewContainerReportObject(cut.Namespace, cut.Podname, cut.Name, probeExecFailureReason(err), false))
 			return
 		}
 		if nbProcesses > 1 {
@@ -983,7 +983,36 @@ func testNamespaceResourceQuota(check *checksdb.Check, env *provider.TestEnviron
 
 const (
 	sshServicePortProtocol = "TCP"
+	sshDaemonProbeExecMsg  = "Probe pod exec failed while checking for sshd; not evidence the pod is running sshd"
 )
+
+func checkFailureReason(err error, probeMsg, otherMsg string) string {
+	if crclient.IsProbeExecFailure(err) {
+		return fmt.Sprintf("%s: %v", probeMsg, err)
+	}
+	if err == nil {
+		return otherMsg
+	}
+	return fmt.Sprintf("%s: %v", otherMsg, err)
+}
+
+func sshDaemonCheckFailureReason(err error) string {
+	return checkFailureReason(err, sshDaemonProbeExecMsg, "Failed to get the ssh port for pod")
+}
+
+func listeningPortsCheckFailureReason(err error) string {
+	return checkFailureReason(err, sshDaemonProbeExecMsg, "Failed to get the listening ports for pod")
+}
+
+func probeExecFailureReason(err error) string {
+	if crclient.IsProbeExecFailure(err) {
+		return fmt.Sprintf("Probe pod exec failed; not a CNF finding: %v", err)
+	}
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
 
 func testNoSSHDaemonsAllowed(check *checksdb.Check, env *provider.TestEnvironment) {
 	mutexPerNode := env.NewPerNodeMutexMap()
@@ -1000,7 +1029,7 @@ func testNoSSHDaemonsAllowed(check *checksdb.Check, env *provider.TestEnvironmen
 		port, err := netutil.GetSSHDaemonPort(cut)
 		if err != nil {
 			check.LogError("Could not get ssh daemon port on %q, err: %v", cut, err)
-			result.AddNonCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, "Failed to get the ssh port for pod", false))
+			result.AddNonCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, sshDaemonCheckFailureReason(err), false))
 			return
 		}
 
@@ -1021,7 +1050,7 @@ func testNoSSHDaemonsAllowed(check *checksdb.Check, env *provider.TestEnvironmen
 		listeningPorts, err := netutil.GetListeningPorts(cut)
 		if err != nil {
 			check.LogError("Failed to get the listening ports for Pod %q, err: %v", put, err)
-			result.AddNonCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, "Failed to get the listening ports for pod", false))
+			result.AddNonCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, listeningPortsCheckFailureReason(err), false))
 			return
 		}
 

--- a/tests/accesscontrol/suite_test.go
+++ b/tests/accesscontrol/suite_test.go
@@ -17,6 +17,7 @@
 package accesscontrol
 
 import (
+	"errors"
 	"io"
 	"testing"
 
@@ -737,4 +738,33 @@ func Test_checkCrossNamespaceRoleBindingViolation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSSHDaemonCheckFailureReason(t *testing.T) {
+	t.Parallel()
+
+	probeErr := errors.New(`unable to upgrade connection: container not found ("container-00")`)
+	got := sshDaemonCheckFailureReason(probeErr)
+	assert.Contains(t, got, "Probe pod exec failed while checking for sshd")
+	assert.Contains(t, got, "not evidence the pod is running sshd")
+	assert.Contains(t, got, "container not found")
+
+	other := sshDaemonCheckFailureReason(errors.New("connection refused"))
+	assert.Contains(t, other, "Failed to get the ssh port for pod")
+	assert.NotContains(t, other, "not evidence the pod is running sshd")
+	assert.Equal(t, "Failed to get the ssh port for pod", sshDaemonCheckFailureReason(nil))
+
+	ports := listeningPortsCheckFailureReason(errors.New("connection refused"))
+	assert.Contains(t, ports, "Failed to get the listening ports for pod")
+	assert.Contains(t, listeningPortsCheckFailureReason(probeErr), "Probe pod exec failed while checking for sshd")
+}
+
+func TestProbeExecFailureReason(t *testing.T) {
+	t.Parallel()
+
+	probeErr := errors.New(`unable to upgrade connection: container not found ("container-00")`)
+	got := probeExecFailureReason(probeErr)
+	assert.Contains(t, got, "Probe pod exec failed; not a CNF finding")
+	assert.Equal(t, "boom", probeExecFailureReason(errors.New("boom")))
+	assert.Equal(t, "", probeExecFailureReason(nil))
 }

--- a/tests/networking/netutil/netutil.go
+++ b/tests/networking/netutil/netutil.go
@@ -72,7 +72,7 @@ func parseListeningPorts(cmdOut string) (map[PortInfo]bool, error) {
 func GetListeningPorts(cut *provider.Container) (map[PortInfo]bool, error) {
 	outStr, errStr, err := crclient.ExecCommandContainerNSEnter(getListeningPortsCmd, cut)
 	if err != nil || errStr != "" {
-		return nil, fmt.Errorf("failed to execute command %s on %s, err: %v", getListeningPortsCmd, cut, err)
+		return nil, wrapNSEnterError(getListeningPortsCmd, cut, errStr, err)
 	}
 
 	return parseListeningPorts(outStr)
@@ -82,8 +82,15 @@ func GetSSHDaemonPort(cut *provider.Container) (string, error) {
 	const findSSHDaemonPort = "ss -tpln | grep sshd | head -1 | awk '{ print $4 }' | awk -F : '{ print $2 }'"
 	outStr, errStr, err := crclient.ExecCommandContainerNSEnter(findSSHDaemonPort, cut)
 	if err != nil || errStr != "" {
-		return "", fmt.Errorf("failed to execute command %s on %s, err: %v", findSSHDaemonPort, cut, err)
+		return "", wrapNSEnterError(findSSHDaemonPort, cut, errStr, err)
 	}
 
 	return strings.TrimSpace(outStr), nil
+}
+
+func wrapNSEnterError(command string, cut *provider.Container, errStr string, err error) error {
+	if err == nil {
+		err = fmt.Errorf("%s", errStr)
+	}
+	return fmt.Errorf("failed to execute command %s on %s: %w", command, cut, err)
 }

--- a/tests/networking/netutil/netutil_test.go
+++ b/tests/networking/netutil/netutil_test.go
@@ -17,9 +17,12 @@
 package netutil
 
 import (
+	"context"
 	"testing"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseListeningPorts(t *testing.T) {
@@ -58,4 +61,18 @@ func TestParseListeningPorts(t *testing.T) {
 			assert.Equal(t, tc.expectedListeningPorts, listeningPorts)
 		}
 	}
+}
+
+func TestWrapNSEnterError(t *testing.T) {
+	t.Parallel()
+
+	cut := &provider.Container{Namespace: "smf1", Podname: "nf-alert"}
+	deadline := wrapNSEnterError("ss -tpln", cut, "", context.DeadlineExceeded)
+	require.Error(t, deadline)
+	assert.ErrorIs(t, deadline, context.DeadlineExceeded)
+	assert.Contains(t, deadline.Error(), "failed to execute command ss -tpln")
+
+	stderrOnly := wrapNSEnterError("ss -tulwnH", cut, "command not found", nil)
+	require.Error(t, stderrOnly)
+	assert.Contains(t, stderrOnly.Error(), "command not found")
 }


### PR DESCRIPTION
## Summary
- `access-control-ssh-daemons` (and similar probe-exec checks) were failing with kubelet `container not found ("container-00")`. `container-00` is the certsuite probe DaemonSet container, not a CNF container, so partners read a tooling outage as an sshd finding.
- Keep the check as **FAIL**. On probe exec failures (`container not found`, SPDY upgrade failure, deadline exceeded), GET the live probe pod and dump phase, ready, restarts, and lastTermination (including OOMKilled) once per probe.
- Wrap the error as a probe-pod exec outage and use that text in the claim. Restore distinct ssh-port vs listening-ports messages. Skip nsenter retries for irrecoverable probe outages instead of sleeping 3s × 4.

This is not the unsecured-ports node-local probe bug in #3869.

## Test Plan
- [x] `go test ./internal/crclient/ ./tests/accesscontrol/ ./tests/networking/netutil/ -count=1`
- [x] `golangci-lint run ./internal/crclient/... ./tests/accesscontrol/... ./tests/networking/netutil/...`
- [ ] GitHub Actions (unit, lint)
- [ ] On a cluster where a probe exec fails, confirm the log includes `Probe pod … live status` once per probe and the claim says probe exec failed, not that the pod is running sshd


Made with [Cursor](https://cursor.com)