### PR TITLE
feat: distinguish probe tool execution errors from test case failures

### DIFF
--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -17,6 +17,7 @@
 package crclient
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -29,6 +30,25 @@ import (
 )
 
 const PsRegex = `(?m)^(\d+?)\s+?(\d+?)\s+?(\d+?)\s+?(.*?)$`
+
+// ProbeToolExecError represents a failure in the certsuite-probe daemonset tool execution,
+// as distinct from a test case failure in the workload under test.
+type ProbeToolExecError struct {
+	Reason  string
+	Wrapped error
+}
+
+func (e *ProbeToolExecError) Error() string {
+	return fmt.Sprintf("probe tool execution error: %s: %v", e.Reason, e.Wrapped)
+}
+
+func (e *ProbeToolExecError) Unwrap() error { return e.Wrapped }
+
+// IsProbeToolExecError returns true if err wraps a ProbeToolExecError.
+func IsProbeToolExecError(err error) bool {
+	var e *ProbeToolExecError
+	return errors.As(err, &e)
+}
 
 type Process struct {
 	PidNs, Pid, PPid int
@@ -117,13 +137,18 @@ func GetContainerProcesses(container *provider.Container, env *provider.TestEnvi
 	return GetPidsFromPidNamespace(pidNs, container)
 }
 
-// ExecCommandContainerNSEnter executes a command in the specified container namespace using nsenter
+// ExecCommandContainerNSEnter executes a command in the specified container namespace using nsenter.
+// Any error returned is a ProbeToolExecError, indicating the certsuite-probe tool failed —
+// not that the workload under test is non-compliant.
 func ExecCommandContainerNSEnter(command string,
 	aContainer *provider.Container) (outStr, errStr string, err error) {
 	env := provider.GetTestEnvironment()
 	ctx, err := GetNodeProbePodContext(aContainer.NodeName, &env)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to get probe pod's context for container %s: %w", aContainer, err)
+		return "", "", &ProbeToolExecError{
+			Reason:  fmt.Sprintf("probe pod not found for container %s on node %s", aContainer, aContainer.NodeName),
+			Wrapped: err,
+		}
 	}
 
 	ch := clientsholder.GetClientsHolder()
@@ -131,7 +156,10 @@ func ExecCommandContainerNSEnter(command string,
 	// Get the container PID to build the nsenter command
 	containerPid, err := GetPidFromContainer(aContainer, ctx)
 	if err != nil {
-		return "", "", fmt.Errorf("cannot get PID from: %s, err: %w", aContainer, err)
+		return "", "", &ProbeToolExecError{
+			Reason:  fmt.Sprintf("cannot get PID for container %s via probe pod %s", aContainer, ctx.GetPodName()),
+			Wrapped: err,
+		}
 	}
 
 	// Add the container PID and the specific command to run with nsenter
@@ -148,7 +176,10 @@ func ExecCommandContainerNSEnter(command string,
 		}
 	}
 	if err != nil {
-		return "", "", fmt.Errorf("cannot execute command: \" %s \"  on %s err:%w", command, aContainer, err)
+		return "", "", &ProbeToolExecError{
+			Reason:  fmt.Sprintf("command %q failed in probe pod %s for container %s", command, ctx.GetPodName(), aContainer),
+			Wrapped: err,
+		}
 	}
 
 	return outStr, errStr, err

--- a/internal/crclient/crclient.go
+++ b/internal/crclient/crclient.go
@@ -122,7 +122,7 @@ func GetContainerPidNamespace(testContainer *provider.Container, env *provider.T
 	command := fmt.Sprintf("lsns -p %d -t pid -n", pid)
 	stdout, stderr, err := clientsholder.GetClientsHolder().ExecCommandContainer(ocpContext, command)
 	if err != nil || stderr != "" {
-		return "", fmt.Errorf("unable to run nsenter due to : %v", err)
+		return "", fmt.Errorf("unable to run nsenter due to : %w", err)
 	}
 
 	return strings.Fields(stdout)[0], nil

--- a/internal/crclient/crclient_test.go
+++ b/internal/crclient/crclient_test.go
@@ -66,3 +66,12 @@ func TestIsProbeToolExecError_nil(t *testing.T) {
 		t.Error("expected IsProbeToolExecError to return false for nil")
 	}
 }
+
+func TestIsProbeToolExecError_doubleWrapped(t *testing.T) {
+	inner := &ProbeToolExecError{Reason: "probe unavailable", Wrapped: errors.New("pods not found")}
+	mid := fmt.Errorf("unable to run nsenter due to : %w", inner)
+	outer := fmt.Errorf("could not get pid namespace, err: %w", mid)
+	if !IsProbeToolExecError(outer) {
+		t.Error("expected IsProbeToolExecError to return true through two levels of %%w wrapping")
+	}
+}

--- a/internal/crclient/crclient_test.go
+++ b/internal/crclient/crclient_test.go
@@ -1,4 +1,4 @@
-// Copyright (C) 2020-2022 Red Hat, Inc.
+// Copyright (C) 2020-2026 Red Hat, Inc.
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -15,3 +15,54 @@
 // 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 
 package crclient
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestProbeToolExecError_Error(t *testing.T) {
+	wrapped := errors.New("unable to upgrade connection: container not found")
+	err := &ProbeToolExecError{Reason: "probe pod unavailable", Wrapped: wrapped}
+	got := err.Error()
+	if got != "probe tool execution error: probe pod unavailable: unable to upgrade connection: container not found" {
+		t.Errorf("unexpected Error() string: %q", got)
+	}
+}
+
+func TestProbeToolExecError_Unwrap(t *testing.T) {
+	wrapped := errors.New("context deadline exceeded")
+	err := &ProbeToolExecError{Reason: "timeout", Wrapped: wrapped}
+	if !errors.Is(err, wrapped) {
+		t.Error("Unwrap should expose the wrapped error via errors.Is")
+	}
+}
+
+func TestIsProbeToolExecError_direct(t *testing.T) {
+	err := &ProbeToolExecError{Reason: "test", Wrapped: errors.New("inner")}
+	if !IsProbeToolExecError(err) {
+		t.Error("expected IsProbeToolExecError to return true for a direct ProbeToolExecError")
+	}
+}
+
+func TestIsProbeToolExecError_wrapped(t *testing.T) {
+	inner := &ProbeToolExecError{Reason: "test", Wrapped: errors.New("inner")}
+	outer := fmt.Errorf("netutil wrapper: %w", inner)
+	if !IsProbeToolExecError(outer) {
+		t.Error("expected IsProbeToolExecError to return true when ProbeToolExecError is wrapped by fmt.Errorf with %%w")
+	}
+}
+
+func TestIsProbeToolExecError_plain(t *testing.T) {
+	err := errors.New("some other error")
+	if IsProbeToolExecError(err) {
+		t.Error("expected IsProbeToolExecError to return false for a plain error")
+	}
+}
+
+func TestIsProbeToolExecError_nil(t *testing.T) {
+	if IsProbeToolExecError(nil) {
+		t.Error("expected IsProbeToolExecError to return false for nil")
+	}
+}

--- a/tests/accesscontrol/suite.go
+++ b/tests/accesscontrol/suite.go
@@ -970,6 +970,11 @@ func testNoSSHDaemonsAllowed(check *checksdb.Check, env *provider.TestEnvironmen
 
 		port, err := netutil.GetSSHDaemonPort(cut)
 		if err != nil {
+			if crclient.IsProbeToolExecError(err) {
+				check.LogError("Tool execution error for %q — probe unavailable, skipping pod (not a test case failure): %v", cut, err)
+				check.SetResultError(fmt.Sprintf("probe tool execution error for pod %s/%s: %v", put.Namespace, put.Name, err))
+				return
+			}
 			check.LogError("Could not get ssh daemon port on %q, err: %v", cut, err)
 			result.AddNonCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, "Failed to get the ssh port for pod", false))
 			return
@@ -991,6 +996,11 @@ func testNoSSHDaemonsAllowed(check *checksdb.Check, env *provider.TestEnvironmen
 		sshPortInfo := netutil.PortInfo{PortNumber: int32(sshServicePortNumber), Protocol: sshServicePortProtocol}
 		listeningPorts, err := netutil.GetListeningPorts(cut)
 		if err != nil {
+			if crclient.IsProbeToolExecError(err) {
+				check.LogError("Tool execution error for %q — probe unavailable, skipping pod (not a test case failure): %v", cut, err)
+				check.SetResultError(fmt.Sprintf("probe tool execution error for pod %s/%s: %v", put.Namespace, put.Name, err))
+				return
+			}
 			check.LogError("Failed to get the listening ports for Pod %q, err: %v", put, err)
 			result.AddNonCompliantObject(testhelper.NewPodReportObject(put.Namespace, put.Name, "Failed to get the listening ports for pod", false))
 			return

--- a/tests/networking/netutil/netutil.go
+++ b/tests/networking/netutil/netutil.go
@@ -72,7 +72,7 @@ func parseListeningPorts(cmdOut string) (map[PortInfo]bool, error) {
 func GetListeningPorts(cut *provider.Container) (map[PortInfo]bool, error) {
 	outStr, errStr, err := crclient.ExecCommandContainerNSEnter(getListeningPortsCmd, cut)
 	if err != nil || errStr != "" {
-		return nil, fmt.Errorf("failed to execute command %s on %s, err: %v", getListeningPortsCmd, cut, err)
+		return nil, fmt.Errorf("failed to execute command %s on %s, err: %w", getListeningPortsCmd, cut, err)
 	}
 
 	return parseListeningPorts(outStr)
@@ -82,7 +82,7 @@ func GetSSHDaemonPort(cut *provider.Container) (string, error) {
 	const findSSHDaemonPort = "ss -tpln | grep sshd | head -1 | awk '{ print $4 }' | awk -F : '{ print $2 }'"
 	outStr, errStr, err := crclient.ExecCommandContainerNSEnter(findSSHDaemonPort, cut)
 	if err != nil || errStr != "" {
-		return "", fmt.Errorf("failed to execute command %s on %s, err: %v", findSSHDaemonPort, cut, err)
+		return "", fmt.Errorf("failed to execute command %s on %s, err: %w", findSSHDaemonPort, cut, err)
 	}
 
 	return strings.TrimSpace(outStr), nil

--- a/tests/networking/suite.go
+++ b/tests/networking/suite.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"strconv"
 
+	"github.com/redhat-best-practices-for-k8s/certsuite/internal/crclient"
 	"github.com/redhat-best-practices-for-k8s/certsuite/internal/log"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/checksdb"
 	"github.com/redhat-best-practices-for-k8s/certsuite/pkg/provider"
@@ -180,6 +181,11 @@ func testUndeclaredContainerPortsUsage(check *checksdb.Check, env *provider.Test
 		firstPodContainer := put.Containers[0]
 		listeningPorts, err := netutil.GetListeningPorts(firstPodContainer)
 		if err != nil {
+			if crclient.IsProbeToolExecError(err) {
+				check.LogError("Tool execution error for %q — probe unavailable, skipping pod (not a test case failure): %v", firstPodContainer, err)
+				check.SetResultError(fmt.Sprintf("probe tool execution error for pod %s/%s: %v", put.Namespace, put.Name, err))
+				return
+			}
 			check.LogError("Failed to get container %q listening ports, err: %v", firstPodContainer, err)
 			result.AddNonCompliantObject(
 				testhelper.NewPodReportObject(put.Namespace, put.Name, fmt.Sprintf("Failed to get the container's listening ports, err: %v", err), false))
@@ -301,6 +307,11 @@ func testReservedPortsUsageParallel(check *checksdb.Check, env *provider.TestEnv
 		firstContainer := put.Containers[0]
 		listeningPorts, err := netutil.GetListeningPorts(firstContainer)
 		if err != nil {
+			if crclient.IsProbeToolExecError(err) {
+				check.LogError("Tool execution error for %q — probe unavailable, skipping pod (not a test case failure): %v", firstContainer, err)
+				check.SetResultError(fmt.Sprintf("probe tool execution error for pod %s/%s: %v", put.Namespace, put.Name, err))
+				return
+			}
 			check.LogError("Failed to get the listening ports on %q, err: %v", firstContainer, err)
 			result.AddNonCompliantObject(
 				testhelper.NewPodReportObject(firstContainer.Namespace, put.Name,


### PR DESCRIPTION
## Summary

- Introduces `ProbeToolExecError` in `internal/crclient` to wrap failures that originate from the `certsuite-probe` daemonset (unavailable pod, container not found, context deadline exceeded), making them distinguishable from genuine test case failures in the claim file
- `ExecCommandContainerNSEnter` now returns `ProbeToolExecError` on all probe failure paths instead of generic `fmt.Errorf`
- `netutil.GetSSHDaemonPort` and `GetListeningPorts` propagate the error type via `%w` so callers can inspect it with `errors.As`
- `testNoSSHDaemonsAllowed` and the two networking `GetListeningPorts` call sites call `check.SetResultError` (not `AddNonCompliantObject`) when a probe tool execution error is detected, keeping `Failed` reserved for genuine test case non-compliance
- Fixes broken `errors.As` chain in `GetContainerPidNamespace` (`%v` → `%w`) that would have silently defeated `IsProbeToolExecError` detection in the performance test path
- Adds `TestIsProbeToolExecError_doubleWrapped` to cover the two-level wrapping case

## Test plan

- [ ] `make build` compiles cleanly
- [ ] `UNIT_TEST=true go test ./internal/crclient/... -v` — all 7 tests pass including `TestIsProbeToolExecError_doubleWrapped`
- [ ] `make lint` passes
- [ ] End-to-end: when `certsuite-probe` pods are unavailable at runtime, affected checks record `error` result instead of `failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)