### PR TITLE
fix: remove probe DaemonSet resource limits to prevent OOMKills

### DIFF
--- a/cmd/certsuite/run/run.go
+++ b/cmd/certsuite/run/run.go
@@ -58,9 +58,9 @@ func NewCommand() *cobra.Command {
 	probeFlags := flag.NewFlagSet("probe", flag.ContinueOnError)
 	probeFlags.String("certsuite-probe-image", "quay.io/redhat-best-practices-for-k8s/certsuite-probe:v0.0.42", "Certsuite probe image")
 	probeFlags.String("daemonset-cpu-req", "100m", "CPU request for the probe daemonset container")
-	probeFlags.String("daemonset-cpu-lim", "100m", "CPU limit for the probe daemonset container")
+	probeFlags.String("daemonset-cpu-lim", "", "CPU limit for the probe daemonset container (empty = no limit)")
 	probeFlags.String("daemonset-mem-req", "100M", "Memory request for the probe daemonset container")
-	probeFlags.String("daemonset-mem-lim", "100M", "Memory limit for the probe daemonset container")
+	probeFlags.String("daemonset-mem-lim", "", "Memory limit for the probe daemonset container (empty = no limit)")
 	probeFlags.Bool("cleanup-probe", true, "Delete the probe daemonset at the end of the test run")
 	probeFlags.Bool("require-probe", false, "Abort the test run if the probe daemonset fails to deploy")
 

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/operator-framework/operator-lifecycle-manager v0.42.0
 	github.com/redhat-best-practices-for-k8s/certsuite-claim v1.0.66
 	github.com/redhat-best-practices-for-k8s/oct v0.0.67
-	github.com/redhat-best-practices-for-k8s/privileged-daemonset v1.0.75
+	github.com/redhat-best-practices-for-k8s/privileged-daemonset v1.0.76
 	github.com/redhat-openshift-ecosystem/openshift-preflight v0.0.0-20260421203005-eb87e5b2d67a
 	github.com/robert-nix/ansihtml v1.0.1
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -426,8 +426,8 @@ github.com/redhat-best-practices-for-k8s/certsuite-claim v1.0.66 h1:Rt6UycqVetFY
 github.com/redhat-best-practices-for-k8s/certsuite-claim v1.0.66/go.mod h1:Q6l1462a89dYcLKhecQpvMtrmGrkNESL2MNjQM7wWCI=
 github.com/redhat-best-practices-for-k8s/oct v0.0.67 h1:nvqQUBsrmO85mUwG5i+YF2A4EZIB5nUqXmbma7Dow4g=
 github.com/redhat-best-practices-for-k8s/oct v0.0.67/go.mod h1:dmMmZEon662ZZQC71CGIL/b6Ay1+nckJcLe6CPlzbyY=
-github.com/redhat-best-practices-for-k8s/privileged-daemonset v1.0.75 h1:N0dsIYVm820B2Ogr/RJblFLN+vAAXsUBtcwIuMl83LE=
-github.com/redhat-best-practices-for-k8s/privileged-daemonset v1.0.75/go.mod h1:cXGiLJjl6k6QRxD6GmLra/R9AFfGmlMAOI8YTcSYE1c=
+github.com/redhat-best-practices-for-k8s/privileged-daemonset v1.0.76 h1:2H9bdSuCeXFZgX0AtG9ArcikCj9N8HjXxtCHlJJHh+g=
+github.com/redhat-best-practices-for-k8s/privileged-daemonset v1.0.76/go.mod h1:NiK1s6OD1hco16zCu3gLUPfUZtq5u1AI6mRT8MBN+yQ=
 github.com/redhat-openshift-ecosystem/openshift-preflight v0.0.0-20260820174747-703ac27fdc42 h1:4ok2xG7g9R3V+1MC8z4+LapI5+9rcpoj6GzlnDo8lL8=
 github.com/redhat-openshift-ecosystem/openshift-preflight v0.0.0-20260820174747-703ac27fdc42/go.mod h1:UyiN/ibGWRlh8xMO3JDZ0J9SJM/quTwZ+oT5O0+dkhc=
 github.com/redis/go-redis/extra/rediscmd/v9 v9.17.3 h1:v9RNP5ynWkruvzscrIoDyyv20c9YeyVn12L9nYnaexw=


### PR DESCRIPTION
## Summary
- Remove default resource limits for probe DaemonSet (CPU and memory)
- Keep resource requests for proper scheduling (100m CPU, 100M memory)
- Bump privileged-daemonset to v1.0.76 which supports optional limits

## Problem
Probe pods were experiencing OOMKilled failures during production testing. The 100M memory limit was too restrictive for privileged operations that scan node resources, perform TLS detection, and execute complex network probing. This caused test failures not because CNFs violated best practices, but because the probe infrastructure couldn't complete diagnostic operations.

## Solution
Make resource limits optional by setting flag defaults to empty strings. The privileged-daemonset v1.0.76 library now checks for empty strings before calling resource.MustParse(), allowing limits to be omitted. Users can still set custom limits via CLI flags if needed for resource-constrained environments.

## Related PRs
| PR | Title | Status |
|----|-------|--------|
| [privileged-daemonset#382](https://github.com/redhat-best-practices-for-k8s/privileged-daemonset/pull/382) | Make resource limits optional | Merged |
| [certsuite#3881](https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3881) | Initial attempt (reverted due to go.mod issues) | Reverted |

## Changes
- cmd/certsuite/run/run.go: Change daemonset-cpu-lim and daemonset-mem-lim defaults from "100m"/"100M" to ""
- go.mod: Bump privileged-daemonset from v1.0.75 to v1.0.76 (only this dependency changed)
- go.sum: Update checksums for privileged-daemonset

## Test Plan
- [x] Build passes
- [x] Lint passes
- [x] Unit tests pass
- [ ] CI passes
- [ ] Verify probe pods deploy successfully without OOMKills in production environment
