### PR TITLE
fix: resolve shfmt 3.14.0 linting failure

### DIFF
--- a/script/run-basic-batch-operators-test.sh
+++ b/script/run-basic-batch-operators-test.sh
@@ -775,13 +775,14 @@ while IFS=, read -r package_name catalog_index; do
 	# Special handling for multicluster-engine operator with + suffix
 	if [ "$actual_package_name" = "multicluster-engine" ] && [ "$skip_cleanup" = true ]; then
 		echo_color "$BLUE" "Creating MultiClusterEngine custom resource"
-		if cat <<EOF | oc apply -f - >>"$LOG_FILE_PATH" 2>&1; then
+		if cat <<EOF | oc apply -f - >>"$LOG_FILE_PATH" 2>&1
 apiVersion: multicluster.openshift.io/v1
 kind: MultiClusterEngine
 metadata:
   name: multiclusterengine
 spec: {}
 EOF
+		then
 			echo_color "$BLUE" "MultiClusterEngine custom resource created successfully"
 			echo_color "$BLUE" "Waiting for MultiClusterEngine to be ready..."
 			sleep 30


### PR DESCRIPTION
## Summary
This PR fixes a global CI breakage caused by the recent release of `shfmt` v3.14.0. The new version introduced stricter formatting rules for heredocs within `if` statements, requiring the `then` keyword to be on a separate line.

## Test plan
- Verified that the new format matches what `shfmt 3.14.0` requested in failing CI logs for other PRs.
- This change should unblock all incoming PRs and the `main` branch.

Made with [Cursor](https://cursor.com)